### PR TITLE
Respect protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,8 @@ module.exports = (nextApp, {
     }
 
     const token = uuid()
-    const url = (serverUrl || `http://${req.headers.host}`) + `${pathPrefix}/email/signin/${token}`
+    const http = req.secure ? 'https' : 'http'
+    const url = (serverUrl || `${http}://${req.headers.host}`) + `${pathPrefix}/email/signin/${token}`
 
     // Create verification token save it to database
     functions.find({ email: email })

--- a/index.js
+++ b/index.js
@@ -113,6 +113,14 @@ module.exports = (nextApp, {
     expressApp.use(lusca.csrf())
   }
 
+   // Respect protocol
+   expressApp.use(function(req, res, next) {
+    if (req.headers["x-forwarded-proto"] === "https") {
+      req.connection.encrypted = true;
+    }
+    next();
+  });
+
   /**
    * With sessions configured we need to configure Passport and trigger
    * passport.initialize() before we add any other routes.

--- a/index.js
+++ b/index.js
@@ -271,8 +271,7 @@ module.exports = (nextApp, {
     }
 
     const token = uuid()
-    const http = req.secure ? 'https' : 'http'
-    const url = (serverUrl || `${http}://${req.headers.host}`) + `${pathPrefix}/email/signin/${token}`
+    const url = (serverUrl || `${req.protocol}://${req.headers.host}`) + `${pathPrefix}/email/signin/${token}`
 
     // Create verification token save it to database
     functions.find({ email: email })


### PR DESCRIPTION
I was encountering a problem w/ the nextjs app deployed on `https`. I did not provide the `SERVER_URL` in the `.env` file (I like to let the library handle that w/ the respective context of the environment).

When I tried to oauth using Google credentials, it would take me to the `http://...` protocol instead of the `https`.

Heroku is on `https`, and the redirect was taking me to the `http://.../callback`

This PR fixes the issue, but I'm not sure if it's the correct thing to do.

Thanks!