### PR TITLE
fallback if user.name is null

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -11,7 +11,7 @@ export default (options) => {
     profile: (profile) => {
       return {
         id: profile.id,
-        name: profile.name,
+        name: profile.name || profile.login,
         email: profile.email,
         image: profile.avatar_url
       }


### PR DESCRIPTION
Github user profiles may not have a user name (can be null), but they always have a login name. Login name should be used as default or at least as a fallback method.