### PR TITLE
Improve appearance of sign in email

### DIFF
--- a/src/providers/email.js
+++ b/src/providers/email.js
@@ -22,22 +22,22 @@ export default (options) => {
   }
 }
 
-const sendVerificationRequest = ({ identifier: emailAddress, url, token, site, provider }) => {
+const sendVerificationRequest = ({ identifier: email, url, token, site, provider }) => {
   return new Promise((resolve, reject) => {
     const { server, from } = provider
-    const siteName = site.replace(/^https?:\/\//, '')
+    site = site.replace(/^https?:\/\//, '') // Strip protocol from site
 
     nodemailer
       .createTransport(server)
       .sendMail({
-        to: emailAddress,
+        to: email,
         from,
-        subject: `Sign in to ${siteName}`,
-        text: text({ url, siteName }),
-        html: html({ url, siteName })
+        subject: `Sign in to ${site}`,
+        text: text({ url, site, email }),
+        html: html({ url, site, email })
       }, (error) => {
         if (error) {
-          logger.error('SEND_VERIFICATION_EMAIL_ERROR', emailAddress, error)
+          logger.error('SEND_VERIFICATION_EMAIL_ERROR', email, error)
           return reject(new Error('SEND_VERIFICATION_EMAIL_ERROR', error))
         }
         return resolve()
@@ -46,28 +46,55 @@ const sendVerificationRequest = ({ identifier: emailAddress, url, token, site, p
 }
 
 // Email HTML body
-const html = ({ url, siteName }) => {
-  const buttonBackgroundColor = '#444444'
+const html = ({ url, site, email }) => {
+  // Insert invisible space into domains and email address to prevent both the
+  // email address and the domain from being turned into a hyperlink by email
+  // clients like Outlook and Apple mail, as this is confusing because it seems
+  // like they are supposed to click on their email address to sign in.
+  const escapedEmail = `${email.replace(/\./g, '&#8203;.')}`
+  const escapedSite = `${site.replace(/\./g, '&#8203;.')}`
+
+  // Some simple styling options
+  const backgroundColor = '#f9f9f9'
+  const textColor = '#444444'
+  const mainBackgroundColor = '#ffffff'
+  const buttonBackgroundColor = '#346df1'
+  const buttonBorderColor = '#346df1'
   const buttonTextColor = '#ffffff'
+
   return `
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
-  <tr>
-    <td align="center" style="padding: 8px 0; font-size: 22px; font-family: Helvetica, Arial, sans-serif; color: #888888;">
-       ${siteName}
-    </td>
-  </tr>
-  <tr>
-    <td align="center" style="padding: 16px 0;">
-      <table border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td align="center" style="border-radius: 3px;" bgcolor="${buttonBackgroundColor}"><a href="${url}" target="_blank" style="font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${buttonTextColor}; text-decoration: none; text-decoration: none;border-radius: 3px; padding: 12px 18px; border: 1px solid ${buttonBackgroundColor}; display: inline-block; font-weight: bold;">Sign in</a></td>
-        </tr>
-      </table>
-    </td>
-  </tr>
-</table>
+<body style="background: ${backgroundColor};">
+  <table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+      <td align="center" style="padding: 10px 0px 20px 0px; font-size: 22px; font-family: Helvetica, Arial, sans-serif; color: ${textColor};">
+        <strong>${escapedSite}</strong>
+      </td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="20" cellpadding="0" style="background: ${mainBackgroundColor}; max-width: 600px; margin: auto; border-radius: 10px;">
+    <tr>
+      <td align="center" style="padding: 10px 0px 0px 0px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${textColor};">
+        Sign in as <strong>${escapedEmail}</strong>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 20px 0;">
+        <table border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center" style="border-radius: 5px;" bgcolor="${buttonBackgroundColor}"><a href="${url}" target="_blank" style="font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${buttonTextColor}; text-decoration: none; text-decoration: none;border-radius: 5px; padding: 10px 20px; border: 1px solid ${buttonBorderColor}; display: inline-block; font-weight: bold;">Sign in</a></td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 0px 0px 10px 0px; font-size: 16px; line-height: 22px; font-family: Helvetica, Arial, sans-serif; color: ${textColor};">
+        If you did not request this email you can safely ignore it.
+      </td>
+    </tr>
+  </table>
+</body>
 `
 }
 
 // Email Text body (fallback for email clients that don't render HTML, e.g. feature phones)
-const text = ({ url, siteName }) => `Sign in to ${siteName}\n${url}\n\n`
+const text = ({ url, site }) => `Sign in to ${site}\n${url}\n\n`

--- a/www/docs/providers/email.md
+++ b/www/docs/providers/email.md
@@ -84,26 +84,39 @@ The Email Provider can be used with both JSON Web Tokens and database sessions, 
 
 You can fully customise the sign in email that is sent by passing a custom function as the `sendVerificationRequest` option to `Providers.Email()`.
 
-The following example shows the complete source for the built-in `sendVerificationRequest()` method.
+e.g.
+
+```js {3} title="pages/api/auth/[...nextauth].js"
+providers: [
+  Providers.Email({
+    server: process.env.EMAIL_SERVER, 
+    from: process.env.EMAIL_FROM,
+    sendVerificationRequest: ({ identifier: email, url, token, site, provider }) => { /* your function */ }
+  })
+]
+```
+
+The following code shows the complete source for the built-in `sendVerificationRequest()` method:
 
 ```js
 import nodemailer from 'nodemailer'
-const sendVerificationRequest = ({ identifier: emailAddress, url, token, site, provider }) => {
+
+const sendVerificationRequest = ({ identifier: email, url, token, site, provider }) => {
   return new Promise((resolve, reject) => {
     const { server, from } = provider
-    const siteName = site.replace(/^https?:\/\//, '')
+    site = site.replace(/^https?:\/\//, '') // Strip protocol from site
 
     nodemailer
       .createTransport(server)
       .sendMail({
-        to: emailAddress,
+        to: email,
         from,
-        subject: `Sign in to ${siteName}`,
-        text: text({ url, siteName }),
-        html: html({ url, siteName })
+        subject: `Sign in to ${site}`,
+        text: text({ url, site, email }),
+        html: html({ url, site, email })
       }, (error) => {
         if (error) {
-          console.error('SEND_VERIFICATION_EMAIL_ERROR', emailAddress, error)
+          logger.error('SEND_VERIFICATION_EMAIL_ERROR', email, error)
           return reject(new Error('SEND_VERIFICATION_EMAIL_ERROR', error))
         }
         return resolve()
@@ -112,33 +125,61 @@ const sendVerificationRequest = ({ identifier: emailAddress, url, token, site, p
 }
 
 // Email HTML body
-const html = ({ url, siteName }) => {
-  const buttonBackgroundColor = '#444444'
+const html = ({ url, site, email }) => {
+  // Insert invisible space into domains and email address to prevent both the
+  // email address and the domain from being turned into a hyperlink by email
+  // clients like Outlook and Apple mail, as this is confusing because it seems
+  // like they are supposed to click on their email address to sign in.
+  const escapedEmail = `${email.replace(/\./g, '&#8203;.')}`
+  const escapedSite = `${site.replace(/\./g, '&#8203;.')}`
+
+  // Some simple styling options
+  const backgroundColor = '#f9f9f9'
+  const textColor = '#444444'
+  const mainBackgroundColor = '#ffffff'
+  const buttonBackgroundColor = '#346df1'
+  const buttonBorderColor = '#346df1'
   const buttonTextColor = '#ffffff'
+
+  // Uses tables for layout and inline CSS due to email client limitations
   return `
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
-  <tr>
-    <td align="center" style="padding: 8px 0; font-size: 22px; font-family: Helvetica, Arial, sans-serif; color: #888888;">
-       ${siteName}
-    </td>
-  </tr>
-  <tr>
-    <td align="center" style="padding: 16px 0;">
-      <table border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td align="center" style="border-radius: 3px;" bgcolor="${buttonBackgroundColor}"><a href="${url}" target="_blank" style="font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${buttonTextColor}; text-decoration: none; text-decoration: none;border-radius: 3px; padding: 12px 18px; border: 1px solid ${buttonBackgroundColor}; display: inline-block; font-weight: bold;">Sign in</a></td>
-        </tr>
-      </table>
-    </td>
-  </tr>
-</table>
+<body style="background: ${backgroundColor};">
+  <table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+      <td align="center" style="padding: 10px 0px 20px 0px; font-size: 22px; font-family: Helvetica, Arial, sans-serif; color: ${textColor};">
+        <strong>${escapedSite}</strong>
+      </td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="20" cellpadding="0" style="background: ${mainBackgroundColor}; max-width: 600px; margin: auto; border-radius: 10px;">
+    <tr>
+      <td align="center" style="padding: 10px 0px 0px 0px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${textColor};">
+        Sign in as <strong>${escapedEmail}</strong>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 20px 0;">
+        <table border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center" style="border-radius: 5px;" bgcolor="${buttonBackgroundColor}"><a href="${url}" target="_blank" style="font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${buttonTextColor}; text-decoration: none; text-decoration: none;border-radius: 5px; padding: 10px 20px; border: 1px solid ${buttonBorderColor}; display: inline-block; font-weight: bold;">Sign in</a></td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 0px 0px 10px 0px; font-size: 16px; line-height: 22px; font-family: Helvetica, Arial, sans-serif; color: ${textColor};">
+        If you did not request this email you can safely ignore it.
+      </td>
+    </tr>
+  </table>
+</body>
 `
 }
 
-// Email Text body (fallback for email clients that don't render HTML, e.g. feature phones)
-const text = ({ url, siteName }) => `Sign in to ${siteName}\n${url}\n\n`
+// Email text body – fallback for email clients that don't render HTML
+const text = ({ url, site }) => `Sign in to ${site}\n${url}\n\n`
 ```
 
 :::tip
-If you want to generate email-client compatible HTML from React, check out https://mjml.io
+If you want to generate great looking email client compatible HTML with React, check out https://mjml.io
 :::


### PR DESCRIPTION
Improve apperance of sign in email
    
* Prevents links from being turned into hyperlinks by email clients
* Improve UI with a primary action button and better font sizing and spacing in the template
* Adds email address to body to clear indicate who they will be signing in as

While not exactly a bug in NextAuth.js it does resolve #331

### Notes
I've tried to avoid using colour schemes in NextAuth.js but in this case it improves the UX to pick a large primary colour for the action button, especially on dark mode devices. It uses a fairly innocuous and generic shade of blue, similar to that used by Google, Apple, Twitter and Facebook on call to action.

Emails are fully customisable as before. There are no breaking changes in this update.

### Example

![Screenshot 2020-06-25 at 17 02 15](https://user-images.githubusercontent.com/595695/85758826-94a9d180-b708-11ea-9aea-cbbd7d3a016d.png)
