### PR TITLE
Rename master branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,20 +8,20 @@ Please see the [Code of Conduct](CODE_OF_CONDUCT.md) and follow any templates co
 
 ## Pull Requests
 
-* The latest changes are always in `master` 
+* The latest changes are always in `main` 
 * Pull Requests should be raised for larger changes
 * Pull Requests do not need approval before merging for those with contributor access (it's just helpful to have them to track changes)
 * Rebasing in Pull Requests is prefered to keep a clean commit history (see below)
 * Running `npm run lint:fix` before committing can make resolving conflicts easier, but is not required
-* Merge commits (and pushing merge commits to `master`) are disabled in this repo
-* Pushing directly to master should ideally be reserved for minor updates / one off fixes
+* Merge commits (and pushing merge commits to `main`) are disabled in this repo
+* Pushing directly to main should ideally be reserved for minor updates / one off fixes
 
 ## Rebasing
 
-If you create a branch and there are conflicting updates in the `master` branch, you can resolve them by rebasing from a check out of your branch:
+If you create a branch and there are conflicting updates in the `main` branch, you can resolve them by rebasing from a check out of your branch:
 
     git fetch
-    git rebase origin/master
+    git rebase origin/main
 
 If there are any conflicts, you can resolve them and stage the files, then run:
 

--- a/www/docs/getting-started/example.md
+++ b/www/docs/getting-started/example.md
@@ -5,7 +5,7 @@ title: Example
 
 ## Example with live demo
 
-The easiest way to get started is to clone the example Next.js application from the [next-auth-example](https://github.com/iaincollins/next-auth-example) repository and to the instructions in the [README](https://github.com/iaincollins/next-auth-example/blob/master/README.md).
+The easiest way to get started is to clone the example Next.js application from the [next-auth-example](https://github.com/iaincollins/next-auth-example) repository and to the instructions in the [README](https://github.com/iaincollins/next-auth-example/blob/main/README.md).
 
 You can find a live demo of the example project at [next-auth-example.now.sh](https://next-auth-example.now.sh)
 

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -91,7 +91,7 @@ module.exports = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/iaincollins/next-auth/edit/master/www'
+          editUrl: 'https://github.com/iaincollins/next-auth/edit/main/www'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')


### PR DESCRIPTION
I'm happy to see this change in terminology happening in the industry, and that GitHub are moving in this direction too. I'll be updating the config for this repo and the example project too, from now on the default branch both will be `main`.