### PR TITLE
Add callbacks and events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.74",
+  "version": "2.0.0-beta.75",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -320,7 +320,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
       debugMessage('GET_VERIFICATION_REQUEST', identifer, token)
       try {
         // Hash token provided with secret before trying to match it with datbase
-        // @TODO Use bcrypt function here instead of simple salted hash
+        // @TODO Use bcrypt instead of salted SHA-256 hash for token
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')
         const verificationRequest = await connection.getRepository(VerificationRequest).findOne({ identifer, token: hashedToken })
 

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -11,10 +11,12 @@ const logger = {
     }
   },
   debug: (debugCode, ...text) => {
-    console.log(
-      `[next-auth][debug][${debugCode}]`,
-      text
-    )
+    if (process && process.env && process.env._NEXT_AUTH_DEBUG) {
+      console.log(
+        `[next-auth][debug][${debugCode}]`,
+        text
+      )
+    }
   }
 }
 

--- a/src/server/lib/callback-url-handler.js
+++ b/src/server/lib/callback-url-handler.js
@@ -3,7 +3,7 @@ import cookie from '../lib/cookie'
 export default async (req, res, options) => {
   const { query } = req
   const { body } = req
-  const { cookies, site, defaultCallbackUrl, allowCallbackUrl } = options
+  const { cookies, site, defaultCallbackUrl, callbacks } = options
 
   // Handle preserving and validating callback URLs
   // If no defaultCallbackUrl option specified, default to the homepage for the site
@@ -14,10 +14,10 @@ export default async (req, res, options) => {
   const callbackUrlCookieValue = req.cookies[cookies.callbackUrl.name] || null
   if (callbackUrlParamValue) {
     // If callbackUrl form field or query parameter is passed try to use it if allowed
-    callbackUrl = await allowCallbackUrl(callbackUrlParamValue, site)
+    callbackUrl = await callbacks.redirect(callbackUrlParamValue, site)
   } else if (callbackUrlCookieValue) {
     // If no callbackUrl specified, try using the value from the cookie if allowed
-    callbackUrl = await allowCallbackUrl(callbackUrlCookieValue, site)
+    callbackUrl = await callbacks.redirect(callbackUrlCookieValue, site)
   }
 
   // Save callback URL in a cookie so that can be used for subsequent requests in signin/signout/callback flow

--- a/src/server/lib/callbacks.js
+++ b/src/server/lib/callbacks.js
@@ -1,0 +1,59 @@
+/**
+ * Use this callback to control if a user is allowed to sign in or not.
+ * If JSON Web Tokens are enabled you can access the JWT here.
+ * If you want to modify the JWT, return the modifed token as the response.
+ * 
+ * @param  {object} user     User (e.g. user id, name, email)
+ * @param  {object} account  Account used to sign in (e.g. OAuth account)
+ * @param  {object} extra    Provider specific metadata (e.g. OAuth Profile)
+ * @param  {object} jwt      If JSON Web Tokens enabled contains decrypted JWT
+ * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
+ *                           Return `false` to deny access
+ */
+const signin = async (user, account, extra, jwt) => {
+  let isAllowedToSignIn = true
+  if (isAllowedToSignIn) {
+    return Promise.resolve(jwt ? jwt : true)
+  } else {
+    return Promise.resolve(false)
+  }
+}
+
+/**
+ * Redirect is called anytime the user is redirected on signin or signout.
+ * By default, for security, only Callback URLs on the same URL as the site
+ * are allowed, you can use this callback to customise that behaviour.
+ * 
+ * @param  {string} url      URL provided as callback URL by the client
+ * @param  {string} baseUrl  Default base URL of site (can be used as fallback)
+ * @return {string}          URL the client will be redirect to
+ */
+const redirect = async (url, baseUrl) => {
+  return url.startsWith(baseUrl)
+    ? Promise.resolve(url)
+    : Promise.resolve(baseUrl)
+}
+
+/**
+ * This callback is called whenever a session is checked
+ * e.g. `getSession()`, `useSession()`, `/api/auth/session` (etc)
+ * 
+ * You can modify the session object and/or the JSON Web Token.
+ * Changes to the JWT will be persised in the token.
+ * 
+ * @param  {object} session  Session that is returned to client
+ * @param  {object} jwt      Decrypted JSON Web Token
+ * @return {object}          Return both Session and JWT objects
+ */
+const session = async (session, jwt) => {
+  Promise.resolve({
+    session,
+    jwt
+  })
+}
+
+export default {
+  signin,
+  redirect,
+  session
+}

--- a/src/server/lib/callbacks.js
+++ b/src/server/lib/callbacks.js
@@ -1,5 +1,5 @@
 /**
- * Use this callback to control if a user is allowed to sign in or not.
+ * Use the signin callback to control if a user is allowed to sign in or not.
  *
  * This is triggered before sign in flow completes, so the user profile may be
  * a user object (with an ID) or it may be just their name and email address,
@@ -40,24 +40,30 @@ const redirect = async (url, baseUrl) => {
 }
 
 /**
- * This callback is called whenever a session is checked.
+ * The session callback is called whenever a session is checked.
  * e.g. `getSession()`, `useSession()`, `/api/auth/session` (etc)
  *
- * @param  {object} session  Session that is returned to client
- * @return {object}          Return session
+ * @param  {object} session  Session object
+ * @param  {object} token    JSON Web Token (if enabled)
+ * @return {object}          Session that will be returned to the client 
  */
-const session = async (session) => {
+const session = async (session, token) => {
   return Promise.resolve(session)
 }
 
 /**
  * This callback is called whenever a JSON Web Token is created / updated.
  * e.g. On sign in, `getSession()`, `useSession()`, `/api/auth/session` (etc)
+ * 
+ * On initial sign in, the raw oAuthProfile is passed if the user is signing in 
+ * with an OAuth provider. It is not avalible on subsequent calls. You can
+ * take advantage of this to persist additional data you need to in the JWT.
  *
- * @param  {object} token  Decrypted JSON Web Token
- * @return {object}        Return  JSON Web Token
+ * @param  {object} token         Decrypted JSON Web Token
+ * @param  {object} oAuthProfile  OAuth profile - only available on sign in
+ * @return {object}               JSON Web Token that will be saved
  */
-const jwt = async (token) => {
+const jwt = async (token, oAuthProfile) => {
   return Promise.resolve(token)
 }
 

--- a/src/server/lib/callbacks.js
+++ b/src/server/lib/callbacks.js
@@ -1,19 +1,24 @@
 /**
  * Use this callback to control if a user is allowed to sign in or not.
- * If JSON Web Tokens are enabled you can access the JWT here.
- * If you want to modify the JWT, return the modifed token as the response.
- * 
- * @param  {object} user     User (e.g. user id, name, email)
+ *
+ * This is triggered before sign in flow completes, so the user profile may be
+ * a user object (with an ID) or it may be just their name and email address,
+ * depending on the sign in flow and if they have an account already.
+ *
+ * When using email sign in, this method is triggered both when the user
+ * requests to sign in and again when they activate the link in the sign in
+ * email.
+ *
+ * @param  {object} profile  User profile (e.g. user id, name, email)
  * @param  {object} account  Account used to sign in (e.g. OAuth account)
- * @param  {object} extra    Provider specific metadata (e.g. OAuth Profile)
- * @param  {object} jwt      If JSON Web Tokens enabled contains decrypted JWT
+ * @param  {object} metadata Provider specific metadata (e.g. OAuth Profile)
  * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
  *                           Return `false` to deny access
  */
-const signin = async (user, account, extra, jwt) => {
-  let isAllowedToSignIn = true
+const signin = async (profile, account, metadata) => {
+  const isAllowedToSignIn = true
   if (isAllowedToSignIn) {
-    return Promise.resolve(jwt ? jwt : true)
+    return Promise.resolve(true)
   } else {
     return Promise.resolve(false)
   }
@@ -23,7 +28,7 @@ const signin = async (user, account, extra, jwt) => {
  * Redirect is called anytime the user is redirected on signin or signout.
  * By default, for security, only Callback URLs on the same URL as the site
  * are allowed, you can use this callback to customise that behaviour.
- * 
+ *
  * @param  {string} url      URL provided as callback URL by the client
  * @param  {string} baseUrl  Default base URL of site (can be used as fallback)
  * @return {string}          URL the client will be redirect to
@@ -35,25 +40,30 @@ const redirect = async (url, baseUrl) => {
 }
 
 /**
- * This callback is called whenever a session is checked
+ * This callback is called whenever a session is checked.
  * e.g. `getSession()`, `useSession()`, `/api/auth/session` (etc)
- * 
- * You can modify the session object and/or the JSON Web Token.
- * Changes to the JWT will be persised in the token.
- * 
+ *
  * @param  {object} session  Session that is returned to client
- * @param  {object} jwt      Decrypted JSON Web Token
- * @return {object}          Return both Session and JWT objects
+ * @return {object}          Return session
  */
-const session = async (session, jwt) => {
-  Promise.resolve({
-    session,
-    jwt
-  })
+const session = async (session) => {
+  return Promise.resolve(session)
+}
+
+/**
+ * This callback is called whenever a JSON Web Token is created / updated.
+ * e.g. On sign in, `getSession()`, `useSession()`, `/api/auth/session` (etc)
+ *
+ * @param  {object} token  Decrypted JSON Web Token
+ * @return {object}        Return  JSON Web Token
+ */
+const jwt = async (token) => {
+  return Promise.resolve(token)
 }
 
 export default {
   signin,
   redirect,
-  session
+  session,
+  jwt
 }

--- a/src/server/lib/callbacks.js
+++ b/src/server/lib/callbacks.js
@@ -45,7 +45,7 @@ const redirect = async (url, baseUrl) => {
  *
  * @param  {object} session  Session object
  * @param  {object} token    JSON Web Token (if enabled)
- * @return {object}          Session that will be returned to the client 
+ * @return {object}          Session that will be returned to the client
  */
 const session = async (session, token) => {
   return Promise.resolve(session)
@@ -54,8 +54,8 @@ const session = async (session, token) => {
 /**
  * This callback is called whenever a JSON Web Token is created / updated.
  * e.g. On sign in, `getSession()`, `useSession()`, `/api/auth/session` (etc)
- * 
- * On initial sign in, the raw oAuthProfile is passed if the user is signing in 
+ *
+ * On initial sign in, the raw oAuthProfile is passed if the user is signing in
  * with an OAuth provider. It is not avalible on subsequent calls. You can
  * take advantage of this to persist additional data you need to in the JWT.
  *

--- a/src/server/lib/dispatch-event.js
+++ b/src/server/lib/dispatch-event.js
@@ -1,0 +1,9 @@
+import logger from '../../lib/logger'
+
+export default async (event, message) => {
+  try {
+    await event(message)
+  } catch (e) {
+    logger.error('EVENT_ERROR', e)
+  }
+}

--- a/src/server/lib/events.js
+++ b/src/server/lib/events.js
@@ -1,0 +1,32 @@
+const signin = async (message) => { }
+
+const signout = async (message) => { }
+
+const createUser = async (message) => { }
+
+const updateUser = async (message) => { }
+
+const deleteUser = async (message) => { }
+
+const linkAccount = async (message) => { }
+
+const unlinkAccount = async (message) => { }
+
+const redirect = async (message) => { }
+
+const session = async (message) => { }
+
+const error = async (message) => { }
+
+export default {
+  signin,
+  signout,
+  createUser,
+  updateUser,
+  deleteUser,
+  linkAccount,
+  unlinkAccount,
+  redirect,
+  session,
+  error
+}

--- a/src/server/lib/events.js
+++ b/src/server/lib/events.js
@@ -12,8 +12,6 @@ const linkAccount = async (message) => { }
 
 const unlinkAccount = async (message) => { }
 
-const redirect = async (message) => { }
-
 const session = async (message) => { }
 
 const error = async (message) => { }
@@ -26,7 +24,6 @@ export default {
   deleteUser,
   linkAccount,
   unlinkAccount,
-  redirect,
   session,
   error
 }

--- a/src/server/lib/events.js
+++ b/src/server/lib/events.js
@@ -15,8 +15,7 @@ const linkAccount = async (message) => {
 }
 
 const session = async (message) => {
-  // Event triggered when an account is session is active
-  // This event is triggered any time a session is active!
+  // Event triggered when a session is active
 }
 
 const error = async (message) => {

--- a/src/server/lib/events.js
+++ b/src/server/lib/events.js
@@ -1,8 +1,8 @@
 const signin = async (message) => {
   // Event triggered on successful sign in
- }
+}
 
-const signout = async (message) => { 
+const signout = async (message) => {
   // Event triggered on signout
 }
 

--- a/src/server/lib/events.js
+++ b/src/server/lib/events.js
@@ -1,20 +1,40 @@
-const signin = async (message) => { }
+const signin = async (message) => {
+  // Event triggered on successful sign in
+ }
 
-const signout = async (message) => { }
+const signout = async (message) => { 
+  // @TODO Event triggered on signout
+}
 
-const createUser = async (message) => { }
+const createUser = async (message) => {
+  // @TODO Event triggered on user creation
+}
 
-const updateUser = async (message) => { }
+const updateUser = async (message) => { 
+  // @TODO Event triggered on update to user
+}
 
-const deleteUser = async (message) => { }
+const deleteUser = async (message) => {
+  // @TODO Event triggered on user deletion
+ }
 
-const linkAccount = async (message) => { }
+const linkAccount = async (message) => {
+  // @TODO Event triggered when an account is linked to a user
+}
 
-const unlinkAccount = async (message) => { }
+const unlinkAccount = async (message) => {
+  // @TODO Event triggered when an account is unlinked from a user
+}
 
-const session = async (message) => { }
+const session = async (message) => {
+  // @TODO Event triggered when an account is session is active
+  // This event is triggered any time a session is active!
+}
 
-const error = async (message) => { }
+const error = async (message) => {
+  // @TODO Event triggered when something goes wrong in an authentication flow
+  // This event may be fired multiple times when an error occurs
+}
 
 export default {
   signin,

--- a/src/server/lib/events.js
+++ b/src/server/lib/events.js
@@ -3,31 +3,19 @@ const signin = async (message) => {
  }
 
 const signout = async (message) => { 
-  // @TODO Event triggered on signout
+  // Event triggered on signout
 }
 
 const createUser = async (message) => {
-  // @TODO Event triggered on user creation
+  // Event triggered on user creation
 }
-
-const updateUser = async (message) => { 
-  // @TODO Event triggered on update to user
-}
-
-const deleteUser = async (message) => {
-  // @TODO Event triggered on user deletion
- }
 
 const linkAccount = async (message) => {
-  // @TODO Event triggered when an account is linked to a user
-}
-
-const unlinkAccount = async (message) => {
-  // @TODO Event triggered when an account is unlinked from a user
+  // Event triggered when an account is linked to a user
 }
 
 const session = async (message) => {
-  // @TODO Event triggered when an account is session is active
+  // Event triggered when an account is session is active
   // This event is triggered any time a session is active!
 }
 
@@ -40,10 +28,7 @@ export default {
   signin,
   signout,
   createUser,
-  updateUser,
-  deleteUser,
   linkAccount,
-  unlinkAccount,
   session,
   error
 }

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -53,7 +53,7 @@ export default async (req, res, options, done) => {
 
         if (useJwtSession) {
           const defaultJwtPayload = { user, account, isNewUser }
-          const jwtPayload = await callbacks.jwt(defaultJwtPayload)
+          const jwtPayload = await callbacks.jwt(defaultJwtPayload, oAuthProfile)
 
           // Sign and encrypt token
           const newEncodedJwt = await jwt.encode({ secret: jwt.secret, token: jwtPayload, maxAge: sessionMaxAge })

--- a/src/server/routes/signout.js
+++ b/src/server/routes/signout.js
@@ -50,7 +50,7 @@ export default async (req, res, options, done) => {
     }
   }
 
-  // Remove Session Token 
+  // Remove Session Token
   cookie.set(res, cookies.sessionToken.name, '', {
     ...cookies.sessionToken.options,
     maxAge: 0

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -1,0 +1,127 @@
+---
+id: callbacks
+title: Callbacks
+---
+
+Callbacks are asynchronous functions you can use to control what happens when an action is performed.
+
+Callbacks are extremely powerful, especially in scenarios involving JSON Web Tokens as they allow you to implement access controls without a database and to integrate with external databases or APIs.
+
+You can specify a handler for any of the callbacks below.
+
+#### How to use the callback option
+
+```js
+callbacks: {
+  signin: async (profile, account, metadata) => { },
+  redirect: async (url, baseUrl) => { },
+  session: async (session, token) => { },
+  jwt: async (token) => { }
+}
+```
+
+The documentation below shows how to implement each callback and their default behaviour.
+
+## Signin
+
+Use the signin callback to control if a user is allowed to sign in or not.
+
+This is triggered before sign in flow completes, so the user profile may be a
+user object (with an ID) or it may be just their name and email address,
+depending on the sign in flow and if they have an account already.
+
+When using email sign in, this method is triggered both when the user requests
+to sign in and again when they activate the link in the sign in email.
+
+```js
+/**
+ * @param  {object} profile  User profile (e.g. user id, name, email)
+ * @param  {object} account  Account used to sign in (e.g. OAuth account)
+ * @param  {object} metadata Provider specific metadata (e.g. OAuth Profile)
+ * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
+ *                           Return `false` to deny access
+ */
+const signin = async (profile, account, metadata) => {
+  const isAllowedToSignIn = true
+  if (isAllowedToSignIn) {
+    return Promise.resolve(true)
+  } else {
+    return Promise.resolve(false)
+  }
+}
+```
+
+## Redirect
+
+The redirect callback is called anytime the user is redirected to a callback URL
+(e.g. on signin or signout).
+
+By default, for security, only Callback URLs on the same URL as the site are
+allowed, you can use the redirect callback to customise that behaviour.
+
+```js
+/**
+ * @param  {string} url      URL provided as callback URL by the client
+ * @param  {string} baseUrl  Default base URL of site (can be used as fallback)
+ * @return {string}          URL the client will be redirect to
+ */
+const redirect = async (url, baseUrl) => {
+  return url.startsWith(baseUrl)
+    ? Promise.resolve(url)
+    : Promise.resolve(baseUrl)
+}
+```
+
+## Session
+
+The session callback is called whenever a session is checked.
+
+e.g. `getSession()`, `useSession()`, `/api/auth/session` (etc)
+
+If JSON Web Tokens are enabled, you can also access the decrypted token and use
+this method to pass information from the encoded token back to the client.
+
+The JWT callback is invoked first so anything you add to the JWT will be 
+immediately available here.
+
+```js
+/**
+
+ * @param  {object} session  Session object
+ * @param  {object} token    JSON Web Token
+ * @return {object}          Session that will be returned to the client 
+ */
+const session = async (session) => {
+  return Promise.resolve(session)
+}
+```
+
+## JWT
+
+This JSON Web Token callback is called whenever a JSON Web Token is created or updated.
+
+e.g. On sign in, `getSession()`, `useSession()`, `/api/auth/session` (etc)
+
+On initial sign in with an OAuth provider, the raw oAuthProfile is also
+available as a parameter. It is not avalible on subsequent calls.
+
+You can take advantage of this to persist additional data you need from their raw profile to the encoded JWT for as long as the user is signed in.
+
+```js
+/**
+ * @param  {object} token         Decrypted JSON Web Token
+ * @param  {object} oAuthProfile  OAuth profile - only available on sign in
+ * @return {object}               JSON Web Token that will be saved
+ */
+const jwt = async (token, oAuthProfile) => {
+  return Promise.resolve(token)
+}
+
+export default {
+  signin,
+  redirect,
+  session,
+  jwt
+}
+
+```

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -98,19 +98,6 @@ session: {
   // Use it to limit write operations. Set to 0 to always update the database.
   // Note: This option is ignored if using JSON Web Tokens 
   updateAge: 24 * 60 * 60, // 24 hours
-  
-  // Easily add custom properties to response from `/api/auth/session`.
-  //
-  // Note: The response should not return any sensitive information. The JWT
-  // option is supplied if JWT enabled and contains a (decrypted) copy of the
-  // JWT payload for instances where you need to use data from it to populate
-  // the response returned to the client.
-  /*
-  get: async (session, jwt) => {
-    session.customSessionProperty = "ABC123"
-    return session
-  }
-  */
 }
 ```
 
@@ -136,26 +123,14 @@ Default values for this option are shown below:
 ```js
 jwt: {
   // secret: 'my-secret-123', // Secret auto-generated if not specified.
-    
-  // Custom encode/decode functions for signing + encryption can be specified.
-  // if you want to override what is in the JWT or how it is signed.
+  
+  // By default the JSON Web Token is signed with SHA256 and encrypted with AES.
+  //
+  // You can define your own encode/decode functions for signing + encryption if
+  // you want to override the default behaviour (or to add/remove information
+  // from the JWT when it is encoded).
   // encode: async ({ secret, key, token, maxAge }) => {},
   // decode: async ({ secret, key, token, maxAge }) => {},
-
-  // Easily add custom to the JWT. It is updated every time it is accessed.
-  // This encrypted and signed by default and may contain sensitive information
-  // as long as a reasonable secret is defined.
-  //
-  // Note: 'oAuthProfile' is the raw oAuth profile from the provider the user
-  // used to sign in with and is only returned when the JWT is created for the 
-  // current user / session, if you want to persist data from it you need to add
-  // the data you want to keep to the token. Keep in mind JWT token size limits.
-  /*
-  set: async (token, oAuthProfile) => { 
-    token.customJwtProperty = "ABC123"
-    return token
-  }
-  */
 }
 ```
 
@@ -203,78 +178,6 @@ export default async (req, res) =>  {
 :::note
 The JWT is stored in the Session Token cookie – the same cookie used for database sessions.
 :::
-
----
-
-### allowSignin
-
-* **Default value**: `function` (returns `boolean`)
-* **Required**: *No*
-
-#### Description
-
-The `allowSignin` option allows you to define a function that determines if a user / account can sign in.
-
-The function is passed a user and account object associated with the the provider the client has used.
-
-If the function returns `true` the user can sign in, if it returns `false` an access denied message is displayed.
-
-This works with all providers (OAuth and Email) and both with and without databases.
-
-It is useful to control access to dashboards/admin pages without requiring a user database.
-
-Example:
-
-```js
-// `user` and `account` correspond the data persisted in the database, they are
-// still present even if not using a database but may contain more limited data.
-//
-// `oAuthProfile` is the raw oAuth profile from the provider the user used to
-// sign in with; is only present when signing with OAuth.
-allowSignin: async (user, account, oAuthProfile) => {
-  // Return true if user / account is allowed to sign in.
-  // Return false to display an access denied message.
-  return true
-}
-```
-
-:::warning
-You should not rely on the email address alone unless that provider is trusted and has supplied a verified email address. e.g. The built-in Google provider is configured to only return verified email addresses.
-:::
-
----
-
-### allowCallbackUrl
-
-* **Default value**: `function` (returns URL as `string`)
-* **Required**: *No*
-
-#### Description
-
-By default `allowCallbackUrl` only allows callbackUrls for signup and signout to be at the same site as the one being signed into.
-
-e.g. if the sign in URL was `https://example.com/api/auth/signin` the following logic would apply:
-
-* ✅ `https://example.com/path/to/page`
-* ❌ `http://example.com/path/to/page` 
-* ❌ `https://subdomain.example.com/path/to/page` 
-* ❌ `https://example.com:8080/path/to/page`
-
-If the URL is not allowed, the callback URL will be set to whatever the `site` option is set to.
-
-The default function looks like this:
-
-```js
-allowCallbackUrl: async (url, site) => {
-  if (url.startsWith(site)) {
-    return Promise.resolve(url)
-  } else {
-    return Promise.resolve(site)
-  }
-}
-```
-
-If you want to support signing in to sites across other domains or hostnames you can pass your own function to `allowCallbackUrl` to customise the behaviour.
 
 ---
 

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -208,6 +208,58 @@ See the documentation for the [pages option](/options/pages) for more informatio
 
 ---
 
+### callbacks
+
+* **Default value**: `object`
+* **Required**: *No*
+
+#### Description
+
+Callbacks are asynchronous functions you can use to control what happens when an action is performed.
+
+Callbacks are extremely powerful, especially in scenarios involving JSON Web Tokens as they allow you to implement access controls without a database and to integrate with external databases or APIs.
+
+You can specify a handler for any of the callbacks below.
+
+```js
+callbacks: {
+  signin: async (profile, account, metadata) => { },
+  redirect: async (url, baseUrl) => { },
+  session: async (session, token) => { },
+  jwt: async (token) => => { }
+}
+```
+
+See the [callbacks documentation](/configuration/callbacks) for more information on how to use the callback functions.
+
+---
+
+### events
+
+* **Default value**: `object`
+* **Required**: *No*
+
+#### Description
+
+Events are asynchronous functions that do not return a response, they are useful for audit logging.
+
+You can specify a handler for any of these events below - e.g. for debugging or to create an audit log.
+
+The content of the message object varies depending on the flow (e.g. OAuth or Email authentication flow, JWT or database sessions, etc), but typically contains a user object and/or contents of the JSON Web Token and other information relevent to the event.
+
+```js
+events: {
+  signin: async (message) => { /* on successful sign in */ },
+  signout: async (message) => { /* on signout */ },
+  createUser: async (message) => { /* user created */ },
+  linkAccount: async (message) => { /* account linked to a user */ },
+  session: async (message) => { /* session is active */ },
+  error: async (message) => { /* error in authentication flow */ }
+}
+```
+
+---
+
 ### debug
 
 * **Default value**: `false`

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -10,7 +10,8 @@ module.exports = {
       'configuration/options',
       'configuration/providers',
       'configuration/database',
-      'configuration/pages'
+      'configuration/pages',
+      'configuration/callbacks'
     ],
     'Authentication Providers': [
       'providers/apple',

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -12,7 +12,7 @@ module.exports = {
       'configuration/database',
       'configuration/pages'
     ],
-    Providers: [
+    'Authentication Providers': [
       'providers/apple',
       'providers/auth0',
       'providers/discord',


### PR DESCRIPTION
This PR resolves #247

## Breaking Changes

The following callbacks have been removed and replaced:

* `allowSignin()`
* `allowCallbackURL()`
* `session.get()`
* `jwt.set()`

### New Callbacks

The following new callbacks have been created, you can specify asynchronous functions for any of these callbacks, by specifying them in the `callbacks` option.

```js
callbacks: {
  signin,
  redirect,
  session,
  jwt
}
```

### New Events

Events are asynchronous functions that do not return a response. You can specify asynchronous functions for any of these events, by specifying them in the `events ` option.

Events are useful for audit logging.

```js
events: {
  signin,
  signout,
  createUser,
  linkAccount,
  session,
  error
}
```

## Callbacks

Built in callback functions and descriptions of when they are invoked, their parameters and their responses.

```js
/**
 * Use the signin callback to control if a user is allowed to sign in or not.
 *
 * This is triggered before sign in flow completes, so the user profile may be
 * a user object (with an ID) or it may be just their name and email address,
 * depending on the sign in flow and if they have an account already.
 *
 * When using email sign in, this method is triggered both when the user
 * requests to sign in and again when they activate the link in the sign in
 * email.
 *
 * @param  {object} profile  User profile (e.g. user id, name, email)
 * @param  {object} account  Account used to sign in (e.g. OAuth account)
 * @param  {object} metadata Provider specific metadata (e.g. OAuth Profile)
 * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
 *                           Return `false` to deny access
 */
const signin = async (profile, account, metadata) => {
  const isAllowedToSignIn = true
  if (isAllowedToSignIn) {
    return Promise.resolve(true)
  } else {
    return Promise.resolve(false)
  }
}

/**
 * Redirect is called anytime the user is redirected on signin or signout.
 * By default, for security, only Callback URLs on the same URL as the site
 * are allowed, you can use this callback to customise that behaviour.
 *
 * @param  {string} url      URL provided as callback URL by the client
 * @param  {string} baseUrl  Default base URL of site (can be used as fallback)
 * @return {string}          URL the client will be redirect to
 */
const redirect = async (url, baseUrl) => {
  return url.startsWith(baseUrl)
    ? Promise.resolve(url)
    : Promise.resolve(baseUrl)
}

/**
 * The session callback is called whenever a session is checked.
 * e.g. `getSession()`, `useSession()`, `/api/auth/session` (etc)
 *
 * @param  {object} session  Session object
 * @param  {object} token    JSON Web Token
 * @return {object}          Session that will be returned to the client 
 */
const session = async (session) => {
  return Promise.resolve(session)
}

/**
 * This callback is called whenever a JSON Web Token is created / updated.
 * e.g. On sign in, `getSession()`, `useSession()`, `/api/auth/session` (etc)
 * 
 * On initial sign in, the raw oAuthProfile is passed if the user is signing in 
 * with an OAuth provider. It is not avalible on subsequent calls. You can
 * take advantage of this to persist additional data you need to in the JWT.
 *
 * @param  {object} token         Decrypted JSON Web Token
 * @param  {object} oAuthProfile  OAuth profile - only available on sign in
 * @return {object}               JSON Web Token that will be saved
 */
const jwt = async (token, oAuthProfile) => {
  return Promise.resolve(token)
}

export default {
  signin,
  redirect,
  session,
  jwt
}
```

## Events

Built in event handlers descriptions of when they are invoked.

```js
const signin = async (message) => {
  // Event triggered on successful sign in
 }

const signout = async (message) => { 
  // Event triggered on signout
}

const createUser = async (message) => {
  // Event triggered on user creation
}

const linkAccount = async (message) => {
  // Event triggered when an account is linked to a user
}

const session = async (message) => {
  // Event triggered when a session is active
}

const error = async (message) => {
  // @TODO Event triggered when something goes wrong in an authentication flow
  // This event may be fired multiple times when an error occurs
}

export default {
  signin,
  signout,
  createUser,
  linkAccount,
  session,
  error
}
```