### PR TITLE
Make email address optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.68",
+  "version": "2.0.0-beta.70",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "publish:canary": "npm publish --tag canary",
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test:db:start": "docker-compose -f test/docker/docker-compose.yml up",
-    "test:db:stop": "docker-compose -f test/docker/docker-compose.yml down"
+    "test:db:run": "docker-compose -f test/docker/docker-compose.yml up",
+    "test:db:clean": "docker-compose -f test/docker/docker-compose.yml down"
   },
   "files": [
     "dist",

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -174,7 +174,7 @@ const Adapter = (config, options = {}) => {
 
     // Display debug output if debug option enabled
     // @TODO Refactor logger so is passed in appOptions
-    function _debug (debugCode, ...args) {
+    function debugMessage (debugCode, ...args) {
       if (appOptions.debug) {
         logger.debug(debugCode, ...args)
       }
@@ -195,7 +195,7 @@ const Adapter = (config, options = {}) => {
     const sessionUpdateAge = appOptions.session.updateAge * 1000
 
     async function createUser (profile) {
-      _debug('createUser', profile)
+      debugMessage('CREATE_USER', profile)
       try {
         // Create user account
         const user = new User(profile.name, profile.email, profile.image)
@@ -207,7 +207,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function getUser (id) {
-      _debug('getUser', id)
+      debugMessage('GET_USER', id)
 
       // In the very specific case of both using JWT for storing session data
       // and using MongoDB to store user data, the ID is a string rather than
@@ -228,7 +228,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function getUserByEmail (email) {
-      _debug('getUserByEmail', email)
+      debugMessage('GET_USER_BY_EMAIL', email)
       try {
         if (!email) { return Promise.resolve(null) }
         return connection.getRepository(User).findOne({ email })
@@ -239,7 +239,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function getUserByProviderAccountId (providerId, providerAccountId) {
-      _debug('getUserByProviderAccountId', providerId, providerAccountId)
+      debugMessage('GET_USER_BY_PROVIDER_ACCOUNT_ID', providerId, providerAccountId)
       try {
         const account = await connection.getRepository(Account).findOne({ providerId, providerAccountId })
         if (!account) { return null }
@@ -251,25 +251,25 @@ const Adapter = (config, options = {}) => {
     }
 
     async function getUserByCredentials (credentials) {
-      _debug('getUserByCredentials', credentials)
+      debugMessage('GET_USER_BY_CREDENTIALS', credentials)
       // @TODO Get user from DB
       return false
     }
 
     async function updateUser (user) {
-      _debug('updateUser', user)
+      debugMessage('UPDATE_USER', user)
       // @TODO Save changes to user object in DB
       return false
     }
 
     async function deleteUser (userId) {
-      _debug('deleteUser', userId)
+      debugMessage('DELETE_USER', userId)
       // @TODO Delete user from DB
       return false
     }
 
     async function linkAccount (userId, providerId, providerType, providerAccountId, refreshToken, accessToken, accessTokenExpires) {
-      _debug('linkAccount', userId, providerId, providerType, providerAccountId, refreshToken, accessToken, accessTokenExpires)
+      debugMessage('LINK_ACCOUNT', userId, providerId, providerType, providerAccountId, refreshToken, accessToken, accessTokenExpires)
       try {
         // Create provider account linked to user
         const account = new Account(userId, providerId, providerType, providerAccountId, refreshToken, accessToken, accessTokenExpires)
@@ -281,7 +281,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function unlinkAccount (userId, providerId, providerAccountId) {
-      _debug('unlinkAccount', userId, providerId, providerAccountId)
+      debugMessage('UNLINK_ACCOUNT', userId, providerId, providerAccountId)
       // @TODO Get current user from DB
       // @TODO Delete [provider] object from user object
       // @TODO Save changes to user object in DB
@@ -289,7 +289,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function createSession (user) {
-      _debug('createSession', user)
+      debugMessage('CREATE_SESSION', user)
       try {
         let expires = null
         if (sessionMaxAge) {
@@ -308,7 +308,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function getSession (sessionToken) {
-      _debug('getSession', sessionToken)
+      debugMessage('GET_SESSION', sessionToken)
       try {
         const session = await connection.getRepository(Session).findOne({ sessionToken })
 
@@ -326,7 +326,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function updateSession (session, force) {
-      _debug('updateSession', session)
+      debugMessage('UPDATE_SESSION', session)
       try {
         if (sessionMaxAge && (sessionUpdateAge || sessionUpdateAge === 0) && session.expires) {
           // Calculate last updated date, to throttle write updates to database
@@ -362,7 +362,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function deleteSession (sessionToken) {
-      _debug('deleteSession', sessionToken)
+      debugMessage('DELETE_SESSION', sessionToken)
       try {
         return await connection.getRepository(Session).delete({ sessionToken })
       } catch (error) {
@@ -372,7 +372,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function createVerificationRequest (identifer, url, token, secret, provider) {
-      _debug('createVerificationRequest', identifer)
+      debugMessage('CREATE_VERIFICATION_REQUEST', identifer)
       try {
         const { site } = appOptions
         const { sendVerificationRequest, maxAge } = provider
@@ -405,7 +405,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function getVerificationRequest (identifer, token, secret, provider) {
-      _debug('getVerificationRequest', identifer, token)
+      debugMessage('GET_VERIFICATION_REQUEST', identifer, token)
       try {
         // Hash token provided with secret before trying to match it with datbase
         // @TODO Use bcrypt function here instead of simple salted hash
@@ -426,7 +426,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function deleteVerificationRequest (identifer, token, secret, provider) {
-      _debug('deleteVerification', identifer, token)
+      debugMessage('DELETE_VERIFICATION', identifer, token)
       try {
         // Delete verification entry so it cannot be used again
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -81,20 +81,11 @@ const Adapter = (config, options = {}) => {
     delete UserSchema.columns.id.type
     UserSchema.columns.id.objectId = true
 
-    // Remove unique constraint from email field and replace with sparce index
-    // to allow more than one field to be null, so that email addresses can
-    // be optional, as `unique: true` and `nullable: true` don't work the same
-    // with MongoDB as they do with SQL databases like MySQL and Postgres.
-    delete UserSchema.columns.email.unique
-    UserSchema.indices = [
-      {
-        name: 'email_index',
-        sparse: true,
-        columns: [
-          'email'
-        ]
-      }
-    ]
+    // The options `unique: true` and `nullable: true` don't work the same
+    // with MongoDB as they do with SQL databases like MySQL and Postgres,
+    // we also to add sparce to the index. This still doesn't allow multiple
+    // *null* values, but does allow some records to omit the property.
+    UserSchema.columns.email.sparse = true
 
     // Update Account schema for MongoDB
     delete AccountSchema.columns.id.type

--- a/src/adapters/typeorm/models/user.js
+++ b/src/adapters/typeorm/models/user.js
@@ -24,7 +24,8 @@ export const UserSchema = {
     },
     email: {
       type: 'varchar',
-      unique: true
+      unique: true,
+      nullable: true
     },
     image: {
       type: 'varchar',

--- a/src/adapters/typeorm/models/user.js
+++ b/src/adapters/typeorm/models/user.js
@@ -1,8 +1,8 @@
 export class User {
   constructor (name, email, image) {
-    this.name = name
-    this.email = email
-    this.image = image
+    if (name) { this.name = name }
+    if (email) { this.email = email }
+    if (image) { this.image = image }
 
     const dateCreated = new Date()
     this.created = dateCreated.toISOString()

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -34,17 +34,8 @@ class AccountNotLinkedError extends UnknownError {
   }
 }
 
-class InvalidProfile extends UnknownError {
-  constructor (message) {
-    super(message)
-    this.name = 'InvalidProfile'
-    this.message = message
-  }
-}
-
 module.exports = {
   UnknownError,
   CreateUserError,
-  AccountNotLinkedError,
-  InvalidProfile
+  AccountNotLinkedError
 }

--- a/src/providers/google.js
+++ b/src/providers/google.js
@@ -14,7 +14,7 @@ export default (options) => {
       return {
         id: profile.id,
         name: profile.name,
-        email: profile.verified_email ? profile.email : null,
+        email: profile.email,
         image: profile.picture
       }
     },

--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -118,7 +118,7 @@ async function _getProfile (error, profileData, accessToken, refreshToken, provi
       accessToken,
       accessTokenExpires: null
     },
-    _profile: profileData
+    oAuthProfile: profileData
   })
 }
 

--- a/src/server/pages/error.js
+++ b/src/server/pages/error.js
@@ -24,7 +24,7 @@ export default ({ site, error, baseUrl }) => {
           <p><a className='button' href={signinPageUrl}>Sign in</a></p>
         </div>
       break
-    case 'oAuthAccountNotLinked':
+    case 'OAuthAccountNotLinked':
       heading = <h1>Sign in with another account</h1>
       message =
         <div>
@@ -36,18 +36,6 @@ export default ({ site, error, baseUrl }) => {
         </div>
       // @TODO Add this text when account linking is complete
       // <p>Once you are signed in, you can link your accounts.</p>
-      // @TODO Display email sign in option if an email provider is configured
-      break
-    case 'EmailRequired':
-      heading = <h1>Sign in with another account</h1>
-      message =
-        <div>
-          <div className='message'>
-            <p>Your account doesn't have an email address (required).</p>
-            <p>Try signing in with a different account.</p>
-          </div>
-          <p><a className='button' href={signinPageUrl}>Sign in</a></p>
-        </div>
       // @TODO Display email sign in option if an email provider is configured
       break
     case 'EmailSignin':

--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -149,7 +149,7 @@ You likely only need to use this if you are not using the built-in `signin()` an
 
 ---
 
-## signin(provider, { options })
+## signin()
 
 * Client Side: **Yes**
 * Server Side: No
@@ -185,7 +185,7 @@ When using it with the email flow, pass the target `email` as an option.
 ```js
 import { signin } from 'next-auth/client'
 
-export default (email) => (
+export default ({ email }) => (
   <button onClick={() => signin('email', { email })}>Sign in with Email</button>
 )
 ```


### PR DESCRIPTION
I think we have a working solution to allows signing in without an email address that would resolve #131 and work for everybody.

* Tested with MySQL, Postgres and MongoDB
* Tested with no database
* Tested with multiple combinations of OAuth accounts from a range of providers, with and without email addresses
* `allowSignin()` is now also passed the full raw oAuthProfile object on sign in (see docs)
* `jwt.set()` is now also passed the full raw oAuthProfile object after first sign in (see docs)

Combined with the above, we no longer need to cater for error handling for signing in without an email address as this can be done in all scenarios by using the `allowSignin()` handler and a custom error page for anyone that wants to do that (although I suspect that will be an edge case).

Additionally, now that these functions exist and the full oAuthProfile data passed to them, we don't need to have constraints on providers like caring if a provider things an email address is verified or not, as that can and should be checked in the `allowSignin()` callback.

Note: It's still possible the name of the `allowSignin()` callback (which was introduced in an earlier release) will change before v2 release so that it will align with future callback methods.
