### PR TITLE
Fix typo in auth0 provider config

### DIFF
--- a/src/providers/auth0.js
+++ b/src/providers/auth0.js
@@ -4,7 +4,7 @@ export default (options) => {
     name: 'Auth0',
     type: 'oauth',
     version: '2.0',
-    params: { grant_type: 'authorization_code', respponse_type: 'code' },
+    params: { grant_type: 'authorization_code', response_type: 'code' },
     scope: 'openid email profile',
     accessTokenUrl: `https://${options.subdomain}.auth0/oauth/token`,
     authorizationUrl: `https://${options.subdomain}.auth0.com/authorize?`,


### PR DESCRIPTION
auth0 was configured with `respponse_type` but should be `response_type`