### PR TITLE
Update passport-google-oauth to v2.0.0 -- Without it results in error…

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -2889,7 +2889,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2907,11 +2908,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2924,15 +2927,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3035,7 +3041,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3045,6 +3052,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3057,17 +3065,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3084,6 +3095,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3156,7 +3168,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3166,6 +3179,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3241,7 +3255,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3271,6 +3286,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3288,6 +3304,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3326,11 +3343,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -4784,12 +4803,12 @@
       }
     },
     "passport-google-oauth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-google-oauth/-/passport-google-oauth-1.0.0.tgz",
-      "integrity": "sha1-ZfUGMxkq0GJ6GLCJYAdxCdhOt20=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth/-/passport-google-oauth-2.0.0.tgz",
+      "integrity": "sha512-JKxZpBx6wBQXX1/a1s7VmdBgwOugohH+IxCy84aPTZNq/iIPX6u7Mqov1zY7MKRz3niFPol0KJz8zPLBoHKtYA==",
       "requires": {
         "passport-google-oauth1": "1.x.x",
-        "passport-google-oauth20": "1.x.x"
+        "passport-google-oauth20": "2.x.x"
       }
     },
     "passport-google-oauth1": {
@@ -4801,9 +4820,9 @@
       }
     },
     "passport-google-oauth20": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-1.0.0.tgz",
-      "integrity": "sha1-O5YOih1w0dvnlGFcgnxoxAOSpdA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
       "requires": {
         "passport-oauth2": "1.x.x"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -23,7 +23,7 @@
     "nodemailer-direct-transport": "^3.3.2",
     "nodemailer-smtp-transport": "^2.7.4",
     "passport-facebook": "^2.1.1",
-    "passport-google-oauth": "^1.0.0",
+    "passport-google-oauth": "^2.0.0",
     "passport-twitter": "^1.0.4",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"


### PR DESCRIPTION
Without this change I get the following error with Google OAuth:

```
GooglePlusAPIError: Legacy People API has not been used in project 1060140124894 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/legacypeople.googleapis.com/overview?project=1060140124894 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
    at /Users/zbellay/Documents/GitHub/next-auth/example/node_modules/passport-google-oauth20/lib/strategy.js:95:21
    at passBackControl (/Users/zbellay/Documents/GitHub/next-auth/example/node_modules/oauth/lib/oauth2.js:132:9)
    at IncomingMessage.<anonymous> (/Users/zbellay/Documents/GitHub/next-auth/example/node_modules/oauth/lib/oauth2.js:157:7)
    at IncomingMessage.emit (events.js:317:22)
    at endReadableNT (_stream_readable.js:1215:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)


```