### PR TITLE
Fix wrong syntax in Apple provider example

### DIFF
--- a/www/docs/providers/apple.md
+++ b/www/docs/providers/apple.md
@@ -169,7 +169,7 @@ app.prepare().then(() => {
     if (err) throw err
     console.log('> Ready on https://localhost:3000')
   })
-}
+})
 ```
 
 ### Example JWT code


### PR DESCRIPTION
It fixes a syntax error in Apple provider example code.