### PR TITLE
Added function for getting original JWT

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+package-lock.json
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "endOfLine": "lf",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,7 +1,14 @@
 // fetch() is built in to Next.js 9.4 (you can use a polyfill if using an older version)
 /* global fetch:false */
-import { useState, useEffect, useContext, createContext, createElement } from 'react'
+import {
+  useState,
+  useEffect,
+  useContext,
+  createContext,
+  createElement
+} from 'react'
 import logger from '../lib/logger'
+import { parseCookies } from '../utils'
 
 // Note: In calls to fetch() from universal methods, all cookies are passed
 // through from the browser, when the server makes the HTTP request, so that
@@ -62,7 +69,9 @@ const useSessionData = (session) => {
       logger.error('CLIENT_USE_SESSION_ERROR', error)
     }
   }
-  useEffect(() => { _getSession() }, [])
+  useEffect(() => {
+    _getSession()
+  }, [])
   return [data, loading]
 }
 
@@ -71,7 +80,9 @@ const signin = async (provider, args) => {
   if (!provider) {
     // Redirect to sign in page if no provider specified
     const baseUrl = _baseUrl()
-    window.location = `${baseUrl}/signin?callbackUrl=${encodeURIComponent(window.location)}`
+    window.location = `${baseUrl}/signin?callbackUrl=${encodeURIComponent(
+      window.location
+    )}`
     return
   }
 
@@ -79,10 +90,14 @@ const signin = async (provider, args) => {
   if (!providers[provider]) {
     // If Provider not recognized, redirect to sign in page
     const baseUrl = _baseUrl()
-    window.location = `${baseUrl}/signin?callbackUrl=${encodeURIComponent(window.location)}`
+    window.location = `${baseUrl}/signin?callbackUrl=${encodeURIComponent(
+      window.location
+    )}`
   } else if (providers[provider].type === 'oauth') {
     // If is an OAuth provider, redirect to providers[provider].signinUrl
-    window.location = `${providers[provider].signinUrl}?callbackUrl=${encodeURIComponent(window.location)}`
+    window.location = `${
+      providers[provider].signinUrl
+    }?callbackUrl=${encodeURIComponent(window.location)}`
   } else {
     // If is any other provider type, POST to providers[provider].signinUrl (with CSRF Token)
     const options = {
@@ -142,9 +157,11 @@ const _baseUrl = ({ req } = {}) => {
     // If we have a 'req' object are running sever side, so we should grab the
     // base URL from cookie that is set by the API route - which is how config
     // is shared automatically between the API route and the client.
-    const cookies = req ? _parseCookies(req.headers.cookie) : null
-    const baseUrlCookieName = process.env.NEXTAUTH_BASE_URL_COOKIE_NAME || DEFAULT_BASE_URL_COOKIE_NAME
-    const cookieValue = cookies[`__Secure-${baseUrlCookieName}`] || cookies[baseUrlCookieName]
+    const cookies = req ? parseCookies(req.headers.cookie) : null
+    const baseUrlCookieName =
+      process.env.NEXTAUTH_BASE_URL_COOKIE_NAME || DEFAULT_BASE_URL_COOKIE_NAME
+    const cookieValue =
+      cookies[`__Secure-${baseUrlCookieName}`] || cookies[baseUrlCookieName]
     const [baseUrl] = cookieValue ? cookieValue.split('|') : [null]
     return baseUrl
   } else {
@@ -156,29 +173,12 @@ const _baseUrl = ({ req } = {}) => {
   }
 }
 
-// Adapted from https://github.com/felixfong227/simple-cookie-parser/blob/master/index.js
-const _parseCookies = (string) => {
-  if (!string) { return {} }
-  try {
-    const object = {}
-    const a = string.split(';')
-    for (let i = 0; i < a.length; i++) {
-      const b = a[i].split('=')
-      if (b[0].length > 1 && b[1]) {
-        object[b[0].trim()] = decodeURIComponent(b[1])
-      }
-    }
-    return object
-  } catch (error) {
-    logger.error('CLIENT_COOKIE_PARSE_ERROR', error)
-    return {}
-  }
-}
-
 const _encodedForm = (formData) => {
-  return Object.keys(formData).map((key) => {
-    return encodeURIComponent(key) + '=' + encodeURIComponent(formData[key])
-  }).join('&')
+  return Object.keys(formData)
+    .map((key) => {
+      return encodeURIComponent(key) + '=' + encodeURIComponent(formData[key])
+    })
+    .join('&')
 }
 
 export default {

--- a/src/lib/jwt.js
+++ b/src/lib/jwt.js
@@ -1,11 +1,24 @@
 import jwt from 'jsonwebtoken'
 import CryptoJS from 'crypto-js'
+import { parseCookies } from '../utils'
+
+const getSessionToken = (cookies, cookieName) => {
+  const secureCookieName = '__Secure-next-auth.session-token'
+  const insecureCookieName = 'next-auth.session-token'
+  return cookieName
+    ? cookies[cookieName]
+    : cookies[secureCookieName] || cookies[insecureCookieName]
+}
 
 const encode = async ({ secret, key = secret, token = {}, maxAge }) => {
   // If maxAge is set remove any existing created/expiry dates and replace them
   if (maxAge) {
-    if (token.iat) { delete token.iat }
-    if (token.exp) { delete token.exp }
+    if (token.iat) {
+      delete token.iat
+    }
+    if (token.exp) {
+      delete token.exp
+    }
   }
   const signedToken = jwt.sign(token, secret, { expiresIn: maxAge })
   const encryptedToken = CryptoJS.AES.encrypt(signedToken, key).toString()
@@ -20,15 +33,13 @@ const decode = async ({ secret, key = secret, token, maxAge }) => {
   return verifiedToken
 }
 
-// This is a simple helper method to make it easier to use JWT from an API route
-const getJwt = async ({ req, secret, cookieName }) => {
+// This is a simple helper method to make it easier to use JWT Payload from an API route
+const getJwtPayload = async ({ req, secret, cookieName }) => {
   if (!req || !secret) throw new Error('Must pass { req, secret } to getJWT()')
-
-  const secureCookieName = '__Secure-next-auth.session-token'
-  const insecureCookieName = 'next-auth.session-token'
-  const cookieValue = cookieName ? req.cookies[cookieName] : req.cookies[secureCookieName] || req.cookies[insecureCookieName]
-
-  if (!cookieValue) { return null }
+  const cookieValue = getSessionToken(req.cookies, cookieName)
+  if (!cookieValue) {
+    return null
+  }
 
   try {
     return await decode({ secret, token: cookieValue })
@@ -37,8 +48,22 @@ const getJwt = async ({ req, secret, cookieName }) => {
   }
 }
 
+// This helper returns signed JWT that could be used for passing to other API services
+const getJwt = async ({ req, secret, cookieName }) => {
+  if (!req || !secret) throw new Error('Must pass { req, secret } to getJWT()')
+  const cookies = parseCookies(req.headers.cookie)
+  const cookieValue = getSessionToken(cookies, cookieName)
+  if (!cookieValue) {
+    return null
+  }
+  const decryptedBytes = CryptoJS.AES.decrypt(cookieValue, secret)
+  const token = decryptedBytes.toString(CryptoJS.enc.Utf8)
+  return token
+}
+
 export default {
   encode,
   decode,
-  getJwt
+  getJwt,
+  getJwtPayload
 }

--- a/src/lib/jwt.js
+++ b/src/lib/jwt.js
@@ -49,7 +49,7 @@ const getJwtPayload = async ({ req, secret, cookieName }) => {
 }
 
 // This helper returns signed JWT that could be used for passing to other API services
-const getJwt = async ({ req, secret, cookieName }) => {
+const getJwt = ({ req, secret, cookieName }) => {
   if (!req || !secret) throw new Error('Must pass { req, secret } to getJWT()')
   const cookies = parseCookies(req.headers.cookie)
   const cookieValue = getSessionToken(cookies, cookieName)
@@ -65,5 +65,5 @@ export default {
   encode,
   decode,
   getJwt,
-  getJwtPayload
+  getJwtPayload,
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,23 @@
+// Adapted from https://github.com/felixfong227/simple-cookie-parser/blob/master/index.js
+const parseCookies = (string) => {
+  // console.log(string);
+  if (!string) {
+    return {}
+  }
+  try {
+    const object = {}
+    const a = string.split(';')
+    for (let i = 0; i < a.length; i++) {
+      const b = a[i].split('=')
+      if (b[0].length > 1 && b[1]) {
+        object[b[0].trim()] = decodeURIComponent(b[1])
+      }
+    }
+    return object
+  } catch (error) {
+    logger.error('CLIENT_COOKIE_PARSE_ERROR', error)
+    return {}
+  }
+}
+
+export { parseCookies }

--- a/www/docs/options/basic-options.md
+++ b/www/docs/options/basic-options.md
@@ -4,18 +4,19 @@ title: Basic Options
 ---
 
 :::note
-* Configuration options are passed to NextAuth.js when initalizing it in an API route.
-* The only *required* options are **site** and **providers**.
-:::
+
+- Configuration options are passed to NextAuth.js when initalizing it in an API route.
+- The only _required_ options are **site** and **providers**.
+  :::
 
 ---
 
 ## site
 
-* **Default value**: `empty string`
-* **Required**: *Yes*
+- **Default value**: `empty string`
+- **Required**: _Yes_
 
-#### Description 
+#### Description
 
 The fully qualified URL for the root of your site.
 
@@ -25,10 +26,10 @@ e.g. `http://localhost:3000` or `https://www.example.com`
 
 ## providers
 
-* **Default value**: `[]`
-* **Required**: *Yes*
+- **Default value**: `[]`
+- **Required**: _Yes_
 
-#### Description 
+#### Description
 
 An array of authentication providers for signing in (e.g. Google, Facebook, Twitter, GitHub, Email, etc) in any order. This can be one of the built-in providers or an object with a custom provider.
 
@@ -38,10 +39,10 @@ See the [providers documentation](/options/providers) for a list of supported pr
 
 ## database
 
-* **Default value**: `null`
-* **Required**: *No* (Except by Email provider)
+- **Default value**: `null`
+- **Required**: _No_ (Except by Email provider)
 
-#### Description 
+#### Description
 
 A database connection string or [TypeORM](https://github.com/typeorm/typeorm/blob/master/docs/using-ormconfig.md) configuration object.
 
@@ -59,8 +60,8 @@ The Email provider currently requires a database to be configured.
 
 ## secret
 
-* **Default value**: `string` (*SHA hash of the "options" object*)
-* **Required**: *No* (but strongly recommended)
+- **Default value**: `string` (_SHA hash of the "options" object_)
+- **Required**: _No_ (but strongly recommended)
 
 #### Description
 
@@ -74,8 +75,8 @@ The default behaviour is secure, but volatile, and it is strongly recommended yo
 
 ## session
 
-* **Default value**: `object`
-* **Required**: *No*
+- **Default value**: `object`
+- **Required**: _No_
 
 #### Description
 
@@ -88,16 +89,16 @@ session: {
   // Use JSON Web Tokens for session instead of database sessions.
   // This option can be used with or without a database for users/accounts.
   // Note: `jwt` is automatically set to `true` if no database is specified.
-  jwt: false, 
-  
+  jwt: false,
+
   // Seconds - How long until an idle session expires and is no longer valid.
   maxAge: 30 * 24 * 60 * 60, // 30 days
-  
+
   // Seconds - Throttle how frequently to write to database to extend a session.
   // Use it to limit write operations. Set to 0 to always update the database.
-  // Note: This option is ignored if using JSON Web Tokens 
+  // Note: This option is ignored if using JSON Web Tokens
   updateAge: 24 * 60 * 60, // 24 hours
-  
+
   // Easily add custom properties to response from `/api/auth/session`.
   //
   // Note: The response should not return any sensitive information. The JWT
@@ -117,8 +118,8 @@ session: {
 
 ## jwt
 
-* **Default value**: `object`
-* **Required**: *No*
+- **Default value**: `object`
+- **Required**: _No_
 
 #### Description
 
@@ -135,18 +136,16 @@ Default values for this option are shown below:
 ```js
 jwt: {
   // secret: 'my-secret-123', // Secret auto-generated if not specified.
-    
   // Custom encode/decode functions for signing + encryption can be specified.
   // if you want to override what is in the JWT or how it is signed.
   // encode: async ({ secret, key, token, maxAge }) => {},
   // decode: async ({ secret, key, token, maxAge }) => {},
-
   // Easily add custom to the JWT. It is updated every time it is accessed.
   // This encrypted and signed by default and may contain sensitive information
   // as long as a reasonable secret is defined.
   //
   // Note: 'oAuthProfile' is the raw oAuth profile from the provider the user
-  // used to sign in with and is only returned when the JWT is created for the 
+  // used to sign in with and is only returned when the JWT is created for the
   // current user / session, if you want to persist data from it you need to add
   // the data you want to keep to the token. Keep in mind JWT token size limits.
   /*
@@ -168,8 +167,8 @@ An example JSON WebToken contains an encrypted payload like this:
     image: 'https://example.com/image.jpg',
     id: 1 // User ID will note be specified if used without a database
   },
-  // The account object stores details for the authentication provider account 
-  // that was used to sign in. It only contains exactly one account, even the 
+  // The account object stores details for the authentication provider account
+  // that was used to sign in. It only contains exactly one account, even the
   // user is linked to multiple provider accounts in a database.
   account: {
     provider: 'google',
@@ -185,16 +184,16 @@ An example JSON WebToken contains an encrypted payload like this:
 }
 ```
 
-You can use the built-in `getJwt()` helper method to read the token, like this:
+You can use the built-in `getJwtPayload()` helper method to read the token payload, like this:
 
 ```js
 import jwt from 'next-auth/jwt'
 
 const secret = process.env.JWT_SECRET
 
-export default async (req, res) =>  {
+export default async (req, res) => {
   // Automatically decrypts and verifies JWT
-  const token = await jwt.getJwt({ req, secret })
+  const token = await jwt.getJwtPayload({ req, secret })
   res.end(JSON.stringify(token, null, 2))
 }
 ```
@@ -207,8 +206,8 @@ The JWT is stored in the Session Token cookie – the same cookie used for datab
 
 ## allowSignin
 
-* **Default value**: `function` (returns `boolean`)
-* **Required**: *No*
+- **Default value**: `function` (returns `boolean`)
+- **Required**: _No_
 
 #### Description
 
@@ -245,8 +244,8 @@ You should not rely on the email address alone unless that provider is trusted a
 
 ## allowCallbackUrl
 
-* **Default value**: `function` (returns URL as `string`)
-* **Required**: *No*
+- **Default value**: `function` (returns URL as `string`)
+- **Required**: _No_
 
 #### Description
 
@@ -254,10 +253,10 @@ By default `allowCallbackUrl` only allows callbackUrls for signup and signout to
 
 e.g. if the sign in URL was `https://example.com/api/auth/signin` the following logic would apply:
 
-* ✅ `https://example.com/path/to/page`
-* ❌ `http://example.com/path/to/page` 
-* ❌ `https://subdomain.example.com/path/to/page` 
-* ❌ `https://example.com:8080/path/to/page`
+- ✅ `https://example.com/path/to/page`
+- ❌ `http://example.com/path/to/page`
+- ❌ `https://subdomain.example.com/path/to/page`
+- ❌ `https://example.com:8080/path/to/page`
 
 If the URL is not allowed, the callback URL will be set to whatever the `site` option is set to.
 
@@ -279,8 +278,8 @@ If you want to support signing in to sites across other domains or hostnames you
 
 ## pages
 
-* **Default value**: `{}`
-* **Required**: *No*
+- **Default value**: `{}`
+- **Required**: _No_
 
 #### Description
 
@@ -288,7 +287,7 @@ Specify URLs to be used if you want to create custom sign in, sign out and error
 
 Pages specified will override the corresponding built-in page.
 
-*For example:*
+_For example:_
 
 ```js
 pages: {
@@ -306,8 +305,8 @@ See the documentation for the [pages option](/options/pages) for more informatio
 
 ## debug
 
-* **Default value**: `false`
-* **Required**: *No*
+- **Default value**: `false`
+- **Required**: _No_
 
 #### Description
 


### PR DESCRIPTION
That PR includes the following changes:
- `getJwt` function renamed to `getJwtPayload`. It was confusing that getJwt returns token payload rather than token by itself that what I expect to see from the name. 
- `getJwt `function returns signed token that could be used for the purpose of forwarding it to other API service
- Removed async from `getJwt` function since there is no need for this. Actually I checked and there is no need for async declaration for all function inside `src/lib/jwt.js`
- Added `.prettierrc` config, it will allow us to have similar formatting rules for all contributors.

Related issues: #244 #243