### PR TITLE
Improve client session syncing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.0.0-beta.84",
+  "version": "2.0.0-beta.85",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -9,15 +9,23 @@ import logger from '../lib/logger'
 
 // These can be overridden with NEXTAUTH_ env vars in next.config.js
 // e.g. process.env.NEXTAUTH_SITE
-const DEFAULT_BASE_URL_COOKIE_NAME = 'next-auth.base-url'
-const DEFAULT_SITE = ''
-const DEFAULT_BASE_PATH = '/api/auth'
+const NEXTAUTH_DEFAULT_BASE_URL_COOKIE_NAME = 'next-auth.base-url'
+const NEXTAUTH_DEFAULT_SITE = ''
+const NEXTAUTH_DEFAULT_BASE_PATH = '/api/auth'
+const NEXTAUTH_DEFAULT_CLIENT_MAXAGE = 0 // e.g. 0 == disabled, 60 == 60 seconds
+
+let NEXTAUTH_EVENT_LISTENER_ADDED = false
 
 // Universal method (client + server)
 const getSession = async ({ req } = {}) => {
   const baseUrl = _baseUrl({ req })
   const options = req ? { headers: { cookie: req.headers.cookie } } : {}
-  return _fetchData(`${baseUrl}/session`, options)
+  const session = await _fetchData(`${baseUrl}/session`, options)
+  _sendMessage({
+    event: 'session',
+    data: session
+  })
+  return session
 }
 
 // Universal method (client + server)
@@ -52,12 +60,44 @@ const useSession = (session) => {
 
 // Internal hook for getting session from the api.
 const useSessionData = (session) => {
+  const clientMaxAge = (process.env.NEXTAUTH_CLIENT_MAXAGE || NEXTAUTH_DEFAULT_CLIENT_MAXAGE) * 1000
+
   const [data, setData] = useState(session)
   const [loading, setLoading] = useState(true)
-  const _getSession = async () => {
+  const _getSession = async (sendEvent = true) => {
     try {
       setData(await getSession())
       setLoading(false)
+
+      // Send event to trigger other tabs to update (unless sendEvent is false)
+      if (sendEvent) {
+        _sendMessage({ event: 'session', data: session })
+      }
+
+      if (typeof window !== 'undefined' && NEXTAUTH_EVENT_LISTENER_ADDED === false) {
+        NEXTAUTH_EVENT_LISTENER_ADDED = true
+        window.addEventListener('storage', async (event) => {
+          if (event.key == 'nextauth.message') {
+            const message = JSON.parse(event.newValue)
+            if (message.event && message.event === 'session' && message.data) {
+              // Fetch new session data but tell it not to fire an event to
+              // avoid an infinate loop.
+              //
+              // Note: We could do `setData(message.data)` but that causes
+              // problems depending on how the session object is being used
+              // on a page, it's safer to update the session this way.
+              await _getSession(false)
+            }
+          }
+        })
+      }
+
+      // If CLIENT_MAXAGE is greater than zero, trigger auto re-fetching session
+      if (clientMaxAge > 0) {
+        setTimeout(async (session) => {
+          await _getSession()
+        }, clientMaxAge)
+      }
     } catch (error) {
       logger.error('CLIENT_USE_SESSION_ERROR', error)
     }
@@ -119,6 +159,12 @@ const signout = async (args) => {
     })
   }
   const res = await fetch(`${baseUrl}/signout`, options)
+
+  _sendMessage({
+    event: 'session',
+    data: {}
+  })
+
   window.location = res.url ? res.url : callbackUrl
 }
 
@@ -146,15 +192,15 @@ const _baseUrl = ({ req } = {}) => {
     // base URL from cookie that is set by the API route - which is how config
     // is shared automatically between the API route and the client.
     const cookies = req ? _parseCookies(req.headers.cookie) : null
-    const baseUrlCookieName = process.env.NEXTAUTH_BASE_URL_COOKIE_NAME || DEFAULT_BASE_URL_COOKIE_NAME
+    const baseUrlCookieName = process.env.NEXTAUTH_BASE_URL_COOKIE_NAME || NEXTAUTH_DEFAULT_BASE_URL_COOKIE_NAME
     const cookieValue = cookies[`__Secure-${baseUrlCookieName}`] || cookies[baseUrlCookieName]
     const [baseUrl] = cookieValue ? cookieValue.split('|') : [null]
     return baseUrl
   } else {
     // Client Side
     // Note: 'site' is empty by default; URL is normally relative.
-    const site = process.env.NEXTAUTH_SITE || DEFAULT_SITE
-    const basePath = process.env.NEXTAUTH_BASE_PATH || DEFAULT_BASE_PATH
+    const site = process.env.NEXTAUTH_SITE || NEXTAUTH_DEFAULT_SITE
+    const basePath = process.env.NEXTAUTH_BASE_PATH || NEXTAUTH_DEFAULT_BASE_PATH
     return `${site}${basePath}`
   }
 }
@@ -182,6 +228,15 @@ const _encodedForm = (formData) => {
   return Object.keys(formData).map((key) => {
     return encodeURIComponent(key) + '=' + encodeURIComponent(formData[key])
   }).join('&')
+}
+
+// use local storage for messaging. Set message in local storage and clear it right away
+// This is a safe way how to communicate with other tabs while not leaving any traces
+//
+const _sendMessage = (message) => {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('nextauth.message', JSON.stringify(message))
+  }
 }
 
 export default {

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -431,6 +431,10 @@ If set to any other value, specifies how many seconds the window or tab should p
 
 When a session is checked this way (or using `getSession()`) it is active and extends the life of the current session.
 
-It can be useful to use this option to prevent sessions from timing out if your applicaiton has a short session expiry time.
+It can be useful to use this option to prevent sessions from timing out if your application has a short session expiry time.
 
 This option usually has cost implications as checking session status triggers a call to a server side route and/or a database.
+
+:::note
+In NextAuth.js session state is automatically synchronized across all open windows and tabs in the same browser. If you have session expiry times of 30 days or more (the default) you probably don't need to use this option, or can set it to a high value (e.g. every 24 hours).
+:::

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -291,7 +291,7 @@ This option allows you to specify a different base path if you don't want to use
 
 If you set this option you **must** also specify the same value in the `NEXTAUTH_BASE_PATH` environment variable in `next.config.js` so that the client knows how to contact the server:
 
-```js
+```js title="next.config.js"
 module.exports = {
   env: {
     NEXTAUTH_BASE_PATH: '/api/my-custom-auth-route',
@@ -403,3 +403,34 @@ cookies: {
 :::warning
 Changing the cookie options may introduce security flaws into your application and may break NextAuth.js integration now or in a future update. Using this option is not recommended.
 :::
+
+---
+
+### Client Max Age
+
+* **Default value**: `0`
+* **Required**: *No*
+
+#### Description
+
+By default the NextAuth.js client will use whatever cached session object it has and will not not re-check the current session if using the `useSession()` hook.
+
+You can change this behaviour and force it to periodically sync the session state by setting a `NEXTAUTH_CLIENT_MAXAGE` environment variable.
+
+```js title="next.config.js"
+module.exports = {
+  env: {
+    NEXTAUTH_CLIENT_MAXAGE: 60, // Will re-check session every 60 seconds
+  },
+}
+```
+
+If set to `0` (the default) sessions are not re-checked automatically, only when a new window or tab is opened or when `getSession()` is called.
+
+If set to any other value, specifies how many seconds the window or tab should poll the server to update the session data.
+
+When a session is checked this way (or using `getSession()`) it is active and extends the life of the current session.
+
+It can be useful to use this option to prevent sessions from timing out if your applicaiton has a short session expiry time.
+
+This option usually has cost implications as checking session status triggers a call to a server side route and/or a database.


### PR DESCRIPTION
* Session state is now synced across Windows and Tabs.
* Adds `NEXTAUTH_CLIENT_MAXAGE` option (set via env var in `next.config.js`) to tell the client to sync the session state with the server every `X` seconds (defaults to `0`, which is never).

Resolves #252 

![NextAuth-Sync](https://user-images.githubusercontent.com/595695/85216167-56fc2000-b379-11ea-9d4b-291c8a57771a.gif)

