### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ See [next-auth.js.org](https://next-auth.js.org) for more information and docume
 
 ### Authentication
 
-* Designed to work with any 0Auth service, it supports 0Auth 1.0, 1.0A and 2.0
-* Built-in support for [many popular 0Auth sign-in services](https://next-auth.js.org/options/providers)
+* Designed to work with any OAuth service, it supports OAuth 1.0, 1.0A and 2.0
+* Built-in support for [many popular OAuth sign-in services](https://next-auth.js.org/options/providers)
 * Supports email / passwordless authentication
 * Supports both JSON Web Tokens and database sessions
 

--- a/www/docs/options/providers.md
+++ b/www/docs/options/providers.md
@@ -15,7 +15,7 @@ export const Image = ({ children, src, alt = '' }) => (
   </div>
  )
 
-NextAuth.js is designed to work with any 0Auth service, it supports 0Auth 1.0, 1.0A and 2.0 and has built-in support for many popular 0Auth sign-in services. It also supports email / passwordless authentication.
+NextAuth.js is designed to work with any OAuth service, it supports OAuth 1.0, 1.0A and 2.0 and has built-in support for many popular OAuth sign-in services. It also supports email / passwordless authentication.
 
 ## Sign in with OAuth
 


### PR DESCRIPTION
I found remains `0Auth` typo 
related: https://github.com/iaincollins/next-auth/commit/64b23d484da30496c0501be23951445f7ed52269