### PR TITLE
Use id_str for reading in Twitter user ID

### DIFF
--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -8,10 +8,11 @@ export default (options) => {
     accessTokenUrl: 'https://api.twitter.com/oauth/access_token',
     requestTokenUrl: 'https://api.twitter.com/oauth/request_token',
     authorizationUrl: 'https://api.twitter.com/oauth/authenticate',
-    profileUrl: 'https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true',
+    profileUrl:
+      'https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true',
     profile: (profile) => {
       return {
-        id: profile.id,
+        id: profile.id_str,
         name: profile.name,
         email: profile.email,
         image: profile.profile_image_url_https.replace(/_normal\.jpg$/, '.jpg')


### PR DESCRIPTION
Hey there!

I ran into a problem authenticating with a newer account on Twitter. The ID of the account is `948493988897554433`, but that number can't be represented in JavaScript (evaluates to `948493988897554400`). As a workaround, we can read in the string value, `id_str`. See https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/user-object

The additional change came from running `yarn run lint --fix`.