### PR TITLE
Refactor urlPrefix as baseURL

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -2,37 +2,20 @@
 /* global fetch:false */
 import { useState, useEffect, useContext, createContext, createElement } from 'react'
 
-const URL_PREFIX_COOKIE = 'next-auth.url-prefix'
+const DEFAULT_BASE_URL_COOKIE_NAME = 'next-auth.base-url'
 const DEFAULT_SITE = ''
-const DEFAULT_PATH_PREFIX = '/api/auth'
+const DEFAULT_BASE_PATH = '/api/auth'
 
 // Isomorphic get session method
-const session = async ({ req, site, pathPrefix, urlPrefixCookieName } = {}) => {
-  // If we have a 'req' object are running sever side and should get cookies from headers
-  const cookies = req ? _parseCookies(req.headers.cookie) : null
-  // We will need the raw header as it will have the HTTP only Session ID cookie in it
-  // and we will need to pass that to get the session data back.
+const session = async ({ req, site, basePath, baseUrlCookieName } = {}) => {
+  const baseUrl = _baseUrl({ req, site, basePath, baseUrlCookieName })
+  if (!baseUrl) { return null }
+
+  // If server side, send with cookies in header (sent automatically client side)
   const fetchOptions = req ? { headers: { cookie: req.headers.cookie } } : {}
 
-  // If site and/or pathPrefix are specified, use them (or the defaults)
-  // otherwise get the server URL from the signed HTTP only cookie.
-  //
-  // If no options specified (which usually will be the case) then grab
-  // the configuration dynamically from a cookie. Prefer the _Secure-
-  // prefixed version if it is avalible, but fall back to checking the
-  // version without the prefix so it still works on URLs like http://localhost
-  //
-  // If there is no cookie set, then we use the default prefix (/api/auth).
-  const urlPrefix = (site || pathPrefix || !cookies)
-    ? `${site || DEFAULT_SITE}${pathPrefix || DEFAULT_PATH_PREFIX}`
-    : _getUrlPrefixFromCookies(cookies, urlPrefixCookieName)
-
-  // If we are rendering server side but don't have a URL prefix, then give up
-  // because we can't call fetch server side an absolute URL to query.
-  if (req && !urlPrefix) { return null }
-
   try {
-    const res = await fetch(`${urlPrefix}/session`, fetchOptions) // Absolute URL
+    const res = await fetch(`${baseUrl}/session`, fetchOptions)
     const data = await res.json()
     return Object.keys(data).length > 0 ? data : null // Return null if session data empty
   } catch (error) {
@@ -41,16 +24,17 @@ const session = async ({ req, site, pathPrefix, urlPrefixCookieName } = {}) => {
   }
 }
 
+
 // Context to store session data globally
 const SessionContext = createContext()
 
 // Internal hook for getting session from the api.
-const useSessionData = (session, { pathPrefix } = {}) => {
+const useSessionData = (session, { basePath } = {}) => {
   const [data, setData] = useState(session)
   const [loading, setLoading] = useState(true)
   const getSession = async () => {
     try {
-      const res = await fetch(`${pathPrefix || DEFAULT_PATH_PREFIX}/session`) // Releative URL
+      const res = await fetch(`${basePath || DEFAULT_BASE_PATH}/session`) // Releative URL
       const data = await res.json()
       setData(Object.keys(data).length > 0 ? data : null) // Return null if session data empty
       setLoading(false)
@@ -63,21 +47,42 @@ const useSessionData = (session, { pathPrefix } = {}) => {
 }
 
 // Provider to wrap the app in to make session data available globally
-const Provider = ({ children, session, pathPrefix }) => {
-  const value = useSession(session, { pathPrefix })
-
+const Provider = ({ children, session, basePath }) => {
+  const value = useSession(session, { basePath })
   return createElement(SessionContext.Provider, { value }, children)
 }
 
 // Hook to access the session data stored in the context
-const useSession = (session, { pathPrefix } = {}) => {
+const useSession = (session, { basePath } = {}) => {
+  console.log('useSession debug 1', session)
+  console.log('useSession debug 1.1', SessionContext)
   const value = useContext(SessionContext)
   // If we have no Provider in the tree we call the actual hook for fetching the session
   if (value === undefined) {
-    return useSessionData(session, { pathPrefix })
+    return useSessionData(session, { basePath })
   }
 
   return value
+}
+
+const _baseUrl = ({ req, site, baseUrlCookieName, basePath }) => {
+  // If we have a 'req' object are running sever side and should get cookies from headers
+  const cookies = req ? _parseCookies(req.headers.cookie) : null
+
+  // If site and/or basePath are specified, use them (or the defaults)
+  // otherwise get the server URL from the signed HTTP only cookie.
+  //
+  // If no options specified (which usually will be the case) then grab
+  // the configuration dynamically from a cookie. Prefer the _Secure-
+  // prefixed version if it is avalible, but fall back to checking the
+  // version without the prefix so it still works on URLs like http://localhost
+  //
+  // If there is no cookie set, then we use the default prefix (/api/auth).
+  const baseUrl = (site || basePath || !cookies)
+    ? `${site || DEFAULT_SITE}${basePath || DEFAULT_BASE_PATH}`
+    : _getUrlPrefixFromCookies(cookies, baseUrlCookieName)
+
+  return baseUrl
 }
 
 // Adapted from https://github.com/felixfong227/simple-cookie-parser/blob/master/index.js
@@ -99,14 +104,15 @@ const _parseCookies = (string) => {
   }
 }
 
-const _getUrlPrefixFromCookies = (cookies, urlPrefixCookieName) => {
-  const cookieValue = cookies[urlPrefixCookieName] || cookies[`__Secure-${URL_PREFIX_COOKIE}`] || cookies[URL_PREFIX_COOKIE]
-  const [urlPrefixValue] = cookieValue ? cookieValue.split('|') : [null]
-  return urlPrefixValue
+const _getUrlPrefixFromCookies = (cookies, baseUrlCookieName) => {
+  const cookieValue = cookies[baseUrlCookieName] || cookies[`__Secure-${DEFAULT_BASE_URL_COOKIE_NAME}`] || cookies[DEFAULT_BASE_URL_COOKIE_NAME]
+  const [baseUrl] = cookieValue ? cookieValue.split('|') : [null]
+  return baseUrl
 }
 
 export default {
   session,
   useSession,
+  baseUrl: _baseUrl,
   Provider
 }

--- a/src/server/lib/providers.js
+++ b/src/server/lib/providers.js
@@ -1,12 +1,12 @@
-export default (_providers, urlPrefix) => {
+export default (_providers, baseUrl) => {
   const providers = {}
 
   _providers.forEach(provider => {
     const providerId = provider.id
     providers[providerId] = {
       ...provider,
-      signinUrl: `${urlPrefix}/signin/${providerId}`,
-      callbackUrl: `${urlPrefix}/callback/${providerId}`
+      signinUrl: `${baseUrl}/signin/${providerId}`,
+      callbackUrl: `${baseUrl}/callback/${providerId}`
     }
   })
 

--- a/src/server/lib/signin/email.js
+++ b/src/server/lib/signin/email.js
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto'
 
 export default async (email, provider, options) => {
   try {
-    const { urlPrefix, adapter } = options
+    const { baseUrl, adapter } = options
     const { createEmailVerification } = await adapter.getAdapter(options)
 
     // Prefer provider specific secret, but use default secret if none specified
@@ -12,7 +12,7 @@ export default async (email, provider, options) => {
     const token = randomBytes(32).toString('hex')
 
     // Send email with link containing token (the unhashed version)
-    const url = `${urlPrefix}/callback/${encodeURIComponent(provider.id)}?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`
+    const url = `${baseUrl}/callback/${encodeURIComponent(provider.id)}?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`
 
     // @TODO Create invite (send secret so can be hashed)
     await createEmailVerification(email, url, token, secret, provider, options)

--- a/src/server/pages/error.js
+++ b/src/server/pages/error.js
@@ -1,8 +1,8 @@
 import { h } from 'preact' // eslint-disable-line no-unused-vars
 import render from 'preact-render-to-string'
 
-export default ({ site, error, urlPrefix }) => {
-  const signinPageUrl = `${urlPrefix}/signin` // @TODO Make sign in URL configurable
+export default ({ site, error, baseUrl }) => {
+  const signinPageUrl = `${baseUrl}/signin` // @TODO Make sign in URL configurable
 
   let heading = <h1>Error</h1>
   let message = <p><a className='site' href={site}>{site.replace(/^https?:\/\//, '')}</a></p>

--- a/src/server/pages/signout.js
+++ b/src/server/pages/signout.js
@@ -1,10 +1,10 @@
 import { h } from 'preact' // eslint-disable-line no-unused-vars
 import render from 'preact-render-to-string'
 
-export default ({ urlPrefix, csrfToken }) => {
+export default ({ baseUrl, csrfToken }) => {
   return render(
     <div className='signout'>
-      <form action={`${urlPrefix}/signout`} method='POST'>
+      <form action={`${baseUrl}/signout`} method='POST'>
         <input type='hidden' name='csrfToken' value={csrfToken} />
         <button type='submit'>Sign out</button>
       </form>

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -5,7 +5,7 @@ import cookie from '../lib/cookie'
 
 // @TODO Refactor oAuthCallback to return promise instead of using a callback and reduce duplicate code
 export default async (req, res, options, done) => {
-  const { provider: providerName, providers, adapter, site, secret, urlPrefix, cookies, callbackUrl, newAccountLandingPageUrl } = options
+  const { provider: providerName, providers, adapter, site, secret, baseUrl, cookies, callbackUrl, newAccountLandingPageUrl } = options
   const provider = providers[providerName]
   const { type } = provider
   const { getEmailVerification, deleteEmailVerification } = await adapter.getAdapter(options)
@@ -18,7 +18,7 @@ export default async (req, res, options, done) => {
       // @TODO Check error
       if (error) {
         console.error('OAUTH_CALLBACK_ERROR', error)
-        res.status(302).setHeader('Location', `${urlPrefix}/error?error=oAuthCallback`)
+        res.status(302).setHeader('Location', `${baseUrl}/error?error=oAuthCallback`)
         res.end()
         return done()
       }
@@ -42,12 +42,12 @@ export default async (req, res, options, done) => {
       } catch (error) {
         if (error.name === 'AccountNotLinkedError') {
           // If the emai lon the account is already linked, but nto with this oAuth account
-          res.status(302).setHeader('Location', `${urlPrefix}/error?error=oAuthAccountNotLinked`)
+          res.status(302).setHeader('Location', `${baseUrl}/error?error=oAuthAccountNotLinked`)
         } else if (error.name === 'CreateUserError') {
-          res.status(302).setHeader('Location', `${urlPrefix}/error?error=oAuthCreateAccount`)
+          res.status(302).setHeader('Location', `${baseUrl}/error?error=oAuthCreateAccount`)
         } else {
           console.error('OAUTH_CALLBACK_ERROR', error)
-          res.status(302).setHeader('Location', `${urlPrefix}/error?error=Callback`)
+          res.status(302).setHeader('Location', `${baseUrl}/error?error=Callback`)
         }
         res.end()
         return done()
@@ -71,7 +71,7 @@ export default async (req, res, options, done) => {
       // Verify email and token match email verification record in database
       const invite = await getEmailVerification(email, token, secret, provider)
       if (!invite) {
-        res.status(302).setHeader('Location', `${urlPrefix}/error?error=Verification`)
+        res.status(302).setHeader('Location', `${baseUrl}/error?error=Verification`)
         res.end()
         return done()
       }
@@ -108,9 +108,9 @@ export default async (req, res, options, done) => {
       return done()
     } catch (error) {
       if (error.name === 'CreateUserError') {
-        res.status(302).setHeader('Location', `${urlPrefix}/error?error=EmailCreateAccount`)
+        res.status(302).setHeader('Location', `${baseUrl}/error?error=EmailCreateAccount`)
       } else {
-        res.status(302).setHeader('Location', `${urlPrefix}/error?error=Callback`)
+        res.status(302).setHeader('Location', `${baseUrl}/error?error=Callback`)
         console.error('EMAIL_CALLBACK_ERROR', error)
       }
       res.end()

--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -3,7 +3,7 @@ import oAuthSignin from '../lib/signin/oauth'
 import emailSignin from '../lib/signin/email'
 
 export default async (req, res, options, done) => {
-  const { provider: providerName, providers, urlPrefix, csrfTokenVerified } = options
+  const { provider: providerName, providers, baseUrl, csrfTokenVerified } = options
   const provider = providers[providerName]
   const { type } = provider
 
@@ -16,7 +16,7 @@ export default async (req, res, options, done) => {
     oAuthSignin(provider, (error, oAuthSigninUrl) => {
       if (error) {
         console.error('OAUTH_SIGNIN_ERROR', error)
-        res.status(302).setHeader('Location', `${urlPrefix}/error?error=oAuthSignin`)
+        res.status(302).setHeader('Location', `${baseUrl}/error?error=oAuthSignin`)
         res.end()
         return done()
       }
@@ -41,7 +41,7 @@ export default async (req, res, options, done) => {
     //
     // Note: Adds ?csrf=true query string param to URL for debugging/tracking
     if (!csrfTokenVerified) {
-      res.status(302).setHeader('Location', `${urlPrefix}/signin?email=${email}&csrf=true`)
+      res.status(302).setHeader('Location', `${baseUrl}/signin?email=${email}&csrf=true`)
       res.end()
       return done()
     }
@@ -50,17 +50,17 @@ export default async (req, res, options, done) => {
       await emailSignin(email, provider, options)
     } catch (error) {
       console.error('EMAIL_SIGNIN_ERROR', error)
-      res.status(302).setHeader('Location', `${urlPrefix}/error?error=EmailSignin`)
+      res.status(302).setHeader('Location', `${baseUrl}/error?error=EmailSignin`)
       res.end()
       return done()
     }
 
-    res.status(302).setHeader('Location', `${urlPrefix}/check-email`)
+    res.status(302).setHeader('Location', `${baseUrl}/check-email`)
     res.end()
     return done()
   } else {
     // If provider not supported, redirect to sign in page
-    res.status(302).setHeader('Location', `${urlPrefix}/signin`)
+    res.status(302).setHeader('Location', `${baseUrl}/signin`)
     res.end()
     return done()
   }

--- a/src/server/routes/signout.js
+++ b/src/server/routes/signout.js
@@ -2,7 +2,7 @@
 import cookie from '../lib/cookie'
 
 export default async (req, res, options, done) => {
-  const { adapter, cookies, callbackUrl, csrfTokenVerified, urlPrefix } = options
+  const { adapter, cookies, callbackUrl, csrfTokenVerified, baseUrl } = options
   const { deleteSession } = await adapter.getAdapter(options)
 
   // Get session ID (if set)
@@ -30,7 +30,7 @@ export default async (req, res, options, done) => {
     //
     // Note: Adds ?csrf=true query string param to URL for debugging/tracking.
     // @TODO Add support for custom signin URLs
-    res.status(302).setHeader('Location', `${urlPrefix}/signout?csrf=true`)
+    res.status(302).setHeader('Location', `${baseUrl}/signout?csrf=true`)
     res.end()
     return done()
   }


### PR DESCRIPTION
The name baseURL (and basePath) are exposed as options.

As they are more more widely used than urlPrefix and pathPrefix I've renamed them globally.

Lots of files changed, but is just a rename, with a small clean up of client code.

This is an advanced option isn't documented yet or used in the example, so I doubt it will break anything for anyone.