### PR TITLE
Fix session expiry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.40",
+  "version": "2.0.0-beta.41",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -24,7 +24,6 @@ const session = async ({ req, site, basePath, baseUrlCookieName } = {}) => {
   }
 }
 
-
 // Context to store session data globally
 const SessionContext = createContext()
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -154,7 +154,7 @@ export default async (req, res, _options) => {
     // except for the options with special handling above
     const options = {
       // Defaults options can be overidden
-      sessionMaxAge: 30 * 60 * 60 * 1000, // Sessions expire after 30 days of being idle
+      sessionMaxAge: 30 * 24 * 60 * 60 * 1000, // Sessions expire after 30 days of being idle
       sessionUpdateAge: 24 * 60 * 60 * 1000, // Sessions updated only if session is greater than this value (0 = always, 24*60*60*1000 = every 24 hours)
       verificationMaxAge: 24 * 60 * 60 * 1000, // Email/passwordless links expire after 24 hours
       debug: false, // Enable debug messages to be displayed


### PR DESCRIPTION
Due to a typo, default time in beta.40 was 30 hours (`30 * 60 * 60 * 1000`) instead of 30 days (`30 * 24 * 60 * 60 * 1000`). Fixed in next-auth@2.0.0-beta.41