### PR TITLE
Refactor adapter logic and add email verification 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.39",
+  "version": "2.0.0-beta.40",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/adapters/typeorm/models/email-verification.js
+++ b/src/adapters/typeorm/models/email-verification.js
@@ -1,12 +1,8 @@
 export class EmailVerification {
-  constructor (email, token) {
-    // @TODO expose time to expire invite as option
-    const dateExpires = new Date()
-    dateExpires.setDate(dateExpires.getDate() + 1) // 1 day
-
+  constructor (email, token, expires) {
     this.email = email
     this.token = token
-    this.expires = dateExpires.toISOString()
+    this.expires = expires
   }
 }
 

--- a/src/adapters/typeorm/models/session.js
+++ b/src/adapters/typeorm/models/session.js
@@ -2,13 +2,6 @@ import { randomBytes } from 'crypto'
 
 export class Session {
   constructor (userId, sessionToken, sessionExpires, accessToken) {
-    // Defaults to 30 days for expiry if sessionExpires not specified
-    if (!sessionExpires) {
-      const dateExpires = new Date()
-      dateExpires.setDate(dateExpires.getDate() + 30)
-      sessionExpires = dateExpires.toISOString()
-    }
-
     this.userId = userId
     this.sessionToken = sessionToken || randomBytes(32).toString('hex')
     this.sessionExpires = sessionExpires

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -153,7 +153,15 @@ export default async (req, res, _options) => {
     // User provided options are overriden by other options,
     // except for the options with special handling above
     const options = {
+      // Defaults options can be overidden
+      sessionMaxAge: 30 * 60 * 60 * 1000, // Sessions expire after 30 days of being idle
+      sessionUpdateAge: 24 * 60 * 60 * 1000, // Sessions updated only if session is greater than this value (0 = always, 24*60*60*1000 = every 24 hours)
+      verificationMaxAge: 24 * 60 * 60 * 1000, // Email/passwordless links expire after 24 hours
+      debug: false, // Enable debug messages to be displayed
+      // Custom options override defaults
       ..._options,
+      // These computed settings can values in _options but override them
+      // and are request-specific.
       site,
       pathPrefix,
       urlPrefix,

--- a/src/server/lib/callback-handler.js
+++ b/src/server/lib/callback-handler.js
@@ -11,15 +11,14 @@
 //
 import { AccountNotLinkedError } from '../../lib/errors'
 
-export default async (adapter, sessionToken, profile, providerAccount) => {
+export default async (sessionToken, profile, providerAccount, options) => {
   try {
     // Input validation
     if (!profile || !profile.email) { throw new Error('Missing or invalid profile') }
 
     if (!providerAccount || !providerAccount.id || !providerAccount.type) { throw new Error('Missing or invalid provider account') }
 
-    // Get adapter - async as dependant on DB connection being ready
-    const _adapter = await adapter.getAdapter()
+    const { adapter } = options
 
     const {
       createUser,
@@ -31,14 +30,12 @@ export default async (adapter, sessionToken, profile, providerAccount) => {
       createSession,
       getSession,
       deleteSession
-    } = _adapter
+    } = await adapter.getAdapter(options)
 
     let session = sessionToken ? await getSession(sessionToken) : null
     const isSignedIn = !!session
     let user = isSignedIn ? await getUser(session.userId) : null
     let isNewAccount = false
-
-    // @TODO replace all Error objects returned with custom error types
 
     if (providerAccount.type === 'email') {
       // If signing in with an email, check if an account with the same email address exists already

--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -83,6 +83,8 @@ function _getProfile (error, profileData, accessToken, refreshToken, provider) {
     }
   }
 
+  if (!profile.email) throw new Error('User profile does not have an email address!')
+
   // Return profile, raw profile and auth provider details
   return ({
     profile: {

--- a/src/server/lib/signin/email.js
+++ b/src/server/lib/signin/email.js
@@ -3,8 +3,7 @@ import { randomBytes } from 'crypto'
 export default async (email, provider, options) => {
   try {
     const { urlPrefix, adapter } = options
-    const _adapter = await adapter.getAdapter()
-    const { createEmailVerification } = _adapter
+    const { createEmailVerification } = await adapter.getAdapter(options)
 
     // Prefer provider specific secret, but use default secret if none specified
     const secret = provider.secret || options.secret

--- a/src/server/pages/error.js
+++ b/src/server/pages/error.js
@@ -52,12 +52,12 @@ export default ({ site, error, urlPrefix }) => {
     case 'Verification':
       // @TODO Check if user is signed in already with the same email address.
       // If they are, no need to display this message, can just direct to callbackUrl
-      heading = <h1>Sign in link invalid</h1>
+      heading = <h1>Sign in failed</h1>
       message =
         <div>
           <div className='message'>
-            <p>The link you used may have been used already or it may have expired.</p>
-            <p>Sign in links can only be used once, you can a new sign in link at any time.</p>
+            <p>The link you followed may have been used already or it may have expired.</p>
+            <p>Sign in links can only be used once and expire, you can a new sign in link at any time.</p>
           </div>
           <p><a className='button' href={signinPageUrl}>Sign in</a></p>
         </div>

--- a/src/server/routes/session.js
+++ b/src/server/routes/session.js
@@ -3,8 +3,7 @@ import cookie from '../lib/cookie'
 
 export default async (req, res, options, done) => {
   const { cookies, adapter } = options
-  const _adapter = await adapter.getAdapter()
-  const { getUser, getSession, updateSession } = _adapter
+  const { getUser, getSession, updateSession } = await adapter.getAdapter(options)
   const sessionToken = req.cookies[cookies.sessionToken.name]
 
   let response = {}
@@ -33,6 +32,10 @@ export default async (req, res, options, done) => {
 
       // Update expiry on Session Token cookie
       cookie.set(res, cookies.sessionToken.name, sessionToken, { expires: session.sessionExpires, ...cookies.sessionToken.options })
+    } else if (sessionToken) {
+      // If sessionToken was found set but it's not valid for a session then
+      // remove the sessionToken cookie from browser.
+      cookie.set(res, cookies.sessionToken.name, '', { ...cookies.sessionToken.options, maxAge: 0 })
     }
   } catch (error) {
     console.error('SESSION_ERROR', error)

--- a/src/server/routes/signout.js
+++ b/src/server/routes/signout.js
@@ -3,8 +3,7 @@ import cookie from '../lib/cookie'
 
 export default async (req, res, options, done) => {
   const { adapter, cookies, callbackUrl, csrfTokenVerified, urlPrefix } = options
-  const _adapter = await adapter.getAdapter()
-  const { deleteSession } = _adapter
+  const { deleteSession } = await adapter.getAdapter(options)
 
   // Get session ID (if set)
   const sessionToken = req.cookies[cookies.sessionToken.name]


### PR DESCRIPTION
There is a lot more going on in this PR than I would like to do at once, but it's all connected.

## Changes in this PR

* Refactored adapter, with less redundant logic
* Removed logic from models
* Added email verification expiry support (defaults to 24 hours)
* Refactored session expiry handling and unified it with how email expiry works
* Default session expiry is still 30 days
* Now only updates expiry for a session at most once every 24 hours by default, to reduce writes to database
* Email verification max age, session max age and how often sessions are updated (to reduce database writes) are all simple options now
* Invalid sessionTokens are now deleted from the client
* Email verfication messages are now deleted once used (or when expired)
* Debug output is now an option (set `debug: true` to enable)
* Removed confusing options / callback from default adapter (except for passing in custom models/schemas)
* Adapter can now access all next-auth options, to make configuration easier

## New options

After implementing session expiry (and looking back at v1 for inspiration) it was clearer how both it and email expiry could be flexible and easier to customise.

How to use the new options, along with the default values that get set for them, is shown below.

```js
const options = {
  site: process.env.SITE,
  providers: [ /* providers */ ],
  adapter: Adapters.Default({ /* adapter options */ }),
  sessionMaxAge: 30*60*60*1000, // Sessions expire after 30 days of being idle
  sessionUpdateAge: 24*60*60*1000, // Sessions updated only if session is greater than this
  verificationMaxAge: 24*60*60*1000, // Verification (email sign in) links expire after 24 hours
  debug: false // Set to true to enable debug messages to be displayed
}

export default (req, res) => NextAuth(req, res, options)
```