### PR TITLE
feat(jwt): Add support for authorization header

### DIFF
--- a/src/lib/jwt.js
+++ b/src/lib/jwt.js
@@ -26,12 +26,20 @@ const getJwt = async ({ req, secret, cookieName, maxAge }) => {
 
   const secureCookieName = '__Secure-next-auth.session-token'
   const insecureCookieName = 'next-auth.session-token'
-  const cookieValue = cookieName ? req.cookies[cookieName] : req.cookies[secureCookieName] || req.cookies[insecureCookieName]
+  let token = cookieName ? req.cookies[cookieName] : req.cookies[secureCookieName] || req.cookies[insecureCookieName]
 
-  if (!cookieValue) { return null }
+  if (!token) {
+    // Check authorization header if no cookie is present
+    if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
+      const urlEncodedToken = req.headers.authorization.split(' ')[1]
+      token = decodeURIComponent(urlEncodedToken)
+    }
+  }
+
+  if (!token) { return null }
 
   try {
-    return await decode({ secret, token: cookieValue, maxAge })
+    return await decode({ secret, token, maxAge })
   } catch (error) {
     return null
   }

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -175,6 +175,8 @@ export default async (req, res) =>  {
 }
 ```
 
+The built-in `getJwt()` helper method will check for an exisiting cookie first, and if that's not found it will check for an `authorization` header with a `Bearer` token. This way you can easily secure e.g. API routes and use a standalone REST/GraphQL client to explore your data.
+
 :::note
 The JWT is stored in the Session Token cookie – the same cookie used for database sessions.
 :::


### PR DESCRIPTION
Been toying with using [Nexus](https://github.com/graphql-nexus/nexus) together with [Prisma](https://www.prisma.io/). Nexus is a graphql server you can use together with Next.js, as illustrated here: https://github.com/graphql-nexus/examples/tree/master/with-nextjs-and-vercel-and-plugins-prisma

I wanted to secure the graphql api so I decided to use https://github.com/Camji55/nexus-plugin-jwt-auth which uses bearer tokens by default, but is able to take in a custom `verify` function which is perfect to use with `getJwt` from next-auth.

I am currently using next-auth like this in nexus:
```javascript
use(
  auth({
    appSecret: secret,
    protectedPaths,
    verify: async (req) => {
      try {
        let token
        if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
          const encodedToken = req.headers.authorization.split(' ')[1]
          const urlDecodedToken = decodeURIComponent(encodedToken)
          token = await decode({ secret, key: secret, token: urlDecodedToken })
        } else {
          token = await getJwt({ req, secret })
        }

        if (token) {
          return token
        } else {
          return {
            token: null,
          }
        }
      } catch (error) {
        console.error(error)
        return {
          token: null,
        }
      }
    },
  })
)
```

but figured there might be more use cases for people to use bearer tokens and since the extra code was minimal to make it work.

With a modified `getJwt` I can reduce the above code to become:
```javascript
use(
  auth({
    appSecret: secret,
    protectedPaths,
    verify: async (req) => await getJwt({ req, secret }),
  })
)

```

Feel free to close the PR if this isn't something you want.