### PR TITLE
Change .env variables on example to reflect the actual variable name

### DIFF
--- a/www/docs/providers/twitter.md
+++ b/www/docs/providers/twitter.md
@@ -18,8 +18,8 @@ import Providers from `next-auth/providers`
 ...
 providers: [
   Providers.Twitter({
-    clientId: process.env.TWITTER_CLIENT_ID,
-    clientSecret: process.env.TWITTER_CLIENT_SECRET
+    clientId: process.env.TWITTER_CLIENT_API_KEY,
+    clientSecret: process.env.TWITTER_CLIENT_API_SECRET_KEY
   })
 }
 ...


### PR DESCRIPTION
What we actually need to authenticate is written on the Twitter page as `API key` and `API secret key`.
So, the name `process.env.TWITTER_CLIENT_ID` and `process.env.TWITTER_CLIENT_SECRET` is confusing and misleading because there's an `App ID` and that's not what we need.