### PR TITLE
Add providers

### DIFF
--- a/src/providers/facebook.js
+++ b/src/providers/facebook.js
@@ -1,1 +1,21 @@
-// @TODO Facebook provider
+export default (options) => {
+  return {
+    id: 'facebook',
+    name: 'Facebook',
+    type: 'oauth',
+    version: '2.0',
+    scope: 'email',
+    accessTokenUrl: 'https://graph.facebook.com/oauth/access_token',
+    authorizationUrl: 'https://www.facebook.com/v7.0/dialog/oauth?response_type=code',
+    profileUrl: 'https://graph.facebook.com/me?fields=email,name,picture',
+    profile: (profile) => {
+      return {
+         id: profile.id,
+         name: profile.name,
+         email: profile.email,
+         image: profile.picture.data.url
+       }
+    },
+		...options
+  }
+}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,6 +1,6 @@
 import Discord from './discord'
 import Email from './email'
-// import Facebook from './facebook' // @TODO
+import Facebook from './facebook' // @TODO
 import GitHub from './github'
 import Google from './google'
 import Mixer from './mixer'
@@ -9,7 +9,8 @@ import Twitch from './twitch'
 import Twitter from './twitter'
 
 export default {
-  Discord,
+	Discord,
+	Facebook,
   GitHub,
   Google,
   Mixer,


### PR DESCRIPTION
Okay, I'm adding some more providers. I already pushed and will update it with commits so everyone can stay up-to-date or if you want certain providers added I can merge it.
I've currently added Facebook but wasn't able to test it locally because off the callback URL problem. I logged the profile response and was able to get the user's info so I think it should work. @iaincollins maybe you can test this on the example site?