### PR TITLE
fix: dotenv loading

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -15,7 +15,7 @@ const nextAuth = require('next-auth')
 const nextAuthConfig = require('./next-auth.config')
 
 // Load environment variables from .env
-require('dotenv').load()
+require('dotenv').config({ path: './.env' })
 
 // Initialize Next.js
 const nextApp = next({

--- a/example/next-auth.config.js
+++ b/example/next-auth.config.js
@@ -12,7 +12,7 @@
  **/
 
 // Load environment variables from a .env file if one exists
-require('dotenv').load()
+require('dotenv').config({ path: './.env' })
 
 const nextAuthProviders = require('./next-auth.providers')
 const nextAuthFunctions = require('./next-auth.functions')

--- a/example/next-auth.functions.js
+++ b/example/next-auth.functions.js
@@ -39,7 +39,7 @@
  **/
 
 // Load environment variables from a .env file if one exists
-require('dotenv').load()
+require('dotenv').config({ path: './.env' })
 
 // This config file uses MongoDB for User accounts, as well as session storage.
 // This config includes options for NeDB, which it defaults to if no DB URI 

--- a/example/next-auth.providers.js
+++ b/example/next-auth.providers.js
@@ -21,7 +21,7 @@
  **/
 
 // Load environment variables from a .env file if one exists
-require('dotenv').load()
+require('dotenv').config({ path: './.env' })
 
 module.exports = () => {
   let providers = []


### PR DESCRIPTION
Small update to the way dotenv loads config.

```
require('dotenv').load()
```

threw an error, apparently this is the new way they want it done.