### PR TITLE
Refactoring naming strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.71",
+  "version": "2.0.0-beta.74",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7465,11 +7465,6 @@
         "yargonaut": "^1.1.2",
         "yargs": "^13.2.1"
       }
-    },
-    "typeorm-naming-strategies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-1.1.0.tgz",
-      "integrity": "sha512-Nu1E4M8lclapX3rdQhQcJKkBjTtmTV4HLWg3M2wouS1ucvnjLPQE1XapOipfmX90LJEVeBwIVh1iPvtf4C5htA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "preact": "^10.4.1",
     "preact-render-to-string": "^5.1.7",
     "querystring": "^0.2.0",
-    "typeorm": "^0.2.24",
-    "typeorm-naming-strategies": "^1.1.0"
+    "typeorm": "^0.2.24"
   },
   "peerDependencies": {
     "react": "^16.13.1",

--- a/src/adapters/typeorm/lib/naming-strategies.js
+++ b/src/adapters/typeorm/lib/naming-strategies.js
@@ -1,0 +1,45 @@
+// Inspired by https://github.com/tonivj5/typeorm-naming-strategies
+import { DefaultNamingStrategy } from 'typeorm'
+import { snakeCase, camelCase } from 'typeorm/util/StringUtils'
+
+export class SnakeCaseNamingStrategy extends DefaultNamingStrategy {
+  // Pluralise table names (set customName to override)
+  tableName (className, customName) {
+    return customName || snakeCase(`${className}s`)
+  }
+
+  columnName (propertyName, customName, embeddedPrefixes) {
+    return `${snakeCase(embeddedPrefixes.join('_'))}${customName || snakeCase(propertyName)}`
+  }
+
+  relationName (propertyName) {
+    return snakeCase(propertyName)
+  }
+
+  joinColumnName (relationName, referencedColumnName) {
+    return snakeCase(`${relationName}_${referencedColumnName}`)
+  }
+
+  joinTableName (firstTableName, secondTableName, firstPropertyName, secondPropertyName) {
+    return snakeCase(`${firstTableName}_${firstPropertyName.replace(/\./gi, '_')}_${secondTableName}`)
+  }
+
+  joinTableColumnName (tableName, propertyName, columnName) {
+    return snakeCase(`${tableName}_${(columnName || propertyName)}`)
+  }
+
+  classTableInheritanceParentColumnName (parentTableName, parentTableIdPropertyName) {
+    return snakeCase(`${parentTableName}_${parentTableIdPropertyName}`)
+  }
+
+  eagerJoinRelationAlias (alias, propertyPath) {
+    return `${alias}__${propertyPath.replace('.', '_')}`
+  }
+}
+
+export class CamelCaseNamingStrategy extends DefaultNamingStrategy {
+  // Pluralise collection names, uses (set customName to override)
+  tableName (className, customName) {
+    return customName || camelCase(`${className}s`)
+  }
+}

--- a/src/adapters/typeorm/lib/transform.js
+++ b/src/adapters/typeorm/lib/transform.js
@@ -1,7 +1,12 @@
 // Perform transforms on SQL models so they can be used with other databases
-import { SnakeNamingStrategy } from 'typeorm-naming-strategies'
+import { SnakeCaseNamingStrategy, CamelCaseNamingStrategy } from './naming-strategies'
 
 const mongodb = (models, options) => {
+  // A CamelCase naming strategy is used for all document databases
+  if (!options.namingStrategy) {
+    options.namingStrategy = new CamelCaseNamingStrategy()
+  }
+
   // Important!
   //
   // 1. You must set 'objectId: true' on one property on a model in MongoDB.
@@ -57,14 +62,13 @@ const mongodb = (models, options) => {
   if (!customModels.VerificationRequest) {
     delete models.VerificationRequest.schema.columns.id.type
     models.VerificationRequest.schema.columns.id.objectId = true
-    models.VerificationRequest.schema.tableName = 'verificationRequests'
   }
 }
 
 const sqlite = (models, options) => {
   // Apply snake case naming strategy by default for SQLite databases
   if (!options.namingStrategy) {
-    options.namingStrategy = new SnakeNamingStrategy()
+    options.namingStrategy = new SnakeCaseNamingStrategy()
   }
 
   const { models: customModels = {} } = options
@@ -109,7 +113,7 @@ export default (config, models, options) => {
   } else {
     // Apply snake case naming strategy by default for SQL databases
     if (!options.namingStrategy) {
-      options.namingStrategy = new SnakeNamingStrategy()
+      options.namingStrategy = new SnakeCaseNamingStrategy()
     }
   }
 }

--- a/src/adapters/typeorm/models/account.js
+++ b/src/adapters/typeorm/models/account.js
@@ -25,7 +25,6 @@ export class Account {
 export const AccountSchema = {
   name: 'Account',
   target: Account,
-  tableName: 'accounts',
   columns: {
     id: {
       // This property has `objectId: true` instead of `type: int` in MongoDB

--- a/src/adapters/typeorm/models/session.js
+++ b/src/adapters/typeorm/models/session.js
@@ -12,7 +12,6 @@ export class Session {
 export const SessionSchema = {
   name: 'Session',
   target: Session,
-  tableName: 'sessions',
   columns: {
     id: {
       // This property has `objectId: true` instead of `type: int` in MongoDB

--- a/src/adapters/typeorm/models/user.js
+++ b/src/adapters/typeorm/models/user.js
@@ -9,7 +9,6 @@ export class User {
 export const UserSchema = {
   name: 'User',
   target: User,
-  tableName: 'users',
   columns: {
     id: {
       // This property has `objectId: true` instead of `type: int` in MongoDB

--- a/src/adapters/typeorm/models/verification-request.js
+++ b/src/adapters/typeorm/models/verification-request.js
@@ -11,7 +11,6 @@ export class VerificationRequest {
 export const VerificationRequestSchema = {
   name: 'VerificationRequest',
   target: VerificationRequest,
-  tableName: 'verification_requests',
   columns: {
     id: {
       // This property has `objectId: true` instead of `type: int` in MongoDB


### PR DESCRIPTION
Not a breaking change, just a refactor!

* Removes dependency on external library for naming strategy
* Resolves problem of messy logic in models and transform by putting it all where it belongs - in the custom naming strategies (one for SQL / snake_case and one for Document / camelCase)
* No changes to actual table or collection schemas!