### PR TITLE
Add custom pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.47",
+  "version": "2.0.0-beta.48",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",


### PR DESCRIPTION
Now supports 'pages' option, which can be any URL.

If specified, these replace the built in pages.

Example usage:

```javascript
pages: {
  signin: 'https://example.com/signin',
  signout: 'https://example.com/signout',
  checkEmail: 'https://example.com/check-email',
  error: 'https://example.com/error'
}
```