### PR TITLE
Improve TypeORM adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6444,7 +6444,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "dev": true,
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -6453,8 +6452,7 @@
         "resolve-from": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-          "dev": true
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,11 +47,17 @@
     "preact": "^10.4.1",
     "preact-render-to-string": "^5.1.7",
     "querystring": "^0.2.0",
+    "require_optional": "^1.0.1",
     "typeorm": "^0.2.24"
   },
   "peerDependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
+  },
+  "peerOptionalDependencies": {
+    "mongodb": "^3.5.9",
+    "mysql": "^2.18.1",
+    "pg": "^8.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/adapters/typeorm/lib/config.js
+++ b/src/adapters/typeorm/lib/config.js
@@ -53,7 +53,7 @@ const parseConnectionString = (configString) => {
 
 const loadConfig = (config, { models, namingStrategy }) => {
   const defaultConfig = {
-    name: 'default',
+    name: 'nextauth',
     autoLoadEntities: true,
     entities: [
       new EntitySchema(models.User.schema),


### PR DESCRIPTION
## Changes

* Uses `require_optional` and `peerOptionalDependencies` instead of dynamic import to resolve issue some users have experience with using using compliers/bundlers (especially on starter projects) that don't handle dynamic imports well.

  This should (hopefully) also make it easier to support older versions of Internet Explorer by avoiding bundlers that choke on dynamic imports unless MongoDB is included as a dependancy (even though it's not code they need to compile).

  We use `require_optional` to load `ObjectID` conditionally, if NextAuth.js is using MongoDB. This is also exactly how the MongoDB driver itself loads the ObjectID from the `bson/bson-ext` module.

  Should resolve #251
    
* The default name for the TypeORM connection is now 'nextauth' instead of 'default'.

  This should help people avoid problems with connection re-use when not using serverless (including in local development), especially if they are doing things with their default connection that differ from whats expected by NextAuth.js (like not using UTF-8 for encoding or UTC timezones).

* Now uses connection manager object from the connection, to allow a custom TypeORM connection name to be specified (resolves #459).

## Testing

I've done smoke testing with MongoDB, Postgres and MySQL.


We should do further production testing on this while testing the v3 branch.