### PR TITLE
Update contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,34 @@ This includes bug reports, feature requests, ideas, pull requests and examples o
 
 Please see the [Code of Conduct](CODE_OF_CONDUCT.md) and follow any templates configured in GitHub when reporting bugs, requesting enhancements or contributing code.
 
-Please note that as I maintain a number of packages it's not always possible to respond to feedback as quickly as I'd like. It can sometimes take a while to get around to reviewing pull requests and acting on issues and feedback, but the time and effort that does into raising them is appreciated.
+## Pull Requests
+
+* Pull Requests should be raised for larger changes.
+* Ideally, lots of small changes should be bundled up in to a larger PR.
+* The latest changes are always in `master`
+* Merging (and pushing merge commits to `master`) is disabled in this repo
+* Rebasing is prefered to keep a clean commit history.
+* Pushing directly to master should be reserved for minor updates / one off fixes.
+* Pull Requests are great for batching up changes and making them easy to review and for tagging people so they can track changes, but they do not require approval from other commiters (commiters may raise and merge their own requests).
+
+## Rebasing
+
+If you create a branch and there are conflicting updates in the `master` branch, you can resolve them by rebasing from a check out of your branch:
+
+    git fetch
+    git rebase origin/master
+
+If there are any conflicts, you can resolve them and stage the files, then run:
+
+    git rebase --continue
+
+*If there are a lot of changes you may be prompted to step more than once.*
+
+When the rebase is complete (i.e. there are no more conflicts) you should push your changes to your branch before doing anyhing else:
+
+   git push --force-with-lease
+
+You should see that any conflicts in your PR are now resolved. You can review changes to make sure it contains changes you intended to make.
+
+*If you accidentally sync before pushing, it will trigger a merge. Uou can use `git merge --abort` to undo the merge.*
+


### PR DESCRIPTION
I've updated the contributing docs to reflect ideally how changes should happen.

I'm going to start raising changes as Pull Requests and try to avoid pushing to master, to avoid conflicts and make things easier to track, and would ask folks also try to do that, as there are are multiple active contributors now and that will make things easier for us all. 😀

Pushing small changes for specific issues is fine, but as a general rule not pushing directly to master would be best. This is not currently a hard rule, would just ask that folks use it sparingly; I appreciate it is still useful, especially for things like website config (where sometimes changes need to be in the master branch to take effect).

PS: I've also disabled merge commits on `master`, in favour encouraging rebasing, and have provided an example of how to do that easily in the guide.

I don't think we need to be doing the actual PR reviews, do please feel free to merge in your own changes; PRs are just handy for bundling up changes. I'll be raising draft PRs to signal I'm working on something that is big, so folks know things might be changing in that area (and will keep an eye out for other draft PRs and avoid refactoring things other folks are working on).

## RE: Documentation site not updating

PS: It looks like the docs website isn't update update to the latest version of the docs when we push changes. It is configured correctly in Vercel dashboard and I have even tried manually promoting each instance in the dashboard but that does nothing - unless I remove and re-add the domain each time, which is annoying.

I think it is because the domain `next-auth.js.org` is also on the site but is not yet configured in DNS. I think it will start updating again once it is.