### PR TITLE
HTTP POST, CSRF and API changes for v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.6",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.3",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "2.2.0",
+  "version": "3.0.0-beta.0",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -21,14 +21,19 @@ import logger from '../lib/logger'
 // 2. When invoked server side the value is picked up from an environment
 //    variable and defaults to 'http://localhost:3000'.
 const __NEXTAUTH = {
+  // Configuration options
   site: (typeof window === 'undefined')
     ? process.env.NEXTAUTH_URL || process.env.VERCEL_URL || 'http://localhost:3000'
     : '',
   basePath: (typeof window === 'undefined')
     ? process.env.NEXTAUTH_BASE_PATH || '/api/auth'
     : '/api/auth',
-  keepAlive: 0, // e.g. 0 == disabled (don't keep alive) 60 == 60 seconds
-  clientMaxAge: 0, // e.g. 0 == disabled (always use cache) 60 == 60 seconds
+  // keepAlive 0 == disabled (don't send); 60 == send every 60 seconds
+  keepAlive: 0, 
+  // clientMaxAge 0 == disabled (only use cache); 60 == sync if last checked more than 60 seconds ago
+  clientMaxAge: 0,
+
+  // These properties are used for tracking internal state only
   _clientLastSync: 0, // used for timestamp since last sycned (in seconds)
   _clientSyncTimer: null, // stores timer for poll interval
   _eventListenersAdded: false, // tracks if event listeners have been added,
@@ -40,7 +45,7 @@ const __NEXTAUTH = {
   _getSession: () => {}
 }
 
-// Add event listners on first invokation
+// Add event listners on load
 if (typeof window !== 'undefined') {
   if (__NEXTAUTH._eventListenersAdded === false) {
     __NEXTAUTH._eventListenersAdded = true
@@ -90,7 +95,7 @@ const setOptions = ({
   if (keepAlive) { 
     __NEXTAUTH.keepAlive = keepAlive
 
-    if (keepAlive > 0) {
+    if (typeof window !== 'undefined' && keepAlive > 0) {
       // Clear existing timer (if there is one)
       if (__NEXTAUTH._clientSyncTimer !== null) { clearTimeout(__NEXTAUTH._clientSyncTimer) }
       

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -29,7 +29,7 @@ const __NEXTAUTH = {
     ? process.env.NEXTAUTH_BASE_PATH || '/api/auth'
     : '/api/auth',
   // keepAlive 0 == disabled (don't send); 60 == send every 60 seconds
-  keepAlive: 0, 
+  keepAlive: 0,
   // clientMaxAge 0 == disabled (only use cache); 60 == sync if last checked more than 60 seconds ago
   clientMaxAge: 0,
 
@@ -38,7 +38,7 @@ const __NEXTAUTH = {
   _clientSyncTimer: null, // stores timer for poll interval
   _eventListenersAdded: false, // tracks if event listeners have been added,
   _clientSession: undefined, // stores last session response from hook,
-  // Generate a unique ID to make it possible to identify when a message 
+  // Generate a unique ID to make it possible to identify when a message
   // was sent from this tab/window so it can be ignored to avoid event loops.
   _clientId: Math.random().toString(36).substring(2) + Date.now().toString(36),
   // Used to store to function export by getSession() hook
@@ -57,7 +57,7 @@ if (typeof window !== 'undefined') {
         const message = JSON.parse(event.newValue)
         if (message.event && message.event === 'session' && message.data) {
           // Ignore storage events fired from the same window that created them
-          if (__NEXTAUTH._clientId === message.clientId) { 
+          if (__NEXTAUTH._clientId === message.clientId) {
             return
           }
 
@@ -69,14 +69,14 @@ if (typeof window !== 'undefined') {
           // on how the session object is being used in the client; it is
           // more robust to have each window/tab fetch it's own copy of the
           // session object rather than share it across instances.
-          await __NEXTAUTH._getSession({event: 'storage'})
+          await __NEXTAUTH._getSession({ event: 'storage' })
         }
       }
     })
 
     // Listen for window focus/blur events
-    window.addEventListener("focus", async (event) => await __NEXTAUTH. _getSession({event: 'focus'}) )
-    window.addEventListener("blur", async (event) => await __NEXTAUTH._getSession({event: 'blur'}) )
+    window.addEventListener('focus', async (event) => await __NEXTAUTH._getSession({ event: 'focus' }))
+    window.addEventListener('blur', async (event) => await __NEXTAUTH._getSession({ event: 'blur' }))
   }
 }
 
@@ -92,18 +92,18 @@ const setOptions = ({
   if (site) { __NEXTAUTH.site = site }
   if (basePath) { __NEXTAUTH.basePath = basePath }
   if (clientMaxAge) { __NEXTAUTH.clientMaxAge = clientMaxAge }
-  if (keepAlive) { 
+  if (keepAlive) {
     __NEXTAUTH.keepAlive = keepAlive
 
     if (typeof window !== 'undefined' && keepAlive > 0) {
       // Clear existing timer (if there is one)
       if (__NEXTAUTH._clientSyncTimer !== null) { clearTimeout(__NEXTAUTH._clientSyncTimer) }
-      
+
       // Set next timer to trigger in number of seconds
-      __NEXTAUTH._clientSyncTimer = setTimeout(async () => { 
+      __NEXTAUTH._clientSyncTimer = setTimeout(async () => {
         // Only invoke keepalive when a session exists
         if (__NEXTAUTH._clientSession) {
-          await __NEXTAUTH._getSession({event: 'timer'})
+          await __NEXTAUTH._getSession({ event: 'timer' })
         }
       }, keepAlive * 1000)
     }
@@ -148,7 +148,7 @@ const useSession = (session) => {
   // Try to use context if we can
   const value = useContext(SessionContext)
 
-  // If we have no Provider in the tree, call the actual hook 
+  // If we have no Provider in the tree, call the actual hook
   if (value === undefined) {
     return _useSessionHook(session)
   }
@@ -162,8 +162,8 @@ const _useSessionHook = (session) => {
   const [loading, setLoading] = useState(true)
   const _getSession = async ({ event = null } = {}) => {
     try {
-      const triggredByEvent = (event !== null) ? true : false
-      const triggeredByStorageEvent = (event && event === 'storage') ? true : false
+      const triggredByEvent = (event !== null)
+      const triggeredByStorageEvent = !!((event && event === 'storage'))
 
       const clientMaxAge = __NEXTAUTH.clientMaxAge
       const clientLastSync = parseInt(__NEXTAUTH._clientLastSync)
@@ -171,12 +171,12 @@ const _useSessionHook = (session) => {
       const clientSession = __NEXTAUTH._clientSession
       const keepAlive = __NEXTAUTH.keepAlive
 
-      // Updates triggered by a storage event *always* trigger an update and we 
+      // Updates triggered by a storage event *always* trigger an update and we
       // always update if we don't have any value for the current session state.
       if (triggeredByStorageEvent === false && clientSession !== undefined) {
         if (clientMaxAge === 0 && triggredByEvent !== true) {
           // If there is no time defined for when a session should be considered
-          // stale, then it's okay to use the value we have until an event is 
+          // stale, then it's okay to use the value we have until an event is
           // triggered which updates it.
           return
         } else if (clientMaxAge > 0 && clientSession === null) {
@@ -186,7 +186,7 @@ const _useSessionHook = (session) => {
           // event and will skip this logic)
           return
         } else if (clientMaxAge > 0 && currentTime < (clientLastSync + clientMaxAge)) {
-          // If the session freshness is within clientMaxAge then don't request 
+          // If the session freshness is within clientMaxAge then don't request
           // it again on this call (avoids too many invokations).
           return
         }
@@ -194,7 +194,7 @@ const _useSessionHook = (session) => {
 
       if (clientSession === undefined) { __NEXTAUTH._clientSession = null }
 
-      // Update clientLastSync before making response to avoid repeated 
+      // Update clientLastSync before making response to avoid repeated
       // invokations that would otherwise be triggered while we are still
       // waiting for a response.
       __NEXTAUTH._clientLastSync = Math.floor(new Date().getTime() / 1000)
@@ -202,11 +202,11 @@ const _useSessionHook = (session) => {
       // If this call was invoked via a storage event (i.e. another window) then
       // tell getSession not to trigger an event when it calls to avoid an
       // infinate loop.
-      const triggerEvent = (triggeredByStorageEvent === false) ? true : false
-      const newClientSessionData =  await getSession({ triggerEvent })
+      const triggerEvent = (triggeredByStorageEvent === false)
+      const newClientSessionData = await getSession({ triggerEvent })
 
       // Save session state internally, just so we can track that we've checked
-      // if a session exists at least once. 
+      // if a session exists at least once.
       __NEXTAUTH._clientSession = newClientSessionData
 
       setData(newClientSessionData)
@@ -218,7 +218,7 @@ const _useSessionHook = (session) => {
 
   __NEXTAUTH._getSession = _getSession
 
-  useEffect(() => { 
+  useEffect(() => {
     _getSession()
   })
   return [data, loading]

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -28,12 +28,9 @@ const __NEXTAUTH = {
   basePath: (typeof window === 'undefined')
     ? process.env.NEXTAUTH_BASE_PATH || '/api/auth'
     : '/api/auth',
-  // keepAlive 0 == disabled (don't send); 60 == send every 60 seconds
-  keepAlive: 0,
-  // clientMaxAge 0 == disabled (only use cache); 60 == sync if last checked more than 60 seconds ago
-  clientMaxAge: 0,
-
-  // These properties are used for tracking internal state only
+  keepAlive: 0, // 0 == disabled (don't send); 60 == send every 60 seconds
+  clientMaxAge: 0, // 0 == disabled (only use cache); 60 == sync if last checked > 60 seconds ago
+  // Properties starting with _ are used for tracking internal app state
   _clientLastSync: 0, // used for timestamp since last sycned (in seconds)
   _clientSyncTimer: null, // stores timer for poll interval
   _eventListenersAdded: false, // tracks if event listeners have been added,
@@ -75,8 +72,8 @@ if (typeof window !== 'undefined') {
     })
 
     // Listen for window focus/blur events
-    window.addEventListener('focus', async (event) => await __NEXTAUTH._getSession({ event: 'focus' }))
-    window.addEventListener('blur', async (event) => await __NEXTAUTH._getSession({ event: 'blur' }))
+    window.addEventListener('focus', async (event) => __NEXTAUTH._getSession({ event: 'focus' }))
+    window.addEventListener('blur', async (event) => __NEXTAUTH._getSession({ event: 'blur' }))
   }
 }
 
@@ -169,7 +166,6 @@ const _useSessionHook = (session) => {
       const clientLastSync = parseInt(__NEXTAUTH._clientLastSync)
       const currentTime = Math.floor(new Date().getTime() / 1000)
       const clientSession = __NEXTAUTH._clientSession
-      const keepAlive = __NEXTAUTH.keepAlive
 
       // Updates triggered by a storage event *always* trigger an update and we
       // always update if we don't have any value for the current session state.

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -14,7 +14,7 @@ const __NEXTAUTH = {
     ? process.env.NEXTAUTH_URL || process.env.VERCEL_URL || 'http://localhost:3000'
     : '',
   basePath: (typeof window === 'undefined')
-    ? process.env.NEXTAUTH_BASE_PATH|| '/api/auth'
+    ? process.env.NEXTAUTH_BASE_PATH || '/api/auth'
     : '/api/auth',
   clientMaxAge: 0, // e.g. 0 == disabled, 60 == 60 seconds
   eventListenerAdded: false
@@ -50,7 +50,7 @@ const getSession = async ({ req, ctx } = {}) => {
 const getCsrfToken = async ({ req }) => {
   const baseUrl = _baseUrl()
   const fetchOptions = req ? { headers: { cookie: req.headers.cookie } } : {}
-  const data = await _fetchData(`${baseUrl}/csrf`. fetchOptions)
+  const data = await _fetchData(`${baseUrl}/csrf`, fetchOptions)
   return data && data.csrfToken ? data.csrfToken : null
 }
 
@@ -124,7 +124,7 @@ const useSessionData = (session) => {
 
 // Client side method
 const signIn = async (provider, args) => {
-  const baseUrl = _baseUrl()  
+  const baseUrl = _baseUrl()
   const callbackUrl = (args && args.callbackUrl) ? args.callbackUrl : window.location
   const providers = await getProviders()
 
@@ -248,5 +248,5 @@ export default {
   providers: getProviders,
   csrfToken: getCsrfToken,
   signin: signIn,
-  signout: signOut,
+  signout: signOut
 }

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -4,16 +4,26 @@ const logger = {
       !text
         ? console.error(errorCode)
         : console.error(
-            `[next-auth][error][${errorCode}]`,
-            text,
-            `\nhttps://next-auth.js.org/errors#${errorCode.toLowerCase()}`
+          `[next-auth][error][${errorCode.toLowerCase()}]`,
+          text,
+          `\nhttps://next-auth.js.org/errors#${errorCode.toLowerCase()}`
+        )
+    }
+  },
+  warn: (warnCode, ...text) => {
+    if (console) {
+      !text
+        ? console.warn(warnCode)
+        : console.warn(
+          `[next-auth][warn][${warnCode.toLowerCase()}]`,
+          text
         )
     }
   },
   debug: (debugCode, ...text) => {
     if (process && process.env && process.env._NEXTAUTH_DEBUG) {
       console.log(
-        `[next-auth][debug][${debugCode}]`,
+        `[next-auth][debug][${debugCode.toLowerCase()}]`,
         text
       )
     }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -192,6 +192,18 @@ export default async (req, res, userSuppliedOptions) => {
       cookie.set(res, cookies.csrfToken.name, newCsrfTokenCookie, cookies.csrfToken.options)
     }
 
+    // Helper method for handling redirects
+    const redirect = (redirectUrl) => {
+      const reponseAsJson = !!((req.body && req.body.json === 'true'))
+      if (reponseAsJson) {
+        res.json({ url: redirectUrl })
+      } else {
+        res.status(302).setHeader('Location', redirectUrl)
+        res.end()
+      }
+      return done()
+    }
+
     // User provided options are overriden by other options,
     // except for the options with special handling above
     const options = {
@@ -216,7 +228,8 @@ export default async (req, res, userSuppliedOptions) => {
       jwt: jwtOptions,
       events: eventsOption,
       callbacks: callbacksOption,
-      callbackUrl: site
+      callbackUrl: site,
+      redirect
     }
 
     // If debug enabled, set ENV VAR so that logger logs debug messages
@@ -224,19 +237,6 @@ export default async (req, res, userSuppliedOptions) => {
 
     // Get / Set callback URL based on query param / cookie + validation
     options.callbackUrl = await callbackUrlHandler(req, res, options)
-
-    // Helper method for handling redirects
-    const redirect = (redirectUrl) => {
-      const reponseAsJson = !!((req.body && req.body.json === 'true'))
-
-      if (reponseAsJson) {
-        res.json({ url: redirectUrl })
-      } else {
-        res.status(302).setHeader('Location', redirectUrl)
-        res.end()
-      }
-      return done()
-    }
 
     if (req.method === 'GET') {
       switch (action) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -250,12 +250,12 @@ export default async (req, res, userSuppliedOptions) => {
           res.json({ csrfToken })
           return done()
         case 'signin':
-          if (options.pages.signin) { return redirect(`${options.pages.signin}${options.pages.signin.includes('?') ? '&' : '?'}callbackUrl=${options.callbackUrl}`) }
+          if (options.pages.signIn) { return redirect(`${options.pages.signIn}${options.pages.signIn.includes('?') ? '&' : '?'}callbackUrl=${options.callbackUrl}`) }
 
           pages.render(req, res, 'signin', { site, providers: Object.values(options.providers), callbackUrl: options.callbackUrl, csrfToken }, done)
           break
         case 'signout':
-          if (options.pages.signout) { return redirect(`${options.pages.signout}${options.pages.signout.includes('?') ? '&' : '?'}callbackUrl=${options.callbackUrl}`) }
+          if (options.pages.signOut) { return redirect(`${options.pages.signOut}${options.pages.signOut.includes('?') ? '&' : '?'}callbackUrl=${options.callbackUrl}`) }
 
           pages.render(req, res, 'signout', { site, baseUrl, csrfToken, callbackUrl: options.callbackUrl }, done)
           break

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -19,7 +19,7 @@ import logger from '../lib/logger'
 //       I don't want to change it until we have tests as refactoring might
 //       involve changes in dozen files or so and too easy to break accidentally.
 const DEFAULT_SITE = process.env.NEXTAUTH_URL || process.env.VERCEL_URL || 'http://localhost:3000'
-const DEFAULT_BASE_PATH =  process.env.NEXTAUTH_BASE_PATH || '/api/auth'
+const DEFAULT_BASE_PATH = process.env.NEXTAUTH_BASE_PATH || '/api/auth'
 
 // While we can run locally without this value being set, to work properly in
 // production with OAuth providers the NEXTAUTH_URL environment variable should
@@ -227,7 +227,7 @@ export default async (req, res, userSuppliedOptions) => {
 
     // Helper method for handling redirects
     const redirect = (redirectUrl) => {
-      const reponseAsJson = (req.body && req.body.json === 'true') ? true : false
+      const reponseAsJson = !!((req.body && req.body.json === 'true'))
 
       if (reponseAsJson) {
         res.json({ url: redirectUrl })
@@ -303,7 +303,6 @@ export default async (req, res, userSuppliedOptions) => {
           break
         case 'callback':
           if (provider && options.providers[provider]) {
-
             // Verified CSRF Token required for credentials providers only
             if (options.providers[provider].type === 'credentials' && !csrfTokenVerified) {
               return redirect(`${baseUrl}/signin?csrf=true`)

--- a/src/server/lib/callbacks.js
+++ b/src/server/lib/callbacks.js
@@ -1,5 +1,5 @@
 /**
- * Use the signin callback to control if a user is allowed to sign in or not.
+ * Use the signIn callback to control if a user is allowed to sign in or not.
  *
  * This is triggered before sign in flow completes, so the user profile may be
  * a user object (with an ID) or it may be just their name and email address,
@@ -15,7 +15,7 @@
  * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
  *                           Return `false` to deny access
  */
-const signin = async (profile, account, metadata) => {
+const signIn = async (profile, account, metadata) => {
   const isAllowedToSignIn = true
   if (isAllowedToSignIn) {
     return Promise.resolve(true)
@@ -68,7 +68,7 @@ const jwt = async (token, oAuthProfile) => {
 }
 
 export default {
-  signin,
+  signIn,
   redirect,
   session,
   jwt

--- a/src/server/lib/cookie.js
+++ b/src/server/lib/cookie.js
@@ -15,7 +15,9 @@ const set = (res, name, value, options = {}) => {
   }
 
   // Preserve any existing cookies that have already been set in the same session
-  const setCookieHeader = res.getHeader('Set-Cookie') || []
+  let setCookieHeader = res.getHeader('Set-Cookie') || []
+  // If not an array (i.e. a string with a single cookie) convert it into an array
+  if (!Array.isArray(setCookieHeader)) { setCookieHeader = [setCookieHeader] }
   setCookieHeader.push(_serialize(name, String(stringValue), options))
   res.setHeader('Set-Cookie', setCookieHeader)
 }

--- a/src/server/lib/events.js
+++ b/src/server/lib/events.js
@@ -1,9 +1,9 @@
-const signin = async (message) => {
+const signIn = async (message) => {
   // Event triggered on successful sign in
 }
 
-const signout = async (message) => {
-  // Event triggered on signout
+const signOut = async (message) => {
+  // Event triggered on sign out
 }
 
 const createUser = async (message) => {
@@ -28,8 +28,8 @@ const error = async (message) => {
 }
 
 export default {
-  signin,
-  signout,
+  signIn,
+  signOut,
   createUser,
   updateUser,
   linkAccount,

--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -1,6 +1,8 @@
-import oAuthClient from './client'
+
+import { createHash } from 'crypto'
 import querystring from 'querystring'
 import jwtDecode from 'jwt-decode'
+import oAuthClient from './client'
 import logger from '../../../lib/logger'
 
 // @TODO Refactor monkey patching in _getOAuthAccessToken() and _get()
@@ -18,6 +20,18 @@ export default async (req, provider, callback) => {
   const client = oAuthClient(provider)
 
   if (provider.version && provider.version.startsWith('2.')) {
+    // For OAuth 2.0 flows, check state returned and matches expected value
+    // (a hash of the NextAuth.js CSRF token).
+    //
+    // This check can be disabled for providers that do not support it by
+    // setting 'useState: false' as a provider option (defaults to true).
+    if (!Object.prototype.hasOwnProperty.call(provider, 'useState') || provider.useState === true) {
+      const expectedState = createHash('sha256').update(csrfToken).digest('hex')
+      if (state !== expectedState) {
+        return callback(new Error("Invalid state returned from oAuth provider"))
+      } 
+    }
+
     if (req.method === 'POST') {
       try {
         const body = JSON.parse(JSON.stringify(req.body))

--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -28,8 +28,8 @@ export default async (req, provider, callback) => {
     if (!Object.prototype.hasOwnProperty.call(provider, 'useState') || provider.useState === true) {
       const expectedState = createHash('sha256').update(csrfToken).digest('hex')
       if (state !== expectedState) {
-        return callback(new Error("Invalid state returned from oAuth provider"))
-      } 
+        return callback(new Error('Invalid state returned from oAuth provider'))
+      }
     }
 
     if (req.method === 'POST') {

--- a/src/server/lib/signin/oauth.js
+++ b/src/server/lib/signin/oauth.js
@@ -1,8 +1,8 @@
 import oAuthClient from '../oauth/client'
-import crypto from 'crypto'
+import { createHash } from 'crypto'
 import logger from '../../../lib/logger'
 
-export default (provider, callback) => {
+export default (provider, csrfToken, callback) => {
   const { callbackUrl } = provider
   const client = oAuthClient(provider)
   if (provider.version && provider.version.startsWith('2.')) {
@@ -10,7 +10,8 @@ export default (provider, callback) => {
     let url = client.getAuthorizeUrl({
       redirect_uri: provider.callbackUrl,
       scope: provider.scope,
-      state: crypto.randomBytes(64).toString('hex')
+      // A hash of the NextAuth.js CSRF token is used as the state
+      state: createHash('sha256').update(csrfToken).digest('hex')
     })
 
     // If the authorizationUrl specified in the config has query parameters on it

--- a/src/server/pages/signin.js
+++ b/src/server/pages/signin.js
@@ -25,10 +25,9 @@ export default ({ req, csrfToken, providers, callbackUrl }) => {
           {provider.type === 'oauth' &&
             <form action={provider.signinUrl} method='POST'>
               <input type='hidden' name='csrfToken' value={csrfToken} />
-              {callbackUrl && <input type='hidden' name='callbackUrl' value={callbackUrl} /> }
-              <button type="submit" className='button'>Sign in with {provider.name}</button>
-            </form>
-          }
+              {callbackUrl && <input type='hidden' name='callbackUrl' value={callbackUrl} />}
+              <button type='submit' className='button'>Sign in with {provider.name}</button>
+            </form>}
           {(provider.type === 'email' || provider.type === 'credentials') && (i > 0) &&
             providersToRender[i - 1].type !== 'email' && providersToRender[i - 1].type !== 'credentials' &&
               <hr />}

--- a/src/server/pages/signin.js
+++ b/src/server/pages/signin.js
@@ -2,7 +2,6 @@ import { h } from 'preact' // eslint-disable-line no-unused-vars
 import render from 'preact-render-to-string'
 
 export default ({ req, csrfToken, providers, callbackUrl }) => {
-  const withCallbackUrl = callbackUrl ? `?callbackUrl=${callbackUrl}` : ''
   const { email } = req.query
 
   // We only want to render providers
@@ -24,7 +23,12 @@ export default ({ req, csrfToken, providers, callbackUrl }) => {
       {providersToRender.map((provider, i) =>
         <div key={provider.id} className='provider'>
           {provider.type === 'oauth' &&
-            <a className='button' data-provider={provider.id} href={`${provider.signinUrl}${withCallbackUrl}`}>Sign in with {provider.name}</a>}
+            <form action={provider.signinUrl} method='POST'>
+              <input type='hidden' name='csrfToken' value={csrfToken} />
+              {callbackUrl && <input type='hidden' name='callbackUrl' value={callbackUrl} /> }
+              <button type="submit" className='button'>Sign in with {provider.name}</button>
+            </form>
+          }
           {(provider.type === 'email' || provider.type === 'credentials') && (i > 0) &&
             providersToRender[i - 1].type !== 'email' && providersToRender[i - 1].type !== 'credentials' &&
               <hr />}

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -18,7 +18,8 @@ export default async (req, res, options, done) => {
     pages,
     jwt,
     events,
-    callbacks
+    callbacks,
+    csrfToken
   } = options
   const provider = providers[providerName]
   const { type } = provider
@@ -30,7 +31,7 @@ export default async (req, res, options, done) => {
 
   if (type === 'oauth') {
     try {
-      oAuthCallback(req, provider, async (error, profile, account, OAuthProfile) => {
+      oAuthCallback(req, provider, csrfToken, async (error, profile, account, OAuthProfile) => {
         try {
           if (error) {
             logger.error('CALLBACK_OAUTH_ERROR', error)

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -55,9 +55,9 @@ export default async (req, res, options, done) => {
           }
 
           // Check if user is allowed to sign in
-          const signinCallbackResponse = await callbacks.signin(profile, account, OAuthProfile)
+          const signInCallbackResponse = await callbacks.signIn(profile, account, OAuthProfile)
 
-          if (signinCallbackResponse === false) {
+          if (signInCallbackResponse === false) {
             return redirect(`${baseUrl}/error?error=AccessDenied`)
           }
 
@@ -81,7 +81,7 @@ export default async (req, res, options, done) => {
             cookie.set(res, cookies.sessionToken.name, session.sessionToken, { expires: session.expires || null, ...cookies.sessionToken.options })
           }
 
-          await dispatchEvent(events.signin, { user, account, isNewUser })
+          await dispatchEvent(events.signIn, { user, account, isNewUser })
 
           // Handle first logins on new accounts
           // e.g. option to send users to a new account landing page on initial login
@@ -134,9 +134,9 @@ export default async (req, res, options, done) => {
       const account = { id: provider.id, type: 'email', providerAccountId: email }
 
       // Check if user is allowed to sign in
-      const signinCallbackResponse = await callbacks.signin(profile, account, null)
+      const signInCallbackResponse = await callbacks.signIn(profile, account, null)
 
-      if (signinCallbackResponse === false) {
+      if (signInCallbackResponse === false) {
         return redirect(`${baseUrl}/error?error=AccessDenied`)
       }
 
@@ -160,7 +160,7 @@ export default async (req, res, options, done) => {
         cookie.set(res, cookies.sessionToken.name, session.sessionToken, { expires: session.expires || null, ...cookies.sessionToken.options })
       }
 
-      await dispatchEvent(events.signin, { user, account, isNewUser })
+      await dispatchEvent(events.signIn, { user, account, isNewUser })
 
       // Handle first logins on new accounts
       // e.g. option to send users to a new account landing page on initial login
@@ -212,9 +212,9 @@ export default async (req, res, options, done) => {
       return redirect(`${baseUrl}/error?error=CredentialsSignin&provider=${encodeURIComponent(provider.id)}`)
     }
 
-    const signinCallbackResponse = await callbacks.signin(user, account, credentials)
+    const signInCallbackResponse = await callbacks.signIn(user, account, credentials)
 
-    if (signinCallbackResponse === false) {
+    if (signInCallbackResponse === false) {
       return redirect(`${baseUrl}/error?error=AccessDenied`)
     }
 
@@ -230,7 +230,7 @@ export default async (req, res, options, done) => {
 
     cookie.set(res, cookies.sessionToken.name, newEncodedJwt, { expires: cookieExpires.toISOString(), ...cookies.sessionToken.options })
 
-    await dispatchEvent(events.signin, { user, account })
+    await dispatchEvent(events.signIn, { user, account })
 
     return redirect(callbackUrl || site)
   } else {

--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -41,7 +41,7 @@ export default async (req, res, options, done) => {
     const account = { id: provider.id, type: 'email', providerAccountId: email }
 
     // Check if user is allowed to sign in
-    const signinCallbackResponse = await callbacks.signin(profile, account)
+    const signinCallbackResponse = await callbacks.signIn(profile, account)
 
     if (signinCallbackResponse === false) {
       return redirect(`${baseUrl}/error?error=AccessDenied`)

--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -7,7 +7,7 @@ export default async (req, res, options, done) => {
   const { provider: providerName, providers, baseUrl, adapter, callbacks, csrfToken } = options
   const provider = providers[providerName]
   const { type } = provider
-  const reponseAsJson = (req.body && req.body.json === 'true') ? true : false
+  const reponseAsJson = !!((req.body && req.body.json === 'true'))
 
   if (!type) {
     res.status(500).end(`Error: Type not specified for ${provider}`)
@@ -82,16 +82,18 @@ export default async (req, res, options, done) => {
     }
 
     if (reponseAsJson) {
-      res.json({ url: `${baseUrl}/verify-request?provider=${encodeURIComponent(
+      res.json({
+        url: `${baseUrl}/verify-request?provider=${encodeURIComponent(
         provider.id
-      )}&type=${encodeURIComponent(provider.type)}` })
+      )}&type=${encodeURIComponent(provider.type)}`
+      })
     } else {
       res.status(302).setHeader(
-          'Location',
+        'Location',
           `${baseUrl}/verify-request?provider=${encodeURIComponent(
             provider.id
           )}&type=${encodeURIComponent(provider.type)}`
-        )
+      )
       res.end()
     }
     return done()

--- a/src/server/routes/signout.js
+++ b/src/server/routes/signout.js
@@ -4,7 +4,7 @@ import logger from '../../lib/logger'
 import dispatchEvent from '../lib/dispatch-event'
 
 export default async (req, res, options, done) => {
-  const { adapter, cookies, events, jwt, callbackUrl } = options
+  const { adapter, cookies, events, jwt, callbackUrl, redirect } = options
   const sessionMaxAge = options.session.maxAge
   const useJwtSession = options.session.jwt
   const sessionToken = req.cookies[cookies.sessionToken.name]
@@ -44,7 +44,5 @@ export default async (req, res, options, done) => {
     maxAge: 0
   })
 
-  res.status(302).setHeader('Location', callbackUrl)
-  res.end()
-  return done()
+  return redirect(callbackUrl)
 }

--- a/src/server/routes/signout.js
+++ b/src/server/routes/signout.js
@@ -13,7 +13,7 @@ export default async (req, res, options, done) => {
     // Dispatch signout event
     try {
       const decodedJwt = await jwt.decode({ secret: jwt.secret, token: sessionToken, maxAge: sessionMaxAge })
-      await dispatchEvent(events.signout, decodedJwt)
+      await dispatchEvent(events.signOut, decodedJwt)
     } catch (error) {
       // Do nothing if decoding the JWT fails
     }
@@ -24,7 +24,7 @@ export default async (req, res, options, done) => {
     try {
       // Dispatch signout event
       const session = await getSession(sessionToken)
-      await dispatchEvent(events.signout, session)
+      await dispatchEvent(events.signOut, session)
     } catch (error) {
       // Do nothing if looking up the session fails
     }

--- a/src/server/routes/signout.js
+++ b/src/server/routes/signout.js
@@ -4,22 +4,10 @@ import logger from '../../lib/logger'
 import dispatchEvent from '../lib/dispatch-event'
 
 export default async (req, res, options, done) => {
-  const { adapter, cookies, events, jwt, callbackUrl, csrfTokenVerified, baseUrl } = options
+  const { adapter, cookies, events, jwt, callbackUrl } = options
   const sessionMaxAge = options.session.maxAge
   const useJwtSession = options.session.jwt
   const sessionToken = req.cookies[cookies.sessionToken.name]
-
-  if (!csrfTokenVerified) {
-    // If a csrfToken was not verified with this request, send the user to
-    // the signout page, as they should have a valid one now and clicking
-    // the signout button should work.
-    //
-    // Note: Adds ?csrf=true query string param to URL for debugging/tracking.
-    // @TODO Add support for custom signin URLs
-    res.status(302).setHeader('Location', `${baseUrl}/signout?csrf=true`)
-    res.end()
-    return done()
-  }
 
   if (useJwtSession) {
     // Dispatch signout event

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -16,7 +16,7 @@ callbacks: {
   signin: async (profile, account, metadata) => { },
   redirect: async (url, baseUrl) => { },
   session: async (session, token) => { },
-  jwt: async (token, oAuthProfile) => { }
+  jwt: async (token, profile) => { }
 }
 ```
 

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -13,7 +13,7 @@ You can specify a handler for any of the callbacks below.
 
 ```js title="pages/api/auth/[...nextauth.js]"
 callbacks: {
-  signin: async (profile, account, metadata) => { },
+  signIn: async (profile, account, metadata) => { },
   redirect: async (url, baseUrl) => { },
   session: async (session, token) => { },
   jwt: async (token, profile) => { }
@@ -22,53 +22,52 @@ callbacks: {
 
 The documentation below shows how to implement each callback and their default behaviour.
 
-## Signin
+## Sign In
 
 Use the signin callback to control if a user is allowed to sign in or not.
 
-This is triggered before sign in flow completes, so the user profile may be a
-user object (with an ID) or it may be just their name and email address,
-depending on the sign in flow and if they have an account already.
+This is triggered before sign in flow completes, so the user profile may be a user object (with an ID) or it may be just their name and email address, depending on the sign in flow and if they have an account already.
 
-When using email sign in, this method is triggered both when the user requests
-to sign in and again when they activate the link in the sign in email.
+When using email sign in, this method is triggered both when the user requests to sign in and again when they activate the link in the sign in email.
 
-```js
-/**
- * @param  {object} profile  User profile (e.g. user id, name, email)
- * @param  {object} account  Account used to sign in (e.g. OAuth account)
- * @param  {object} metadata Provider specific metadata (e.g. OAuth Profile)
- * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
- *                           Return `false` to deny access
- */
-const signin = async (profile, account, metadata) => {
-  const isAllowedToSignIn = true
-  if (isAllowedToSignIn) {
-    return Promise.resolve(true)
-  } else {
-    return Promise.resolve(false)
+```js title="pages/api/auth/[...nextauth.js]"
+callbacks: {
+  /**
+   * @param  {object} profile  User profile (e.g. user id, name, email)
+   * @param  {object} account  Account used to sign in (e.g. OAuth account)
+   * @param  {object} metadata Provider specific metadata (e.g. OAuth Profile)
+   * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
+   *                           Return `false` to deny access
+   */
+  signIn: async (profile, account, metadata) => {
+    const isAllowedToSignIn = true
+    if (isAllowedToSignIn) {
+      return Promise.resolve(true)
+    } else {
+      return Promise.resolve(false)
+    }
   }
 }
 ```
 
 ## Redirect
 
-The redirect callback is called anytime the user is redirected to a callback URL
-(e.g. on signin or signout).
+The redirect callback is called anytime the user is redirected to a callback URL (e.g. on signin or signout).
 
-By default, for security, only Callback URLs on the same URL as the site are
-allowed, you can use the redirect callback to customise that behaviour.
+By default, for security, only Callback URLs on the same URL as the site are allowed, you can use the redirect callback to customise that behaviour.
 
-```js
-/**
- * @param  {string} url      URL provided as callback URL by the client
- * @param  {string} baseUrl  Default base URL of site (can be used as fallback)
- * @return {string}          URL the client will be redirect to
- */
-const redirect = async (url, baseUrl) => {
-  return url.startsWith(baseUrl)
-    ? Promise.resolve(url)
-    : Promise.resolve(baseUrl)
+```js title="pages/api/auth/[...nextauth.js]"
+callbacks: {
+  /**
+   * @param  {string} url      URL provided as callback URL by the client
+   * @param  {string} baseUrl  Default base URL of site (can be used as fallback)
+   * @return {string}          URL the client will be redirect to
+   */
+  redirect: async (url, baseUrl) => {
+    return url.startsWith(baseUrl)
+      ? Promise.resolve(url)
+      : Promise.resolve(baseUrl)
+  }
 }
 ```
 
@@ -78,20 +77,21 @@ The session callback is called whenever a session is checked.
 
 e.g. `getSession()`, `useSession()`, `/api/auth/session` (etc)
 
-If JSON Web Tokens are enabled, you can also access the decrypted token and use
-this method to pass information from the encoded token back to the client.
+If JSON Web Tokens are enabled, you can also access the decrypted token and use this method to pass information from the encoded token back to the client.
 
 The JWT callback is invoked before the session() callback is called, so anything you add to the
 JWT will be immediately available in the session callback.
 
-```js
-/**
- * @param  {object} session  Session object
- * @param  {object} token    JSON Web Token (if enabled)
- * @return {object}          Session that will be returned to the client 
- */
-const session = async (session, token) => {
-  return Promise.resolve(session)
+```js title="pages/api/auth/[...nextauth.js]"
+callbacks: {
+  /**
+   * @param  {object} session  Session object
+   * @param  {object} token    JSON Web Token (if enabled)
+   * @return {object}          Session that will be returned to the client 
+   */
+  session: async (session, token) => {
+    return Promise.resolve(session)
+  }
 }
 ```
 
@@ -104,16 +104,19 @@ e.g. `/api/auth/signin`, `getSession()`, `useSession()`, `/api/auth/session` (et
 
 * The JWT expiry time is updated / extended whenever a session is accessed.
 
-* On sign in, the raw profile object returned by the provider is also passed as a parameter.
-It is not available on subsequent calls. You can take advantage of this to persist additional data from the profile in the JWT.
+* On sign in, the raw profile for a user returned by the provider is also passed as a parameter.
 
-```js
-/**
- * @param  {object} token    Decrypted JSON Web Token
- * @param  {object} profile  Profile - only available on sign in
- * @return {object}          JSON Web Token that will be saved
- */
-const jwt = async (token, profile) => {
-  return Promise.resolve(token)
+The raw profile is not available after the initial callback that is triggered when the user signs in. You can take advantage of it beomg present on the first callback, to persist any additional data you need from the users profile in the JWT.
+
+```js title="pages/api/auth/[...nextauth.js]"
+callbacks: {
+  /**
+   * @param  {object} token    Decrypted JSON Web Token
+   * @param  {object} profile  Profile - only available on sign in
+   * @return {object}          JSON Web Token that will be saved
+   */
+  jwt: async (token, profile) => {
+    return Promise.resolve(token)
+  }
 }
 ```

--- a/www/docs/configuration/events.md
+++ b/www/docs/configuration/events.md
@@ -3,7 +3,7 @@ id: events
 title: Events
 ---
 
-Events are asynchronous functions that do not return a response, they are useful for audit logging.
+Events are asynchronous functions that do not return a response, they are useful for audit logs / reporting.
 
 ### Example
 
@@ -11,8 +11,8 @@ You can specify a handler for any of these events below - e.g. for debugging or 
 
 ```js title="pages/api/auth/[...nextauth.js]"
 events: {
-  signin: async (message) => { /* on successful sign in */ },
-  signout: async (message) => { /* on signout */ },
+  signIn: async (message) => { /* on successful sign in */ },
+  signOut: async (message) => { /* on signout */ },
   createUser: async (message) => { /* user created */ },
   linkAccount: async (message) => { /* account linked to a user */ },
   session: async (message) => { /* session is active */ },
@@ -20,4 +20,4 @@ events: {
 }
 ```
 
-The content of the message object varies depending on the flow (e.g. OAuth or Email authentication flow, JWT or database sessions, etc), but typically contains a user object and/or contents of the JSON Web Token and other information relevent to the event.
+The content of the message object varies depending on the flow (e.g. OAuth or Email authentication flow, JWT or database sessions, etc) but typically contains a user object and/or contents of the JSON Web Token and other information relevent to the event.

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -5,24 +5,27 @@ title: Options
 
 ## Environment Variables
 
-There are two options that must be set using environment variables.
+_Environment variable support was introduced in v3.0 to reduce the amount of configuration across client and server side rendered pages and API routes. Only the `NEXTAUTH_URL` environment variable is required._
 
-#### NEXTAUTH_URL (required)
+### NEXTAUTH_URL
 
-Set the `NEXTAUTH_URL` environment variable to the URL of your site.
+When deploying to production you need to set the `NEXTAUTH_URL` environment variable to the canonical URL of your site. This is required for sign in and to access sessions from API routes and server side functions.
 
-e.g. `NEXTAUTH_URL=https://example.com`
+#### Example
 
-#### NEXTAUTH_BASE_PATH (optional)
+```
+NEXTAUTH_URL=https://example.com
+```
 
-Only use `NEXTAUTH_BASE_PATH` if you cannot use `/api/auth` for your API route.
+### NEXTAUTH_BASE_PATH
 
-e.g. `NEXTAUTH_BASE_PATH=/api/auth` (default)
+If you cannot use `/api/auth` for your API route you can optionally define a different path using `NEXTAUTH_BASE_PATH`.
 
-:::note
-Environment variable configuration was introduced in v3.0 to simplify configuration across all pages and API routes.
-The `NEXTAUTH_URL` environment variable replaces the `site` option from NextAuth.js v2.
-:::
+#### Example
+
+```
+NEXTAUTH_BASE_PATH=/api/auth
+```
 
 ---
 
@@ -229,7 +232,7 @@ You can specify a handler for any of the callbacks below.
 
 ```js
 callbacks: {
-  signin: async (profile, account, metadata) => { },
+  signIn: async (profile, account, metadata) => { },
   redirect: async (url, baseUrl) => { },
   session: async (session, token) => { },
   jwt: async (token, profile) => => { }
@@ -255,8 +258,8 @@ The content of the message object varies depending on the flow (e.g. OAuth or Em
 
 ```js
 events: {
-  signin: async (message) => { /* on successful sign in */ },
-  signout: async (message) => { /* on signout */ },
+  signIn: async (message) => { /* on successful sign in */ },
+  signOut: async (message) => { /* on signout */ },
   createUser: async (message) => { /* user created */ },
   linkAccount: async (message) => { /* account linked to a user */ },
   session: async (message) => { /* session is active */ },

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -3,26 +3,32 @@ id: options
 title: Options
 ---
 
-Options are passed to NextAuth.js when initializing it in an API route.
+## Environment Variables
+
+There are two options that must be set using environment variables.
+
+#### NEXTAUTH_URL (required)
+
+Set the `NEXTAUTH_URL` environment variable to the URL of your site.
+
+e.g. `NEXTAUTH_URL=https://example.com`
+
+#### NEXTAUTH_BASE_PATH (optional)
+
+Only use `NEXTAUTH_BASE_PATH` if you cannot use `/api/auth` for your API route.
+
+e.g. `NEXTAUTH_BASE_PATH=/api/auth` (default)
 
 :::note
-The only *required* options are **site** and **providers**.
+Environment variable configuration was introduced in v3.0 to simplify configuration across all pages and API routes.
+The `NEXTAUTH_URL` environment variable replaces the `site` option from NextAuth.js v2.
 :::
+
+---
 
 ## Options
 
-### site
-
-* **Default value**: `empty string`
-* **Required**: *Yes*
-
-#### Description 
-
-The fully qualified URL for the root of your site.
-
-e.g. `http://localhost:3000` or `https://www.example.com`
-
----
+Options are passed to NextAuth.js when initializing it in an API route.
 
 ### providers
 
@@ -110,15 +116,15 @@ session: {
 
 #### Description
 
-JSON Web Tokens are only used if JWT sessions are enabled with `session: { jwt: true }` (see `session` documentation).
+Using JSON Web Tokens to store session data is often faster, cheaper and more scaleable than using a database to store sessions.
 
-The `jwt` object and all properties on it are optional.
+You can use JSON Web Tokens for session data in conjuction with a database for user data, or you can use JSON Web Tokens without a database.
 
-When enabled, JSON Web Tokens is signed with `HMAC SHA256` and encrypted with symmetric `AES`.
+JSON Web Tokens are only used if JWT sessions are enabled with `session: { jwt: true }`, or if you have not specified a database (in which case they are enabled by default).
 
-Using JWT to store sessions is often faster, cheaper and more scaleable relying on a database.
+When enabled, JSON Web Tokens are signed with **HMAC SHA256** and then encrypted with symmetric **AES**.
 
-Default values for this option are shown below:
+Default values for the JWT option are shown below:
 
 ```js
 jwt: {
@@ -161,7 +167,7 @@ An example JSON WebToken contains an encrypted payload like this:
 }
 ```
 
-You can use the built-in `getJwt()` helper method to read the token, like this:
+You can use the built-in `getJwt()` helper method to verify and decrupt the token, like this:
 
 ```js
 import jwt from 'next-auth/jwt'
@@ -169,9 +175,9 @@ import jwt from 'next-auth/jwt'
 const secret = process.env.JWT_SECRET
 
 export default async (req, res) =>  {
-  // Automatically decrypts and verifies JWT
   const token = await jwt.getJwt({ req, secret })
-  res.end(JSON.stringify(token, null, 2))
+  console.log(JSON.stringify(token, null, 2))
+  res.end()
 }
 ```
 
@@ -226,7 +232,7 @@ callbacks: {
   signin: async (profile, account, metadata) => { },
   redirect: async (url, baseUrl) => { },
   session: async (session, token) => { },
-  jwt: async (token) => => { }
+  jwt: async (token, profile) => => { }
 }
 ```
 
@@ -273,31 +279,7 @@ Set debug to `true` to enable debug messages for authentication and database ope
 
 ## Advanced Options
 
-
-:::warning
 Advanced options are passed the same way as basic options, but may have complex implications or side effects. You should try to avoid using advanced options unless you are very comfortable using them.
-:::
-
----
-
-### basePath
-
-* **Default value**: `/api/auth`
-* **Required**: *No*
-
-#### Description
-
-This option allows you to specify a different base path if you don't want to use `/api/auth` for some reason.
-
-If you set this option you **must** also configure it along with the `site` property in `pages/_app.js`
-
-```js title="pages/_app.js"
-import { config } from 'next-auth/client'
-config({ 
-  site: process.env.SITE, // e.g. 'http://localhost:3000'
-  basePath: process.env.BASE_PATH // e.g. '/api/some-other-route-name'
-})
-```
 
 ---
 
@@ -336,7 +318,7 @@ Properties on any custom `cookies` that are specified override this option.
 :::
 
 :::warning
-Setting this option to *false* in production is a security risk and may allow sessions to hijacked.
+Setting this option to *false* in production is a security risk and may allow sessions to hijacked. Using this option is not recommended.
 :::
 
 ---

--- a/www/docs/configuration/pages.md
+++ b/www/docs/configuration/pages.md
@@ -7,7 +7,7 @@ NextAuth.js automatically creates simple, unbranded authentication pages for han
 
 The options displayed on the sign up page are automatically generated based on the providers specified in the options passed to NextAuth.js.
 
-### Example
+### Configuration
 
 To add a custom login page, for example. You can use the `pages` option:
 
@@ -23,67 +23,46 @@ To add a custom login page, for example. You can use the `pages` option:
   ...
 ```
 
-## Sign in
+## Examples
 
-### OAuth sign in page
+### OAuth Sign in
 
 In order to get the available authentication providers and the URLs to use for them, you can make a request to the API endpoint `/api/auth/providers`:
 
 ```jsx title="pages/auth/signin"
 import React from 'react'
-import { providers, signin } from 'next-auth/client'
+import { providers, signIn } from 'next-auth/client'
 
 export default ({ providers }) => {
   return (
     <>
       {Object.values(providers).map(provider => (
-        <p key={provider.name}>
-          <a href={provider.signinUrl} onClick={(e) => e.preventDefault()}>
-            <button onClick={() => signin(provider.id)}>Sign in with {provider.name}</button>
-          </a>
-        </p>
+        <div key={provider.name}>
+          <button onClick={() => signIn(provider.id)}>Sign in with {provider.name}</button>
+        </div>
       ))}
     </>
   )
 }
 
-export async function getServerSideProps (context) {
+export async function getInitalProps(context) {
   return {
-    props: {
-      providers: await providers(context)
-    }
+    providers: await providers(context)
   }
 }
 ```
 
-:::tip
-The **signin()** method automatically sets the callback URL to the current page. Using a link as a fallback means it sign in can work even without client side JavaScript.
-:::
-
-### Email sign in page
+### Email Sign in
 
 If you create a custom sign in form for email sign in, you will need to submit both fields for the **email** address and **csrfToken** from **/api/auth/csrf** in a POST request to **/api/auth/signin/email**.
 
-This is easier if you use the build in `signin()` function, as it sets the CSRF token automatically.
-
-:::tip
-To create a sign in page that works on clients with and without client side JavaScript, you can use both the **signin()** method and the **csrfToken()** method
-:::
-
 ```jsx title="pages/auth/email-signin"
 import React from 'react'
-import { csrfToken, signin } from 'next-auth/client'
+import { csrfToken } from 'next-auth/client'
 
 export default ({ csrfToken }) => {
   return (
-    <form
-      method='post'
-      action='/api/auth/signin/email'
-      onSubmit={(e) => {
-        e.preventDefault()
-        signin('email', { email: document.getElementById('email').value })
-      }}
-    >
+    <form method='post' action='/api/auth/signin/email'>
       <input name='csrfToken' type='hidden' defaultValue={csrfToken}/>
       <label>
         Email address
@@ -94,11 +73,53 @@ export default ({ csrfToken }) => {
   )
 }
 
-export async function getServerSideProps (context) {
+export async function getInitalProps(context) {
   return {
-    props: {
-      csrfToken: await csrfToken(context)
-    }
+    csrfToken: await csrfToken(context)
   }
 }
+```
+
+You can also use the `signIn()` function which will handle obtaining the CSRF token for you:
+
+```js
+signIn('email', { email: 'jsmith@example.com' })
+```
+
+### Credentials Sign in
+
+If you create a sign in form for credentials based authenticaiton, you will needt to pass a **csrfToken** from **/api/auth/csrf** in a POST request to **/api/auth/callback/credentials**.
+
+```jsx title="pages/auth/credentials-signin"
+import React from 'react'
+import { csrfToken } from 'next-auth/client'
+
+export default ({ csrfToken }) => {
+  return (
+    <form method='post' action='/api/auth/callback/credentials'>
+      <input name='csrfToken' type='hidden' defaultValue={csrfToken}/>
+      <label>
+        Username
+        <input name='username' type='text'/>
+      </label>
+      <label>
+        Password
+        <input name='password' type='text'/>
+      </label>
+      <button type='submit'>Sign in</button>
+    </form>
+  )
+}
+
+export async function getInitalProps(context) {
+  return {
+    csrfToken: await csrfToken(context)
+  }
+}
+```
+
+You can also use the `signIn()` function which will handle obtaining the CSRF token for you:
+
+```js
+signIn('credentials', { username: 'jsmith', password: '1234' })
 ```

--- a/www/docs/configuration/pages.md
+++ b/www/docs/configuration/pages.md
@@ -14,8 +14,8 @@ To add a custom login page, for example. You can use the `pages` option:
 ```javascript title="pages/api/auth/[...nextauth].js"
   ...
   pages: {
-    signin: '/auth/signin',
-    signout: '/auth/signout',
+    signIn: '/auth/signin',
+    signOut: '/auth/signout',
     error: '/auth/error', // Error code passed in query string as ?error=
     verifyRequest: '/auth/verify-request', // (used for check email message)
     newUser: null // If set, new users will be directed here on first sign in

--- a/www/docs/errors.md
+++ b/www/docs/errors.md
@@ -21,34 +21,7 @@ This error occurs when the `useSession()` React Hook has a problem fetching sess
 
 #### CLIENT_FETCH_ERROR
 
-If you see `CLIENT_FETCH_ERROR` and "_TypeError: Only absolute URLs are supported_" in the console when accessing a page it means you have tried to use the client method server side without first configuring the site name in `pages/app.js` correctly.
-
-* This usually happens when calling `getSession()` from `getServerSideProps()` but the site property in the Provider in `pages/_app.js` is not set.
-
-* Check you have configured your environment variable correctly by [checking out the example project](https://github.com/iaincollins/next-auth-example) and following the instructions in the README.
-
-You should not use log bugs against `CLIENT_FETCH_ERROR` unless you are certain it is a bug in NextAuth.js.
-
-*If it works in the [live demo of the example project](https://next-auth-example.now.sh/ssr) it is not a bug in NextAuth.js*
-
-**How to use getSession() from an API Route**
-
-In the special case of calling `getSession()` in an API route, `pages/_app.js` is not used and won't help.
-
-You can use an undocumented feature called `setOptions()` in API routes to configure the site name so you can use `getSession()` in an API route. This is not yet a supported feature and it's possible it may be changed or removed in future but it exists specifically to address this problem as an interim solution.
-
-_You should not use this approach in pages, only in API routes._
-
-```js
-import { setOptions, getSession } from 'next-auth/client'
-setOptions({ site: process.env.SITE })
-
-export default async (req, res) =>  {
-  const session = await getSession({ req })
-  console.log('session', session)
-  res.end()
-}
-```
+If you see `CLIENT_FETCH_ERROR` make sure you have configured the `NEXTAUTH_URL` envionment variable.
 
 ---
 

--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -5,27 +5,6 @@ title: Client API
 
 The NextAuth.js client library makes it easy to interact with sessions from React applications.
 
-Some of the methods can be called both client side and server side.
-
-:::note
-To use client methods server side in `getServerSideProp()` or `getInitialProps()` you should add the NextAuth.js  `<Provider>` in `pages/app.js`
-
-```jsx title="pages/_app.js"
-import { Provider } from 'next-auth/client'
-
-export default ({ Component, pageProps }) => {
-  const { session } = pageProps
-  return (
-    <Provider options={{ site: process.env.SITE }} session={session} >
-      <Component {...pageProps} />
-    </Provider>
-  )
-}
-```
-
-Specify the same site name as used in the route. [Documentation for `<Provider>`](/getting-started/client#provider)
-:::
-
 ## useSession()
 
 * Client Side: **Yes**
@@ -55,7 +34,7 @@ export default () => {
 * Client Side: **Yes**
 * Server Side: **Yes**
 
-NextAuth.js also provides a `getSession()` method which can be called client or server side to return a session.
+NextAuth.js provides a `getSession()` method which can be called client or server side to return a session.
 
 It calls `/api/auth/session` and returns a promise with a session object, or null if no session exists.
 
@@ -75,8 +54,10 @@ A session object looks like this:
 
 You can call `getSession()` inside a function to check if a user is signed in, or use it for server side rendered pages that supporting signing in without requiring client side JavaScript.
 
-:::info
-Note that because it exposed to the client it does not contain sensitive information such as the Session Token or OAuth service related tokens. It includes enough information (e.g name, email) to display information on a page about the user who is signed in, and an Access Token that can be used to identify the session without exposing the Session Token itself.
+:::note
+The session data returned to the client it does not contain sensitive information such as the Session Token or OAuth tokens. It only includes enough data needed to display information on a page about the user who is signed in (e.g name, email) .
+
+You can use the [session callback](/configuration/callbacks#session) to customize the session object returned to the client if you need to add additional data to it.
 :::
 
 Because it is a Universal method, you can use `getSession()` in both client and server side functions.
@@ -126,40 +107,40 @@ It can be use useful if you are creating a dynamic custom sign in page.
 ## getCsrfToken()
 
 * Client Side: **Yes**
-* Server Side: **Yes**
+* Server Side: No
 
 The `getCsrfToken()` method returns the current Cross Site Request Forgery (CSRF Token) required to make POST requests (e.g. for signing in and signing out). It calls `/api/auth/csrf`.
 
-You likely only need to use this if you are not using the built-in `signin()` and `signout()` methods.
+You likely only need to use this if you are not using the built-in `signIn()` and `signOut()` methods.
 
 ---
 
-## signin()
+## signIn()
 
 * Client Side: **Yes**
 * Server Side: No
 
-Using the `signin()` method ensures the user ends back on the page they started on after completing a sign in flow. It will also handle CSRF tokens for you automatically when signing in with email.
+Using the `signIn()` method ensures the user ends back on the page they started on after completing a sign in flow. It will also handle CSRF tokens for you automatically when signing in with email.
 
-The `signin()` method can be called from the client in different ways, as shown below.
+The `signIn()` method can be called from the client in different ways, as shown below.
 
 #### Redirects to sign in page when clicked
 
 ```js
-import { signin } from 'next-auth/client'
+import { signIn } from 'next-auth/client'
 
 export default () => (
-  <button onClick={signin}>Sign in</button>
+  <button onClick={signIn}>Sign in</button>
 )
 ```
 
 #### Starts Google OAuth sign-in flow when clicked
 
 ```js
-import { signin } from 'next-auth/client'
+import { signIn } from 'next-auth/client'
 
 export default () => (
-  <button onClick={() => signin('google')}>Sign in with Google</button>
+  <button onClick={() => signIn('google')}>Sign in with Google</button>
 )
 ```
 
@@ -168,10 +149,10 @@ export default () => (
 When using it with the email flow, pass the target `email` as an option.
 
 ```js
-import { signin } from 'next-auth/client'
+import { signIn } from 'next-auth/client'
 
 export default ({ email }) => (
-  <button onClick={() => signin('email', { email })}>Sign in with Email</button>
+  <button onClick={() => signIn('email', { email })}>Sign in with Email</button>
 )
 ```
 
@@ -179,44 +160,40 @@ export default ({ email }) => (
 
 By default, the URL of page the client is on when they sign in is used as the `callbackUrl` and that is the URL the client will be redirected to after signing in.
 
-You can specify a different URL as the `callbackUrl` parameter by passing it in the second argument to `signin()`. This works for all calls to `signin()`.
+You can specify a different URL as the `callbackUrl` parameter by passing it in the second argument to `signIn()`. This works for all calls to `signIn()`.
 
 e.g.
 
-* `signin(null, { callbackUrl: 'http://localhost:3000/foo' })`
-* `signin('google', { callbackUrl: 'http://localhost:3000/foo' })`
-* `signin('email', { email, callbackUrl: 'http://localhost:3000/foo' })`
+* `signIn(null, { callbackUrl: 'http://localhost:3000/foo' })`
+* `signIn('google', { callbackUrl: 'http://localhost:3000/foo' })`
+* `signIn('email', { email, callbackUrl: 'http://localhost:3000/foo' })`
 
 The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect). By default this means it must be an absolute URL at the same hostname (or else it will default to the homepage); you can define your own custom redirect callback to allow other URLs, including supporting relative URLs.
 
-:::tip
-To also support signing in from clients that do not have client side JavaScript, use a regular link, add an onClick handler to it and call **e.preventDefault()** before calling the **signin()** method.
-:::
-
 ---
 
-## signout()
+## signOut()
 
 * Client Side: **Yes**
 * Server Side: No
 
-Using the `signout()` method ensures the user ends back on the page they started on after completing the sign out flow. It also handles CSRF tokens for you automatically.
+Using the `signOut()` method ensures the user ends back on the page they started on after completing the sign out flow. It also handles CSRF tokens for you automatically.
 
 It reloads the page in the browser when complete.
 
 ```js
-import { signout } from 'next-auth/client'
+import { signOut } from 'next-auth/client'
 
 export default () => (
-  <button onClick={signout}>Sign out</button>
+  <button onClick={signOut}>Sign out</button>
 )
 ```
 
 #### Specifying a callbackUrl
 
-As with the `signin()` function, you can specify a `callbackUrl` parameter by passing it as an option.
+As with the `signIn()` function, you can specify a `callbackUrl` parameter by passing it as an option.
 
-e.g. `signout({ callbackUrl: 'http://localhost:3000/foo' })`
+e.g. `signOut({ callbackUrl: 'http://localhost:3000/foo' })`
 
 The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect). By default this means it must be an absolute URL at the same hostname (or else it will default to the homepage); you can define your own custom redirect callback to allow other URLs, including supporting relative URLs.
 
@@ -228,15 +205,13 @@ Using the supplied React `<Provider>` allows instances of `useSession()` to shar
 
 This improves performance, reduces network calls and avoids page flicker when rendering. It is highly recommended and can be easily added to all pages in Next.js apps by using `pages/_app.js`.
 
-It is also *required* if you want to use client methods like `getSession()` in server side functions like `getServerSideProp()` or `getInitialProps()`.
-
 ```jsx title="pages/_app.js"
 import { Provider } from 'next-auth/client'
 
 export default ({ Component, pageProps }) => {
   const { session } = pageProps
   return (
-    <Provider options={{ site: process.env.SITE }} session={session} >
+    <Provider session={session} >
       <Component {...pageProps} />
     </Provider>
   )
@@ -247,14 +222,32 @@ If you pass the `session` page prop to the `<Provider>` – as in the example ab
 
 ### Options
 
-* `site` (required) - The URL of the site (e.g. `http://localhost:3000`)
-* `baseUrl` (optional) - The base URL for NextAuth.js (e.g. `/api/auth`)
-* `clientMaxAge` (optional) - How often to refresh the session the background (in seconds)
+You can pass options to the provider.
 
+e.g.
+
+```jsx title="pages/_app.js"
+import { Provider } from 'next-auth/client'
+
+export default ({ Component, pageProps }) => {
+  const { session } = pageProps
+  return (
+    <Provider options={{ 
+      clientMaxAge: 60 * 60 // Auto-update client state every hour
+     }} session={session} >
+      <Component {...pageProps} />
+    </Provider>
+  )
+}
+```
+
+#### clientMaxAge
+
+**clientMaxAge** defines how often (in seconds) the client should automatically refresh the session.
 
 When `clientMaxAge` is set to `0` (the default) sessions are not re-checked automatically, only when a new window or tab is opened or when `getSession()` is called. If set to any other value, specifies how many seconds the client should poll the server to check the session is valid and to keep it alive.
 
-It can be useful to use this option to prevent sessions from timing out if your application has a short session expiry time. This option usually has cost implications as checking session status triggers a call to a server side route and/or a database.
+It can be useful to use this option to prevent sessions from timing out if your application has a short session expiry time but when you want them to stay active as long as a window or tab is active. This option usually has cost implications as checking session status triggers a call to a server side route and/or a database.
 
 :::tip
 In NextAuth.js session state is automatically synchronized across all open windows and tabs in the same browser. If you have session expiry times of 30 days or more (the default) you probably don't need to use the `clientMaxAge` option, or can set it to a high value (e.g. every 24 hours).

--- a/www/docs/getting-started/example.md
+++ b/www/docs/getting-started/example.md
@@ -3,15 +3,15 @@ id: example
 title: Example
 ---
 
-## Example with live demo
+## Example project
 
 The easiest way to get started is to clone the example Next.js application from the [next-auth-example](https://github.com/iaincollins/next-auth-example) repository and to the instructions in the [README](https://github.com/iaincollins/next-auth-example/blob/main/README.md).
 
 You can find a live demo of the example project at [next-auth-example.now.sh](https://next-auth-example.now.sh)
 
-## How to use NextAuth.js
+## Adding NextAuth.js to an existing project
 
-*The examples below show how to add authentication with NextAuth.js to an existing Next.js project.*
+*The examples code below shows how to add authentication with NextAuth.js to an existing Next.js project.*
 
 ### Add API route
 
@@ -22,14 +22,13 @@ import NextAuth from 'next-auth'
 import Providers from 'next-auth/providers'
 
 const options = {
-  site: process.env.SITE || 'http://localhost:3000',
-
   // Configure one or more authentication providers
   providers: [
     Providers.GitHub({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET
     }),
+    // ...add more providers here
   ],
 
   // A database is optional, but required to persist accounts in a database
@@ -70,6 +69,17 @@ export default () => {
 ```
 
 *That's all the code you need to add authentication to a project!*
+
+### Environment variables
+
+When deploying to production, you should also set the `NEXTAUTH_URL` environment variable to the canonical URL of your site. This is required for sign in and to access sessions from API routes and server side functions.
+
+e.g. `NEXTAUTH_URL=https://example.com`
+
+:::note
+Providers like [Vercel](https://vercel.com) provide a value `VERCEL_URL` which is similar (and is used as a fallback) but is not identical as it represents the instance of the site not the canonical URL.
+:::
+
 
 :::tip
 Check out the [client documentation](/getting-started/client) to see how you can improve the user experience and page performance by using the NextAuth.js client.

--- a/www/docs/getting-started/example.md
+++ b/www/docs/getting-started/example.md
@@ -50,34 +50,42 @@ The `useSession()` React Hook in the NextAuth.js client is the easiest way to ch
 
 ```jsx title="pages/index.js"
 import React from 'react'
-import { useSession } from 'next-auth/client'
+import {
+  signIn, 
+  signOut,
+  useSession
+} from 'next-auth/client'
 
 export default () => {
   const [ session, loading ] = useSession()
 
-  return <p>
+  return <>
     {!session && <>
       Not signed in <br/>
-      <a href="/api/auth/signin">Sign in</a>
+      <button onClick={signIn}>Sign in</button>
     </>}
     {session && <>
       Signed in as {session.user.email} <br/>
-      <a href="/api/auth/signout">Sign out</a>
+      <button onClick={signOut}>Sign out</button>
     </>}
-  </p>
+  </>
 }
 ```
 
 *That's all the code you need to add authentication to a project!*
 
-### Environment variables
+### Environment Variables
 
-When deploying to production, you should also set the `NEXTAUTH_URL` environment variable to the canonical URL of your site. This is required for sign in and to access sessions from API routes and server side functions.
+When deploying to production you need to set the `NEXTAUTH_URL` environment variable to the canonical URL of your site. This is required for sign in and to access sessions from API routes and server side functions.
 
-e.g. `NEXTAUTH_URL=https://example.com`
+#### Example
+
+```
+NEXTAUTH_URL=https://example.com
+```
 
 :::note
-Providers like [Vercel](https://vercel.com) provide a value `VERCEL_URL` which is similar (and is used as a fallback) but is not identical as it represents the instance of the site not the canonical URL.
+Providers like [Vercel](https://vercel.com) provide a value `VERCEL_URL` which is similar (and is used as a fallback) but is not identical as it represents the instance of the site not the canonical URL; you need to explicitly configure `NEXTAUTH_URL` with the URL of your site in your deployment.
 :::
 
 

--- a/www/docs/getting-started/rest-api.md
+++ b/www/docs/getting-started/rest-api.md
@@ -5,27 +5,21 @@ title: REST API
 
 NextAuth.js exposes a REST API which is used by the NextAuth.js client.
 
-:::note
-The default base path is `/api/auth` but it is configurable with the `basePath` option.
-:::
-
 #### GET /api/auth/signin
 
 Displays the sign in page.
 
-#### GET /api/auth/signin/:provider
-
-Starts an OAuth signin flow for the specified provider.
-
 #### POST /api/auth/signin/:provider
 
-A POST submission is required for email sign in.
+Starts an OAuth signin flow for the specified provider.
 
 The POST submission requires CSRF token from `/api/auth/csrf`.
 
 #### GET /api/auth/callback/:provider
 
 Handles retuning requests from OAuth services during sign in.
+
+For OAuth 2.0 providers, the value of the `state` parameter is checked against the one that was generated when the sign in flow was started.
 
 #### GET /api/auth/signout
 
@@ -49,6 +43,12 @@ The CSRF token returned by this endpoint must be passed as form variable named `
 
 #### GET /api/auth/providers
 
-Returns a list of configured OAuth services and the configuration (e.g. sign in and callback URLs) for each service.
+Returns a list of configured OAuth services and details (e.g. sign in and callback URLs) for each service.
 
 It can be used to dynamically generate custom sign up pages and to check what callback URLs are configured for each OAuth provider that is configured.
+
+---
+
+:::note
+The default base path used here is `/api/auth` but it is configurable with the `basePath` option.
+:::

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -202,7 +202,6 @@ import NextAuth from 'next-auth'
 import Providers from 'next-auth/providers'
 
 const options = {
-  site: 'https://example.com',
   providers: [
     // OAuth authentication providers
     Providers.Apple({

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -175,25 +175,25 @@ function Home () {
 
 const reactComponentCode = `
 import React from 'react'
-import { 
-  useSession, 
-  signin, 
-  signout 
+import {
+  signIn, 
+  signOut,
+  useSession
 } from 'next-auth/client'
 
 export default () => {
   const [ session, loading ] = useSession()
 
-  return <p>
+  return <>
     {!session && <>
       Not signed in <br/>
-      <button onClick={signin}>Sign in</button>
+      <button onClick={signIn}>Sign in</button>
     </>}
     {session && <>
       Signed in as {session.user.email} <br/>
-      <button onClick={signout}>Sign out</button>
+      <button onClick={signOut}>Sign out</button>
     </>}
-  </p>
+  </>
 }
 `.trim()
 


### PR DESCRIPTION
## Change Log

* The `NEXTAUTH_URL` environment variable can now be set to configure all pages and routes within the application, this replaces the  `site` configuration option in version 2.0.
* Sign in routes all now use HTTP POST (instead of HTTP GET) and require Cross Site Request Forgery Tokens.
* Cross Site Request Forgery Tokens are now checked on all sign in routes - some POST routes were missing it.
* Compliance with the recommended use of the _state_ object in [RFC 6749](https://tools.ietf.org/html/rfc6749). Client state is now checked and verified on all OAuth 2.0 providers, using a value unique and known only to the client. It can be disabled for OAuth providers who do not support the option using `useState: false`.
* The Client API and the options for Events, Callbacks and Pages are all now camelCase (e.g. 'signin()' is now 'signIn()' and 'signOut' is now 'signOut()' This is a breaking change except in the case of the Client API which supports both for backwards compatibility.  Configuration of Events, Callbacks and Pages should be updated.
* Improved client event handling for reduced network and memory footprint, while improving automatic session state syncing in clients and across tabs/windows.
* Changes include refactored event handler logic and improved `clientMaxAge` behaviour (now more passive / efficient) and new `keepAlive` option. Users with short session expiry times will benefit the most from these changes.
* The documentation and example code has been updated and examples improved and expanded.
