### PR TITLE
Add additional session configuration options

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,32 @@ module.exports = (nextApp, {
   // elapsed since it was last checked so they always display state correctly.
   // If set to 0 will revalidate a session before rendering every page.
   sessionRevalidateAge = 60000,
+  // Forces the session to be saved back to the session store, even if
+  // the session  was never modified during the request. Depending on your
+  // store this may be necessary, but it can also create race conditions where
+  // a client makes two parallel requests to your server and changes made to
+  // the session in one request may get overwritten when the other request ends,
+  // even if it made no changes (this behavior also depends on what store you're
+  // using). https://www.npmjs.com/package/express-session#resave
+  sessionResave = false,
+  // Force a session identifier cookie to be set on every response.
+  // The expiration is reset to the original maxAge, resetting the expiration countdown.
+  // The default value is false.
+  // Note When this option is set to true but the saveUninitialized option
+  // is set to false, the cookie will not be set on a response with an
+  // uninitialized session. https://www.npmjs.com/package/express-session#rolling
+  sessionRolling = true,
+  // Forces a session that is "uninitialized" to be saved to the store. A session
+  // is uninitialized when it is new but not modified. Choosing false is useful
+  // for implementing login sessions, reducing server storage usage, or complying
+  // with laws that require permission before setting a cookie. Choosing false
+  // will also help with race conditions where a client makes multiple parallel
+  // requests without a session.
+  // The default value is true, but using the default has been deprecated, as
+  // the default will change in the future. Please research into this setting and
+  // choose what is appropriate to your use-case.
+  // https://www.npmjs.com/package/express-session#saveuninitialized
+  sessionSaveUninitialized = false,
   // Canonical URL of the server (optional, but recommended).
   // e.g. 'http://localhost:3000' or 'https://www.example.com' 
   // Used in callbak URLs and email sign in links. It will be auto generated
@@ -109,9 +135,9 @@ module.exports = (nextApp, {
   expressApp.use(expressSession({
     secret: sessionSecret,
     store: sessionStore,
-    resave: false,
-    rolling: true,
-    saveUninitialized: false,
+    resave: sessionResave,
+    rolling: sessionRolling,
+    saveUninitialized: sessionSaveUninitialized,
     cookie: {
       httpOnly: true,
       secure: 'auto',


### PR DESCRIPTION
This PR provides configuration access to `resave`, `rolling` and `saveUninitialized` session options. Without setting `resave = true`, connect-redis was not updating session TTL on subsequent session hits, which resulted in session timeouts for active users.