### PR TITLE
Customise website theme and homepage

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'NextAuth',
-  tagline: 'Serverless Authentication, written from scratch for Next.js',
+  tagline: 'Serverless authentication for Next.js',
   url: 'https://next-auth.js.org',
   baseUrl: '/',
   favicon: 'img/favicon.ico',
@@ -9,10 +9,12 @@ module.exports = {
   themeConfig: {
     navbar: {
       title: 'NextAuth',
+      /*
       logo: {
         alt: 'NextAuth Logo',
         src: 'img/nextjs-logo.svg'
       },
+      */
       links: [
         {
           to: '/getting-started',
@@ -21,8 +23,8 @@ module.exports = {
           position: 'left'
         },
         {
-          href: 'https://npmjs.com/package/next-auth',
-          label: 'npm',
+          href: 'https://www.npmjs.com/package/next-auth/v/beta',
+          label: 'next-auth@beta',
           position: 'right'
         },
         {
@@ -32,13 +34,12 @@ module.exports = {
         }
       ]
     },
-    /* announcementBar: { */
-    /*   id: 'support_us', */
-    /*   content: */
-    /*     'We just launched v2! Check out how to upgrade <a target="_blank" rel="noopener noreferrer" href="/upgrade">here</a> 🎉', */
-    /*   backgroundColor: '#fafbfc', */
-    /*   textColor: '#091E42' */
-    /* }, */
+    announcementBar: {
+      id: 'beta-announcement',
+      content: 'NextAuth v2 is in beta! <a target="_blank" rel="noopener noreferrer" href="https://github.com/iaincollins/next-auth/issues/99">View announcement</a>',
+      backgroundColor: '#eee',
+      textColor: '#091E42'
+    },
     footer: {
       style: 'dark',
       links: [

--- a/www/package.json
+++ b/www/package.json
@@ -5,7 +5,9 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy"
+    "deploy": "docusaurus deploy",
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.54",

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -15,6 +15,13 @@
   --ifm-color-primary-lighter: #40C4FF;
   --ifm-color-primary-lightest: #60CEFF;
   --ifm-code-font-size: 95%;
+  --ifm-color-info: #03a9fc;
+  --ifm-color-success: #00cc66;
+  --ifm-color-warning: #c94b4b;
+}
+
+.footer.footer--dark {
+  --ifm-footer-background-color: #1F201C;
 }
 
 .docusaurus-highlight-code-line {
@@ -24,9 +31,76 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
+.hero {
+  background-color: var(--ifm-background-color);
+  color: black;
+}
+
+.hero .hero__title {
+  font-size: 4rem;
+  margin-bottom: 0.5rem;
+}
+
+.hero .hero__subtitle {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.hero .button {
+  border-radius: 2rem;
+  margin-top: 1rem;
+}
+
 .home-subtitle {
   justify-content: center;
-  margin-top: 20px;
-  font-size: 0.8rem;
-  color: #adadad;
+  margin-top: 2rem;
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.home-main h3 {
+  text-align: center;
+  line-height: 3.5rem;
+  margin: 0.5rem 0;  
+}
+
+.home-main .code {
+  padding: 0;
+  height: 100%;
+  font-size: 0.9rem;
+  background: #292D3D;
+  overflow: hidden;
+  border-radius: .5rem;
+}
+
+.home-main .code .code-heading {
+  color: rgba(255,255,255,.8);
+  background: rgba(0,0,0,.2);
+  margin: 0;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  width: 100%;
+}
+
+.home-main .col {
+  margin-bottom: 1.5rem;
+}
+
+.home-main .row {
+  margin-bottom: 2rem;
+}
+
+html[data-theme='dark'] { 
+  --ifm-background-color: #1F201C;
+}
+
+html[data-theme="dark"] .hero .hero__title,
+html[data-theme="dark"] .hero .hero__subtitle,
+html[data-theme="dark"] .home-subtitle,
+html[data-theme="dark"] .hero .button {
+  color: white;
+}
+
+html[data-theme='dark'] .footer.footer--dark {
+  --ifm-footer-background-color: #242526;
 }

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -4,6 +4,7 @@ import Layout from '@theme/Layout'
 import Link from '@docusaurus/Link'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import useBaseUrl from '@docusaurus/useBaseUrl'
+import CodeBlock from '@theme/CodeBlock'
 import styles from './styles.module.css'
 
 const features = [
@@ -12,19 +13,18 @@ const features = [
     imageUrl: 'img/undraw_authentication.svg',
     description: (
       <>
-        Serverless authentication library built primarily for Next.js, but will
-        work in any environment. Simple to setup and does not require Express or PassportJS.
+        Open source full stack authentication library designed for Next.js and serverless deployment. Simple to setup
+        with either an SQL or noSQL database. Use with client and server side React.
       </>
     )
   },
   {
-    title: <>Many Login Providers</>,
+    title: <>oAuth and Passwordless</>,
     imageUrl: 'img/undraw_social.svg',
     description: (
       <>
-        Built-in support for many OAuth providers. If you can't find yours, we make it
-        easy to add others as well. We also support an Email / Password based signup and
-        login method.
+        Comes with built-in support for popular oAuth providers, including Google, Facebook, Twitter, GitHub and Auth0.
+        Use with any oAuth service. Supports passwordless email sign in.
       </>
     )
   },
@@ -33,9 +33,8 @@ const features = [
     imageUrl: 'img/undraw_secure.svg',
     description: (
       <>
-        OAuth, CSRF Protection, and secure host only and http only signed cookies out
-        of the box! Session IDs are never exposed to client-side javascript so your
-        users sessions cant get hijacked.
+        CSRF protection, signed server-only prefixed cookies (secure / host only) and secure account linking.
+        Doesn't expose session tokens to client side JavaScript, or rely on client side JavaScript.
       </>
     )
   }
@@ -60,28 +59,41 @@ function Home () {
   const context = useDocusaurusContext()
   const { siteConfig = {} } = context
   return (
-    <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description='Description will go into a meta tag in <head />'
-    >
-      <header className={classnames('hero hero--primary', styles.heroBanner)}>
+    <Layout title='Home' description={siteConfig.tagline}>
+      <header className={classnames('hero', styles.heroBanner)}>
         <div className='container'>
           <h1 className='hero__title'>{siteConfig.title}</h1>
           <p className='hero__subtitle'>{siteConfig.tagline}</p>
           <div className={styles.buttons}>
             <Link
               className={classnames(
-                'button button--outline button--secondary button--lg',
+                'button button--primary button--lg',
                 styles.getStarted
               )}
               to={useBaseUrl('/getting-started')}
             >
-              Get Started
+                Get Started
             </Link>
           </div>
         </div>
       </header>
-      <main>
+      <main className='home-main'>
+        <div className='container'>
+          <div className='row'>
+            <div className='col col--6'>
+              <div className='code'>
+                <h4 className='code-heading'>Serverless function</h4>
+                <CodeBlock className='javascript'>{serverlessFunctionCode}</CodeBlock>
+              </div>
+            </div>
+            <div className='col col--6'>
+              <div className='code'>
+                <h4 className='code-heading'>React component</h4>
+                <CodeBlock className='javascript'>{reactComponentCode}</CodeBlock>
+              </div>
+            </div>
+          </div>
+        </div>
         {features && features.length && (
           <section className={styles.features}>
             <div className='container'>
@@ -91,7 +103,7 @@ function Home () {
                 ))}
               </div>
               <div className='row home-subtitle'>
-                We are not affiliated with Now / Vercel / Next.js in any way!
+                NextAuth is not affiliated with Vercel, Next.js or Now.sh
               </div>
             </div>
           </section>
@@ -100,5 +112,41 @@ function Home () {
     </Layout>
   )
 }
+
+const reactComponentCode = `
+import React from 'react'
+import NextAuth from 'next-auth'
+
+export default () => {
+  const [session, loading] = NextAuth.useSession()
+
+  return <>
+    {session && <p>Signed in as {session.user.email}.</p>}
+    {!session && <p><a href="/api/auth/signin">Sign in</p>}
+  </>
+}
+`.trim()
+
+const serverlessFunctionCode = `
+import NextAuth from 'next-auth'
+import Providers from 'next-auth/providers'
+
+const options = {
+  site: 'https://example.com'
+  providers: [
+    Providers.Google({
+      clientId: process.env.GOOGLE_ID,
+      clientSecret: process.env.GOOGLE_SECRET
+    }),
+    Providers.Email({
+      server: 'smtp://username:password@smtp.example.com',
+      from: '<no-reply@example.com>'
+    }),
+  ],
+  database: process.env.DATABASE_URI
+}
+
+export default (req, res) => NextAuth(req, res, options)
+`.trim()
 
 export default Home


### PR DESCRIPTION
I love this documentation site! <3

The example server usage on the homepage is something I'm thinking of switching to the syntax for the default way to configure the database (i.e. just set a database string or object and don't have to think about 'Adapters' except for if you are actually doing your own database support).

I'm also thinking of adding in JWT sessions, where sessions are not stored in a database at all in the longer term, which should make things even simpler for some people, but I think that is further down the road.

The reason why adapters were created in the first place was to allow people to avoid including code in production they would not need - e.g. if they wanted to use something other than TypeORM - but the size for the function is fairly small (about 2.8 MB) so perhaps this is not a major concern. I'm going to think it over though and might do something in between.

I'll update with some actual documentation soon. :-)