### PR TITLE
Add limited support for credentials sign in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.76",
+  "version": "2.0.0-beta.77",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/providers/credentials.js
+++ b/src/providers/credentials.js
@@ -1,1 +1,9 @@
-// @TODO Credentials provider
+export default (options) => {
+  return {
+    id: 'credentials',
+    name: 'Credentials',
+    type: 'credentials',
+    authorize: null,
+    ...options
+  }
+}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,5 +1,6 @@
 import Auth0 from './auth0'
 import Apple from './apple'
+import Credentials from './credentials'
 import Discord from './discord'
 import Email from './email'
 import Facebook from './facebook' // @TODO
@@ -14,7 +15,9 @@ import Twitter from './twitter'
 export default {
   Auth0,
   Apple,
+  Credentials,
   Discord,
+  Email,
   Facebook,
   GitHub,
   Google,
@@ -22,6 +25,5 @@ export default {
   Okta,
   Slack,
   Twitter,
-  Twitch,
-  Email
+  Twitch
 }

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -81,17 +81,17 @@ e.g. `getSession()`, `useSession()`, `/api/auth/session` (etc)
 If JSON Web Tokens are enabled, you can also access the decrypted token and use
 this method to pass information from the encoded token back to the client.
 
-The JWT callback is invoked first so anything you add to the JWT will be 
-immediately available here.
+The JWT callback is invoked before session is called, so anything you add to the
+JWT will be immediately available in the session callback.
 
 ```js
 /**
 
  * @param  {object} session  Session object
- * @param  {object} token    JSON Web Token
+ * @param  {object} token    JSON Web Token (if enabled)
  * @return {object}          Session that will be returned to the client 
  */
-const session = async (session) => {
+const session = async (session, token) => {
   return Promise.resolve(session)
 }
 ```
@@ -100,12 +100,13 @@ const session = async (session) => {
 
 This JSON Web Token callback is called whenever a JSON Web Token is created or updated.
 
-e.g. On sign in, `getSession()`, `useSession()`, `/api/auth/session` (etc)
+e.g. `/api/auth/signin`, `getSession()`, `useSession()`, `/api/auth/session` (etc)
 
-On initial sign in with an OAuth provider, the raw oAuthProfile is also
-available as a parameter. It is not avalible on subsequent calls.
+On initial sign in with an OAuth provider, the raw oAuthProfile returned by the
+provider is also passed as a parameter - it is not available on subsequent calls.
 
-You can take advantage of this to persist additional data you need from their raw profile to the encoded JWT for as long as the user is signed in.
+You can take advantage of this to persist additional data you need from their
+raw profile to the encoded JWT.
 
 ```js
 /**

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -170,3 +170,33 @@ See the [Email provider documentation](/providers/email) for more information on
 The email provider requires a database, it cannot be used without one.
 :::
 
+
+## Sign in with Credentials
+
+The Credentials provider allows you to handle signing in with arbitrary credentials, such as a username and password, two factor authentication or hardware device (e.g. YubiKey U2F / FIDO).
+
+It is intended to support use cases where you have an existing system you need to authenticate users against.
+
+```js title="/pages/api/auth/[...nextauth].js"
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.Credentials({
+    authorize: async (credentials) => {
+      const user = getUserFromCredentials(credentials) // You need to add this!
+      if (user) {
+        return Promise.resolve(user)
+      } else {
+        return Promise.resolve(false)
+      }
+    }
+  })
+}
+...
+```
+
+See the [Credentials provider documentation](/providers/credentials) for more information.
+
+:::note
+The Credentials provider can only be used if JSON Web Tokens are enabled for sessions. Users authenticated with the Credentials provider are not persisted in the database.
+:::

--- a/www/docs/errors.md
+++ b/www/docs/errors.md
@@ -55,7 +55,13 @@ These erros are displayed on the terminal.
 
 #### EMAIL_REQUIRES_ADAPTER_ERROR
 
+The Email authentication provider can only be used if a database is configured.
 
+#### CALLBACK_CREDENTIALS_JWT_ERROR
+
+The Credentials authentication provider can only be used if JSON Web Tokens are used for sessions.
+
+#### CALLBACK_CREDENTIALS_HANDLER_ERROR
 ---
 
 ### Session Handling

--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -11,8 +11,6 @@ Some of the methods can be called both client side and server side.
 When using any of the client API methods server side, [context](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps#context-object) must be passed as an argument. The documentation for **getSession()** has an example.
 :::
 
----
-
 ## useSession()
 
 * Client Side: **Yes**

--- a/www/docs/providers/credentials.md
+++ b/www/docs/providers/credentials.md
@@ -1,0 +1,62 @@
+---
+id: credentials
+title: Credentials
+---
+
+## Overview
+
+The Credentials provider allows you to handle signing in with arbitrary credentials, such as a username and password, two factor authentication or hardware device (e.g. YubiKey U2F / FIDO).
+
+It is intended to support use cases where you have an existing system you need to authenticate users against.
+
+It comes with the constraint that users authenticated in this manner are not persisted in the database, and that the Credentials provider can only be used if JSON Web Tokens are enabled for sessions.
+
+:::note
+The functionality provided for credentials based authentication is intentionally limited to discourage use of username and password based authenticaiton due to the inherent security risks associated with using usernames and passwords, and the complexities associated with supporting them.
+:::
+
+## Usage
+
+The Credentials provider is specified like other providers, except that you need to define a handler for `authorize()` that accepts credentials input and returns either a `user` object or `false`.
+
+If you return an object it will be persisted to the JSON Web Token and the user will be signed in.
+
+If you return `false` then Access Denied will be displayed.
+
+```js title="/pages/api/auth/[...nextauth].js"
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.Credentials({
+    authorize: async (credentials) => {
+      const user = getUserFromCredentials(credentials) // You need to add this!
+      if (user) {
+        return Promise.resolve(user)
+      } else {
+        return Promise.resolve(false)
+      }
+    }
+  })
+}
+...
+```
+
+To use your new credentials provider, you will need to create a form that posts back to `/api/auth/callback/credentials`.
+
+All form parameters submitted will be passed as `credentials` to your `authorize` callback.
+
+```js title="/pages/signin"
+import React from 'react'
+
+export default () => {
+  return (
+    <form method='post' action='/api/auth/callback/credentials'>
+      <input name='email' type='text' defaultValue='' />
+      <input name='password' type='password' defaultValue='' />
+      <button type='submit'>Sign in</button>
+    </form>
+  )
+}
+```
+
+As the JSON Web Token is encrypted, you can safely store user credentials in it and revalidate them whenever an action is performed. See the [callbacks documentation](/configuration/callbacks) for more information on how to interact with the token.

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -18,6 +18,7 @@ module.exports = {
       'providers/auth0',
       'providers/discord',
       'providers/email',
+      'providers/credentials',
       'providers/facebook',
       'providers/github',
       'providers/google',


### PR DESCRIPTION
The functionality in this update  is limited but working and the feature is fully documented.

You can use any credentials and backend or crypto token and you can easily persist data in the encrypted JSON Web Token.

The constraints of this implementation are that users authenticated with a Credentials based provider are not persisted to the database and JSON Web Tokens need to be enabled.

I expect we will review this in future and see how we might want to extend or improve on it.