### PR TITLE
case sensitive providerName in passport.authenticate

### DIFF
--- a/src/passport-strategies.js
+++ b/src/passport-strategies.js
@@ -277,11 +277,11 @@ module.exports = ({
     providerOptions
   }) => {
     // Route to start sign in
-    expressApp.get(`${pathPrefix}/oauth/${providerName.toLowerCase()}`, passport.authenticate(providerName.toLowerCase(), providerOptions))
+    expressApp.get(`${pathPrefix}/oauth/${providerName.toLowerCase()}`, passport.authenticate(providerName, providerOptions))
     
     // Route to call back to after signing in
     expressApp.get(`${pathPrefix}/oauth/${providerName.toLowerCase()}/callback`,
-      passport.authenticate(providerName.toLowerCase(), {
+      passport.authenticate(providerName, {
         successRedirect: `${pathPrefix}/callback?action=signin&service=${providerName}`,
         failureRedirect: `${pathPrefix}/error?action=signin&type=oauth&service=${providerName}`
       })


### PR DESCRIPTION
Strategy name in Passoport is not enforced to be all lower case (at least I haven't found that rule), and it's up to strategy author to pick a name.
So, there's a chance that strategy with mixed case name [exists](https://github.com/exlinc/keycloak-passport/blob/master/index.js#L23).
Without this change such strategies won't work with next-auth.