### PR TITLE
Exposing params in the getProfile call

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ The example configuration provided is for Mongo DB. By defining the behaviour in
 #### Required
 
 * find({id,email,emailToken,provider})
-* insert(user, oAuthProfile)
-* update(user, oAuthProfile)
+* insert(user, oAuthProfile, providerParams)
+* update(user, oAuthProfile, providerParams)
 * remove(id)
 * serialize(user)
 * deserialize(id)

--- a/src/passport-strategies.js
+++ b/src/passport-strategies.js
@@ -69,7 +69,7 @@ module.exports = ({
     strategyOptions.callbackURL = (strategyOptions.callbackURL || (serverUrl || '') + `${pathPrefix}/oauth/${providerName.toLowerCase()}/callback`)
     strategyOptions.passReqToCallback = true
 
-    passport.use(new Strategy(strategyOptions, (req, accessToken, refreshToken, _params, _profile, next) => {
+    passport.use(providerName, new Strategy(strategyOptions, (req, accessToken, refreshToken, _params, _profile, next) => {
 
       try {
         // Normalise the provider specific profile into a standard basic

--- a/src/passport-strategies.js
+++ b/src/passport-strategies.js
@@ -74,7 +74,7 @@ module.exports = ({
       try {
         // Normalise the provider specific profile into a standard basic
         // profile object with just { id, name, email } properties.
-        let profile = getProfile(_profile, _params)
+        let profile = getProfile(_profile)
 
         // Save the Access Token to the current session.
         req.session[providerName.toLowerCase()] = {
@@ -116,7 +116,7 @@ module.exports = ({
                     refreshToken: refreshToken
                   }
 
-                  functions.update(user, _profile)
+                  functions.update(user, _profile, _params)
                   .then(user => {
                     return next(null, user)
                   })
@@ -178,7 +178,7 @@ module.exports = ({
                 }
 
                 // Update details for the new provider for this user.
-                return functions.update(user, _profile)
+                return functions.update(user, _profile, _params)
                 .then(user => {
                   return next(null, user)
                 })
@@ -204,7 +204,7 @@ module.exports = ({
               if (accessToken || refreshToken) {
                 if (accessToken) user[providerName.toLowerCase()].accessToken = accessToken
                 if (refreshToken) user[providerName.toLowerCase()].refreshToken = refreshToken
-                return functions.update(user, _profile)
+                return functions.update(user, _profile, _params)
                 .then(user => {
                   return next(null, user)
                 })
@@ -246,7 +246,7 @@ module.exports = ({
                     accessToken: accessToken,
                     refreshToken: refreshToken
                   }
-                }, _profile)
+                }, _profile, _params)
                 .then(user => {
                   return next(null, user)
                 })

--- a/src/passport-strategies.js
+++ b/src/passport-strategies.js
@@ -69,12 +69,12 @@ module.exports = ({
     strategyOptions.callbackURL = (strategyOptions.callbackURL || (serverUrl || '') + `${pathPrefix}/oauth/${providerName.toLowerCase()}/callback`)
     strategyOptions.passReqToCallback = true
 
-    passport.use(new Strategy(strategyOptions, (req, accessToken, refreshToken, _profile, next) => {
+    passport.use(new Strategy(strategyOptions, (req, accessToken, refreshToken, _params, _profile, next) => {
 
       try {
         // Normalise the provider specific profile into a standard basic
         // profile object with just { id, name, email } properties.
-        let profile = getProfile(_profile)
+        let profile = getProfile(_profile, _params)
 
         // Save the Access Token to the current session.
         req.session[providerName.toLowerCase()] = {


### PR DESCRIPTION
passport-oauth2 calls back with extra parameters if specified - this is based on the number of arguments passed to the callback function when defining the strategy (https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js). This change exposes that extra parameter. This is useful if users want to store id_token for instance which is available in the _params object.