### PR TITLE
feat(client): Add optional provider for using useSession with context api

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,23 +71,17 @@ export default () => {
 
 *This is all the code you need to add support for signing in to a project!*
 
-If you want to avoid multiple requests being made from the `useSession()` hook being used in several components, there is also `useGlobalSession()` in combination with `<NextAuth.SessionProvider>` which uses [React Context](https://reactjs.org/docs/context.html)
+Using `useSession()` like this will work perfectly fine, but keep in mind this will do a network request to fetch the session in each component you use it. If you want to only do one network request you can wrap your component tree in our `Provider`, which will make `useSession()` use [React Context](https://reactjs.org/docs/context.html) instead.
 
+You can use this `Provider` on a specific page if you want, or for all pages by overriding your `_app.js` file in Next.js [as documented here](https://nextjs.org/docs/advanced-features/custom-app)
+Example `pages/_app.js`:
 ```javascript
-const Welcome = () => {
-  const [session, loading] = NextAuth.useGlobalSession()
-
-  return <>
-    {loading && <p>Checking session…</p>}
-    {!loading && session && <p>Welcome {session.user.name || session.user.email}.</p>}
-    {!loading && !session && <p><a href="/api/auth/signin">Sign in here</p>}
-  </>
-}
-
-export default () => {
-  <NextAuth.SessionProvider>
-    <Welcome />
-  </NextAuth.SessionProvider>
+export default ({ Component, pageProps }) => {
+  return (
+    <NextAuth.Provider>
+      <Component {...pageProps} />
+    </NextAuth.Provider>
+  )
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ export default () => {
 
 *This is all the code you need to add support for signing in to a project!*
 
+If you want to avoid multiple requests being made from the `useSession()` hook being used in several components, there is also `useGlobalSession()` in combination with `<NextAuth.SessionProvider>` which uses [React Context](https://reactjs.org/docs/context.html)
+
+```javascript
+const Welcome = () => {
+  const [session, loading] = NextAuth.useGlobalSession()
+
+  return <>
+    {loading && <p>Checking session…</p>}
+    {!loading && session && <p>Welcome {session.user.name || session.user.email}.</p>}
+    {!loading && !session && <p><a href="/api/auth/signin">Sign in here</p>}
+  </>
+}
+
+export default () => {
+  <NextAuth.SessionProvider>
+    <Welcome />
+  </NextAuth.SessionProvider>
+}
+```
+
 #### Server Side Rendering
 
 Authentication in Server Side Rendering flows is also supported.

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -44,9 +44,8 @@ const session = ({req, site, pathPrefix, urlPrefixCookieName}) => {
 // Context to store session data globally
 const SessionContext = createContext()
 
-// Hook for getting session from the api. Can be used if you don't want to use a context.
-// It's also used in the `useGlobalSession`, but with context instead.
-const useSession = (session, pathPrefix) => {
+// Internal hook for getting session from the api.
+const useSessionData = (session, pathPrefix) => {
   const [data, setData] = useState(session)
   const [loading, setLoading] = useState(true)
   const getSession = async () => {
@@ -64,14 +63,23 @@ const useSession = (session, pathPrefix) => {
 }
 
 // Provider to wrap the app in to make session data available globally
-const SessionProvider = ({ children, session, pathPrefix }) => {
+const Provider = ({ children, session, pathPrefix }) => {
   const value = useSession(session, pathPrefix)
 
   return createElement(SessionContext.Provider, { value }, children)
 }
 
 // Hook to access the session data stored in the context
-const useGlobalSession = () => useContext(SessionContext)
+const useSession = (session, pathPrefix) => {
+  const value = useContext(SessionContext)
+  // If we have no Provider in the tree
+  // we call the actual hook for fetching the session
+  if (value === undefined) {
+    return useSessionData(session, pathPrefix)
+  }
+
+  return value
+}
 
 // Adapted from https://github.com/felixfong227/simple-cookie-parser/blob/master/index.js
 const _parseCookies = (string) => {
@@ -102,6 +110,5 @@ const _getUrlPrefix = (cookies, urlPrefixCookieName) => {
 export default {
   session,
   useSession,
-  useGlobalSession,
-  SessionProvider,
+  Provider,
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useContext, createContext, createElement } from 'react'
 import fetch from 'isomorphic-unfetch'
 
 const URL_PREFIX_COOKIE = 'next-auth.url-prefix'
@@ -41,7 +41,11 @@ const session = ({req, site, pathPrefix, urlPrefixCookieName}) => {
   })
 }
 
-// Client Side Session method
+// Context to store session data globally
+const SessionContext = createContext()
+
+// Hook for getting session from the api. Can be used if you don't want to use a context.
+// It's also used in the `useGlobalSession`, but with context instead.
 const useSession = (session, pathPrefix) => {
   const [data, setData] = useState(session)
   const [loading, setLoading] = useState(true)
@@ -58,6 +62,16 @@ const useSession = (session, pathPrefix) => {
   useEffect(() => { getSession() }, [])
   return [data, loading]
 }
+
+// Provider to wrap the app in to make session data available globally
+const SessionProvider = ({ children, session, pathPrefix }) => {
+  const value = useSession(session, pathPrefix)
+
+  return createElement(SessionContext.Provider, { value }, children)
+}
+
+// Hook to access the session data stored in the context
+const useGlobalSession = () => useContext(SessionContext)
 
 // Adapted from https://github.com/felixfong227/simple-cookie-parser/blob/master/index.js
 const _parseCookies = (string) => {
@@ -87,5 +101,7 @@ const _getUrlPrefix = (cookies, urlPrefixCookieName) => {
 
 export default {
   session,
-  useSession
+  useSession,
+  useGlobalSession,
+  SessionProvider,
 }


### PR DESCRIPTION
Users might want to use the `useSession()` hook in several components, and with the current hook implementation that would mean doing one request to the api per use. This change intends to add an alternate hook which uses context instead.

So you would still have the `useSession()` for a simple "go and get session" thing, but then also one which requires you to wrap your components in a provider but allows you to use `useGlobalSession()` anywhere without doing multiple requests.

Not sure if this is something you want but figured I'd at least make a PR :)