### PR TITLE
Fix using merged models var instead of user provided models in props

### DIFF
--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -28,7 +28,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
   // anything to do them). This function updates arguments by reference.
   adapterTransform(typeOrmConfigObject, models, options)
 
-  const config = adapterConfig.loadConfig(typeOrmConfigObject, { models, ...options })
+  const config = adapterConfig.loadConfig(typeOrmConfigObject, { ...options, models })
 
   // Create objects from models that can be consumed by functions in the adapter
   const User = models.User.model


### PR DESCRIPTION
While researching how to use custom models found a tiny bug.

When you specify a `model` prop in your adapter initialization, this prop gets preference used in the spread in L32 instead of the previously built/merged `models` variable.

Putting the spread at the beginning and `models` later will make sure that we overwrite whatever the user custom models are with the merged object from default/user provided.

Happy to fix any wording or whatever else is needed, working on a Tutorial for the usage of custom models also.