### PR TITLE
Simplify database configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.41",
+  "version": "2.0.0-beta.42",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/server/pages/error.js
+++ b/src/server/pages/error.js
@@ -62,6 +62,16 @@ export default ({ site, error, baseUrl }) => {
           <p><a className='button' href={signinPageUrl}>Sign in</a></p>
         </div>
       break
+    case 'Configuration':
+      heading = <h1>Server configuration error</h1>
+      message =
+        <div>
+          <div className='message'>
+            <p>There is a problem with the NextAuth server configuration.</p>
+            <p>Check the server logs for details.</p>
+          </div>
+        </div>
+      break
     default:
   }
 


### PR DESCRIPTION
* Now accepts 'database' as an option as an alterantive to 'adapter'.
* If specified, 'database' can be a string or object and will load the default adapter.
* The 'adapter' option is still valid, and overrides the 'database' option.

 If neither option is specified, displays console error and web error page.

This change is backwards compatible, it just provides a new simpler way to configure a database.