### PR TITLE
Fix missing closing tag in docs

### DIFF
--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -43,7 +43,7 @@ export default () => {
 
   return <>
     {session && <p>Signed in as {session.user.email}</p>}
-    {!session && <p><a href="/api/auth/signin">Sign in</p>}
+    {!session && <p><a href="/api/auth/signin">Sign in</a></p>}
   </>
 }
 ```


### PR DESCRIPTION
I couldn't run an example right away, here is the quick fix.