### PR TITLE
Improvements to Apple provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ yarn-error.log*
 
 # Docusaurus
 www/build
+
+#VS
+/.vs/slnx.sqlite-journal
+/.vs/slnx.sqlite
+/.vs

--- a/src/providers/apple.js
+++ b/src/providers/apple.js
@@ -13,9 +13,11 @@ export default (options) => {
     profileUrl: null,
     idToken: true,
     profile: (profile) => {
+
+      //The name of the user will only return on first login
       return {
         id: profile.sub,
-        name: profile.name == null ? profile.sub : profile.name,
+        name: profile.user != null ? profile.user.name.firstName + " " + profile.user.name.lastName : null,
         email: profile.email
       }
     },

--- a/src/providers/apple.js
+++ b/src/providers/apple.js
@@ -36,7 +36,9 @@ export default (options) => {
           aud: 'https://appleid.apple.com',
           sub: appleId
         },
-        privateKey,
+        // Automatically convert \\n into \n if found in private key. If the key
+        // is passed in an environment variable \n can get escaped as \\n
+        privateKey.replace(/\\n/g, '\n'), 
         {
           algorithm: 'ES256',
           keyid: keyId

--- a/src/providers/apple.js
+++ b/src/providers/apple.js
@@ -13,11 +13,10 @@ export default (options) => {
     profileUrl: null,
     idToken: true,
     profile: (profile) => {
-
-      //The name of the user will only return on first login
+      // The name of the user will only return on first login
       return {
         id: profile.sub,
-        name: profile.user != null ? profile.user.name.firstName + " " + profile.user.name.lastName : null,
+        name: profile.user != null ? profile.user.name.firstName + ' ' + profile.user.name.lastName : null,
         email: profile.email
       }
     },

--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -14,14 +14,24 @@ import logger from '../../../lib/logger'
 // @TODO Refactor to use jsonwebtoken instead of jwt-decode & remove dependancy
 
 export default async (req, provider, callback) => {
-  let { oauth_token, oauth_verifier, code } = req.query // eslint-disable-line camelcase
+  //user = specific to apple provider on first sign in returns an object '{"name":{"firstName":"Johnny","lastName":"Appleseed"},"email":"johnny.appleseed@nextauth.com"}'
+  let { oauth_token, oauth_verifier, code, user } = req.query // eslint-disable-line camelcase
   const client = oAuthClient(provider)
 
   if (provider.version && provider.version.startsWith('2.')) {
     if (req.method === 'POST') {
+
       // Get the CODE from Body
       const body = JSON.parse(JSON.stringify(req.body))
+
+      // @TODO Handle error
+      if (body.error) {
+        logger.error('OAUTH_CALLBACK_HANDLER_ERROR', body.error, req.body, provider.id, code)
+        return callback()
+      }
+
       code = body.code
+      user = body.user != null ? JSON.parse(body.user) : null;
     }
 
     // Pass authToken in header by default (unless 'useAuthTokenHeader: false' is set)
@@ -38,6 +48,7 @@ export default async (req, provider, callback) => {
       code,
       provider,
       (error, accessToken, refreshToken, results) => {
+        // @TODO Handle error
         if (error || results.error) {
           logger.error('OAUTH_GET_ACCESS_TOKEN_ERROR', error, results, provider.id, code)
           return callback(error || results.error)
@@ -45,7 +56,7 @@ export default async (req, provider, callback) => {
 
         if (provider.idToken) {
 
-          // If we don't have an ID Token most likely the user hit a cancel
+           // If we don't have an ID Token most likely the user hit a cancel
           // button when signing in (or the provider is misconfigured).
           //
           // Unfortunately, we can't tell which, so we can't treat it as an
@@ -62,7 +73,7 @@ export default async (req, provider, callback) => {
             refreshToken,
             results.id_token,
             async (error, profileData) => {
-              const { profile, account, OAuthProfile } = await _getProfile(error, profileData, accessToken, refreshToken, provider)
+              const { profile, account, OAuthProfile } = await _getProfile(error, profileData, accessToken, refreshToken, provider, user)
               callback(error, profile, account, OAuthProfile)
             }
           )
@@ -107,7 +118,11 @@ export default async (req, provider, callback) => {
   }
 }
 
-async function _getProfile (error, profileData, accessToken, refreshToken, provider) {
+/**
+ * //6/30/2020 @geraldnolan added userData parameter to attach additional data to the profileData object
+ * Returns profile, raw profile and auth provider details
+ */
+async function _getProfile (error, profileData, accessToken, refreshToken, provider, userData) {
   // @TODO Handle error
   if (error) {
     logger.error('OAUTH_GET_PROFILE_ERROR', error)
@@ -117,6 +132,12 @@ async function _getProfile (error, profileData, accessToken, refreshToken, provi
   try {
     // Convert profileData into an object if it's a string
     if (typeof profileData === 'string' || profileData instanceof String) { profileData = JSON.parse(profileData) }
+
+    if(userData != null)
+    {
+       profileData.user = userData;
+       logger.debug("ProfileData and UserData", profileData)
+    }
 
     profile = await provider.profile(profileData)
   } catch (exception) {


### PR DESCRIPTION
When using a provider that uses Token ID option (like Apple) a user hitting cancel with no longer cause the app to crash.

Users who do this will now be taken back to the sign in page.

This was already working for other providers that didn't use this option but wasn't supported for providers that did use it.

This addresses one issue raised in #346