### PR TITLE
Rename "Identifer" to "Identifier"

### DIFF
--- a/src/adapters/example/index.js
+++ b/src/adapters/example/index.js
@@ -72,18 +72,18 @@ const Adapter = (config, options = {}) => {
       return null
     }
 
-    async function createVerificationRequest (identifer, url, token, secret, provider) {
-      _debug('createVerificationRequest', identifer)
+    async function createVerificationRequest (identifier, url, token, secret, provider) {
+      _debug('createVerificationRequest', identifier)
       return null
     }
 
-    async function getVerificationRequest (identifer, token, secret, provider) {
-      _debug('getVerificationRequest', identifer, token)
+    async function getVerificationRequest (identifier, token, secret, provider) {
+      _debug('getVerificationRequest', identifier, token)
       return null
     }
 
-    async function deleteVerificationRequest (identifer, token, secret, provider) {
-      _debug('deleteVerification', identifer, token)
+    async function deleteVerificationRequest (identifier, token, secret, provider) {
+      _debug('deleteVerification', identifier, token)
       return null
     }
 

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -283,8 +283,8 @@ const Adapter = (typeOrmConfig, options = {}) => {
       }
     }
 
-    async function createVerificationRequest (identifer, url, token, secret, provider) {
-      debugMessage('CREATE_VERIFICATION_REQUEST', identifer)
+    async function createVerificationRequest (identifier, url, token, secret, provider) {
+      debugMessage('CREATE_VERIFICATION_REQUEST', identifier)
       try {
         const { site } = appOptions
         const { sendVerificationRequest, maxAge } = provider
@@ -302,12 +302,12 @@ const Adapter = (typeOrmConfig, options = {}) => {
         }
 
         // Save to database
-        const newVerificationRequest = new VerificationRequest(identifer, hashedToken, expires)
+        const newVerificationRequest = new VerificationRequest(identifier, hashedToken, expires)
         const verificationRequest = await getManager().save(newVerificationRequest)
 
         // With the verificationCallback on a provider, you can send an email, or queue
         // an email to be sent, or perform some other action (e.g. send a text message)
-        await sendVerificationRequest({ identifer, url, token, site, provider })
+        await sendVerificationRequest({ identifier, url, token, site, provider })
 
         return verificationRequest
       } catch (error) {
@@ -316,13 +316,13 @@ const Adapter = (typeOrmConfig, options = {}) => {
       }
     }
 
-    async function getVerificationRequest (identifer, token, secret, provider) {
-      debugMessage('GET_VERIFICATION_REQUEST', identifer, token)
+    async function getVerificationRequest (identifier, token, secret, provider) {
+      debugMessage('GET_VERIFICATION_REQUEST', identifier, token)
       try {
         // Hash token provided with secret before trying to match it with datbase
         // @TODO Use bcrypt instead of salted SHA-256 hash for token
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')
-        const verificationRequest = await connection.getRepository(VerificationRequest).findOne({ identifer, token: hashedToken })
+        const verificationRequest = await connection.getRepository(VerificationRequest).findOne({ identifier, token: hashedToken })
 
         if (verificationRequest && verificationRequest.expires && new Date() > new Date(verificationRequest.expires)) {
           // Delete verification entry so it cannot be used again
@@ -337,8 +337,8 @@ const Adapter = (typeOrmConfig, options = {}) => {
       }
     }
 
-    async function deleteVerificationRequest (identifer, token, secret, provider) {
-      debugMessage('DELETE_VERIFICATION', identifer, token)
+    async function deleteVerificationRequest (identifier, token, secret, provider) {
+      debugMessage('DELETE_VERIFICATION', identifier, token)
       try {
         // Delete verification entry so it cannot be used again
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')

--- a/src/adapters/typeorm/models/verification-request.js
+++ b/src/adapters/typeorm/models/verification-request.js
@@ -1,8 +1,8 @@
 // This model is used for sign in emails, but is designed to support other
 // mechanisms in future (e.g. 2FA via text message or short codes)
 export class VerificationRequest {
-  constructor (identifer, token, expires) {
-    if (identifer) { this.identifer = identifer }
+  constructor (identifier, token, expires) {
+    if (identifier) { this.identifier = identifier }
     if (token) { this.token = token }
     if (expires) { this.expires = expires }
   }
@@ -18,7 +18,7 @@ export const VerificationRequestSchema = {
       type: 'int',
       generated: true
     },
-    identifer: {
+    identifier: {
       // An email address, phone number, username or other unique identifier
       // associated with the request (used to track who it was on behalf of)
       type: 'varchar'

--- a/src/providers/email.js
+++ b/src/providers/email.js
@@ -22,7 +22,7 @@ export default (options) => {
   }
 }
 
-const sendVerificationRequest = ({ identifer: emailAddress, url, token, site, provider }) => {
+const sendVerificationRequest = ({ identifier: emailAddress, url, token, site, provider }) => {
   return new Promise((resolve, reject) => {
     const { server, from } = provider
     const siteName = site.replace(/^https?:\/\//, '')

--- a/test/schemas/mysql.json
+++ b/test/schemas/mysql.json
@@ -162,8 +162,8 @@
       "nullable": false,
       "default": null
     },
-    "identifer": {
-      "name": "identifer",
+    "identifier": {
+      "name": "identifier",
       "type": "varchar(255)",
       "nullable": false,
       "default": null

--- a/test/schemas/postgres.json
+++ b/test/schemas/postgres.json
@@ -162,8 +162,8 @@
       "nullable": false,
       "default": "nextval('verification_requests_id_seq'::regclass)"
     },
-    "identifer": {
-      "name": "identifer",
+    "identifier": {
+      "name": "identifier",
       "type": "character varying",
       "nullable": false,
       "default": null

--- a/www/docs/providers/email.md
+++ b/www/docs/providers/email.md
@@ -88,7 +88,7 @@ The following example shows the complete source for the built-in `sendVerificati
 
 ```js
 import nodemailer from 'nodemailer'
-const sendVerificationRequest = ({ identifer: emailAddress, url, token, site, provider }) => {
+const sendVerificationRequest = ({ identifier: emailAddress, url, token, site, provider }) => {
   return new Promise((resolve, reject) => {
     const { server, from } = provider
     const siteName = site.replace(/^https?:\/\//, '')

--- a/www/docs/schemas/adapters.md
+++ b/www/docs/schemas/adapters.md
@@ -166,7 +166,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function createVerificationRequest (
-      identifer,
+      identifier,
       url,
       token,
       secret,
@@ -176,7 +176,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function getVerificationRequest (
-      identifer,
+      identifier,
       token,
       secret,
       provider
@@ -185,7 +185,7 @@ const Adapter = (config, options = {}) => {
     }
 
     async function deleteVerificationRequest (
-      identifer,
+      identifier,
       token,
       secret,
       provider

--- a/www/docs/schemas/mysql.md
+++ b/www/docs/schemas/mysql.md
@@ -186,8 +186,8 @@ The schema generated for a MySQL database when using the built-in models.
     "nullable": false,
     "default": null
   },
-  "identifer": {
-    "name": "identifer",
+  "identifier": {
+    "name": "identifier",
     "type": "varchar(255)",
     "nullable": false,
     "default": null

--- a/www/docs/schemas/postgres.md
+++ b/www/docs/schemas/postgres.md
@@ -186,8 +186,8 @@ The schema generated for a Postgres database when using the built-in models.
     "nullable": false,
     "default": "nextval('verification_requests_id_seq'::regclass)"
   },
-  "identifer": {
-    "name": "identifer",
+  "identifier": {
+    "name": "identifier",
     "type": "character varying",
     "nullable": false,
     "default": null


### PR DESCRIPTION
As far as I can tell, the parameter "identifer" is a typo which seems to have stuck and ended up in the documentation. This PR renames all instances of "identifer" to "identifier".