### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a defect with the software
+title: Short clear summary of the problem
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the defect is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+Include example code (or link to public repository) which can be used to reproduce the behaviour.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots or error logs**
+If applicable, add screenshots or error logs to help explain the problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: Short clear summary of the request
+labels: enhancement
+assignees: ''
+
+---
+
+*Please stick to one distinct feature request per issue where possible and raise additional feature quests as separate issues. Try to avoid adding feature requests to existing issues in the comments of issues raised by other users.*
+
+**Summary of proposed feature**
+A clear and concise description of the feature being proposed.
+
+**Purpose of proposed feature**
+A clear and concise description description of why this feature is necessary and what problems it solves.
+
+**Detail of the proposed**
+A detailed description of how the proposal might work (if you have one).
+
+**Potential problems**
+Describe any potential problems or potential limitations or caveats of the proposed solution you can think of.
+
+**Describe any alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+*Please indicate if you are willing and able to help implement the proposed feature.*

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: Question
+about: Ask for information or support
+title: " Short clear summary of the question"
+labels: question
+assignees: ''
+
+---
+
+*Please refer to the [documentation](https://next-auth.js.org/getting-started/introduction), the [example project](https://github.com/iaincollins/next-auth-example) and existing issues before creating a new issue.*
+
+**Your question**
+A clear and concise question.
+
+**What are you trying to do**
+A description of what you are trying to do.


### PR DESCRIPTION
Trying to create some structure to get external contributors to think about feature requests and/or provide more information when raising issues.

This is not intended for core committers - I'm just trying to wrangle the input we get to improve signal to noise, especially as I'm also starting to get emails asking for support now.