### PR TITLE
Refactor JWT support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0-beta.16",
+  "version": "3.0.0-beta.17",
   "description": "An authentication library for Next.js",
   "repository": "https://github.com/iaincollins/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",

--- a/src/providers/email.js
+++ b/src/providers/email.js
@@ -25,7 +25,7 @@ export default (options) => {
 const sendVerificationRequest = ({ identifier: email, url, baseUrl, provider }) => {
   return new Promise((resolve, reject) => {
     const { server, from } = provider
-     // Strip protocol from URL and use domain as site name
+    // Strip protocol from URL and use domain as site name
     const site = baseUrl.replace(/^https?:\/\//, '')
 
     nodemailer

--- a/src/providers/spotify.js
+++ b/src/providers/spotify.js
@@ -15,8 +15,8 @@ export default (options) => {
         id: profile.id,
         name: profile.display_name,
         email: profile.email,
-        image: profile.images[0].url,
-      };
+        image: profile.images[0].url
+      }
     },
     ...options
   }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -121,6 +121,7 @@ export default async (req, res, userSuppliedOptions) => {
     const jwtOptions = {
       secret,
       key: secret,
+      encryption: 'AES', // One of [ 'AES', false ] (default 'AES')
       encode: jwt.encode,
       decode: jwt.decode,
       ...userSuppliedOptions.jwt

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -69,7 +69,7 @@ export default async (req, res, options, done) => {
             const jwtPayload = await callbacks.jwt(defaultJwtPayload, OAuthProfile)
 
             // Sign and encrypt token
-            const newEncodedJwt = await jwt.encode({ secret: jwt.secret, token: jwtPayload, maxAge: sessionMaxAge })
+            const newEncodedJwt = await jwt.encode({ secret: jwt.secret, key: jwt.key, token: jwtPayload, maxAge: sessionMaxAge, encryption: jwt.encryption })
 
             // Set cookie expiry date
             const cookieExpires = new Date()
@@ -148,7 +148,7 @@ export default async (req, res, options, done) => {
         const jwtPayload = await callbacks.jwt(defaultJwtPayload)
 
         // Sign and encrypt token
-        const newEncodedJwt = await jwt.encode({ secret: jwt.secret, token: jwtPayload, maxAge: sessionMaxAge })
+        const newEncodedJwt = await jwt.encode({ secret: jwt.secret, key: jwt.key, token: jwtPayload, maxAge: sessionMaxAge, encryption: jwt.encryption })
 
         // Set cookie expiry date
         const cookieExpires = new Date()
@@ -222,7 +222,7 @@ export default async (req, res, options, done) => {
     const jwtPayload = await callbacks.jwt(defaultJwtPayload)
 
     // Sign and encrypt token
-    const newEncodedJwt = await jwt.encode({ secret: jwt.secret, token: jwtPayload, maxAge: sessionMaxAge })
+    const newEncodedJwt = await jwt.encode({ secret: jwt.secret, key: jwt.key, token: jwtPayload, maxAge: sessionMaxAge, encryption: jwt.encryption })
 
     // Set cookie expiry date
     const cookieExpires = new Date()

--- a/src/server/routes/session.js
+++ b/src/server/routes/session.js
@@ -19,7 +19,7 @@ export default async (req, res, options, done) => {
   if (useJwtSession) {
     try {
       // Decrypt and verify token
-      const decodedJwt = await jwt.decode({ secret: jwt.secret, token: sessionToken, maxAge: sessionMaxAge })
+      const decodedJwt = await jwt.decode({ secret: jwt.secret, key: jwt.key, token: sessionToken, maxAge: sessionMaxAge, encryption: jwt.encryption })
 
       // Generate new session expiry date
       const sessionExpiresDate = new Date()
@@ -45,7 +45,7 @@ export default async (req, res, options, done) => {
       response = sessionPayload
 
       // Refresh JWT expiry by re-signing it, with an updated expiry date
-      const newEncodedJwt = await jwt.encode({ secret: jwt.secret, token: jwtPayload, maxAge: sessionMaxAge })
+      const newEncodedJwt = await jwt.encode({ secret: jwt.secret, key: jwt.key, token: jwtPayload, maxAge: sessionMaxAge, encryption: jwt.encryption })
 
       // Set cookie, to also update expiry date on cookie
       cookie.set(res, cookies.sessionToken.name, newEncodedJwt, { expires: sessionExpires, ...cookies.sessionToken.options })

--- a/src/server/routes/signout.js
+++ b/src/server/routes/signout.js
@@ -12,7 +12,7 @@ export default async (req, res, options, done) => {
   if (useJwtSession) {
     // Dispatch signout event
     try {
-      const decodedJwt = await jwt.decode({ secret: jwt.secret, token: sessionToken, maxAge: sessionMaxAge })
+      const decodedJwt = await jwt.decode({ secret: jwt.secret, key: jwt.key, token: sessionToken, maxAge: sessionMaxAge, encryption: jwt.encryption })
       await dispatchEvent(events.signOut, decodedJwt)
     } catch (error) {
       // Do nothing if decoding the JWT fails

--- a/www/docs/faq.md
+++ b/www/docs/faq.md
@@ -134,6 +134,8 @@ As with database session tokens, JSON Web Tokens are limited in the amount of da
 
 JSON Web Tokens are signed (to prevent tampering) and the contents encoded using Base64, but JSON Web Tokens are not encrypted on their own - anyone with access to a token can decode it and read the contents.
 
-NextAuth.js implements [JSON Web Tokens (RFC 7519)](https://tools.ietf.org/html/rfc7519) using the sign-then-encrypt model. By default, it currently uses [Advanced Encryption Standard (RFC 3826)](https://tools.ietf.org/html/rfc3826) rather than [JSON Web Encryption (RFC 7516)](https://tools.ietf.org/html/rfc7516) for encryption, but you can define custom encoding and decoding routines for JSON Web Tokens to use any encryption methods (or none).
+NextAuth.js implements [JSON Web Tokens (RFC 7519)](https://tools.ietf.org/html/rfc7519) by default uses a sign-then-encrypt model using the [Advanced Encryption Standard (RFC 3826)](https://tools.ietf.org/html/rfc3826) to encrypt tokens to ensure data is encoded securely by default. 
 
-For example, if you want to use tokens that are signed (but not encrypted) so they can be more easily used by other services running on the same domain (and it is secure to do so) you can specify custom encode and decode functions that implement signing only.
+You can define custom encoding and decoding routines for JSON Web Tokens to use any encryption method (e.g. [JSON Web Encryption (RFC 7516)](https://tools.ietf.org/html/rfc7516)).
+
+You can disable encryption on tokens by setting the encryption option on the JWT to false. It can be useful to use tokens that are signed (but not encrypted) if you want them to be shared services running on the same domain, as long as the tokens do not contain sensitive information (e.g. secret tokens or API keys).

--- a/www/src/components/ProviderMarquee.js
+++ b/www/src/components/ProviderMarquee.js
@@ -17,7 +17,7 @@ const icons = [
   '/img/providers/openid.svg',
   '/img/providers/slack.svg',
   '/img/providers/spotify.svg',
-  '/img/providers/twitter.svg',
+  '/img/providers/twitter.svg'
 ]
 
 const ProviderMarquee = React.memo(({ size }) => {

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -111,7 +111,7 @@ function Home () {
           </div>
         </div>
         <div className='hero-wave'>
-          <div className="hero-wave-inner"/>
+          <div className='hero-wave-inner' />
         </div>
       </header>
       <main className='home-main'>
@@ -153,7 +153,7 @@ function Home () {
             </div>
             <div className='row'>
               <div className='col'>
-                <p className='text--center' style={{marginTop: '2rem'}}>
+                <p className='text--center' style={{ marginTop: '2rem' }}>
                   <Link
                     to='/getting-started/example'
                     className='button button--primary button--lg rounded-pill'


### PR DESCRIPTION
## Changes

* Adds option to disable encryption
* Easy to add custom helper
* Removed getJWT helper
* Added getToken helper
* Helper does not fallback to trying non-prefixed cookie on HTTPS sites
* Supports bearer tokens in HTTP header on helper #397

## getToken() Example

```js
import jwt from 'next-auth/jwt'

const secret = process.env.JWT_SECRET

export default async (req, res) => {
  const token = await jwt.getToken({ req, secret })
  console.log('JSON Web Token', token)
  res.end()
}
```

**Update:** This should work as of `next-auth@3.0.0-beta.18`.

(The branching was handled incorrectly and the merge included an extra commit it shouldn't have.)