### PR TITLE
Add tutorial on how to use custom typeorm models

### DIFF
--- a/www/docs/tutorials/custom-typeorm-models.md
+++ b/www/docs/tutorials/custom-typeorm-models.md
@@ -1,0 +1,80 @@
+---
+id: custom-typeorm-models
+title: Custom TypeORM Models
+---
+
+## Using Custom TypeORM Models
+
+NextAuth.js provides TypeORM models based on [the default tables](https://next-auth.js.org/schemas/models).
+
+You can pass in models extending the defaults by specifying the `models` property on your `adapter` configuration object as the second parameter.
+
+```js title="api/auth/[...nextauth].js"
+import NextAuth from "next-auth";
+import Providers from "next-auth/providers";
+import Adapters from "next-auth/adapters";
+
+import Models from "../../../models";
+
+const options = {
+  providers: [
+    // your providers
+  ],
+
+  adapter: Adapters.TypeORM.Adapter(
+    {
+      // first argument are your database options
+      database: "your-database-string",
+    },
+    {
+      // second argument are your custom adapter options
+      models: {
+        User: Models.User,
+      },
+    }
+  ),
+};
+
+export default (req, res) => NextAuth(req, res, options);
+```
+
+```js title="models/User.js"
+import Adapters from "next-auth/adapters";
+
+// you can also just re export the default model
+export default class User extends Adapters.TypeORM.Models.User.model {
+  // default required fields for the model
+  constructor(name, email, image, emailVerified) {
+    super(name, email, image, emailVerified);
+  }
+}
+
+export const UserSchema = {
+  name: "User",
+  target: User,
+  columns: {
+    // we're extending the default columns here
+    ...Adapters.TypeORM.Models.User.schema.columns,
+    phoneNumber: {
+      type: "varchar",
+      nullable: true,
+    },
+  },
+};
+```
+
+```js title="models/index.js"
+// we're following the same structure as NextAuth.js
+import User, { UserSchema } from "./User";
+
+export default {
+  User: {
+    model: User,
+    schema: UserSchema,
+  },
+};
+```
+
+:::note
+You can find all the default models [here](https://github.com/iaincollins/next-auth/tree/main/src/adapters/typeorm/models)
+:::

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -42,7 +42,10 @@ module.exports = {
       "schemas/mongodb",
       "schemas/adapters",
     ],
-    Tutorials: ["tutorials/testing"],
+    Tutorials: [
+      "tutorials/testing",
+      "tutorials/custom-typeorm-models",
+    ],
     /*
     'Version 1 (Legacy)': [
       'v1/getting-started-v1',


### PR DESCRIPTION
Docs on how to use custom typeorm models, goes only as far as specifying how to pass in a custom model, how to extend/inherit from the default ones.

The rest should be up to your typeorm expertise/goals

Maybe I should add a warning about overriding the default properties as they might break something?

Fixes https://github.com/iaincollins/next-auth/issues/283