### PR TITLE
Adapter improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
     "test:db:postgres": "node test/postgres.js",
     "test:db:mongodb": "node test/mongodb.js",
     "db:start": "docker-compose -f test/docker/docker-compose.yml up -d",
+    "db:start:mongo": "docker-compose -f test/docker/mongo.yml up -d",
+    "db:start:mysql": "docker-compose -f test/docker/mysql.yml up -d",
+    "db:start:postgres": "docker-compose -f test/docker/postgres.yml up -d",
     "db:stop": "docker-compose -f test/docker/docker-compose.yml down",
+    "db:stop:mongo": "docker-compose -f test/docker/mongo.yml down",
+    "db:stop:mysql": "docker-compose -f test/docker/mysql.yml down",
+    "db:stop:postgres": "docker-compose -f test/docker/postgres.yml down",
     "prepublishOnly": "npm run build",
     "publish:beta": "npm publish --tag beta",
     "publish:canary": "npm publish --tag canary",
@@ -57,7 +63,8 @@
   "peerOptionalDependencies": {
     "mongodb": "^3.5.9",
     "mysql": "^2.18.1",
-    "pg": "^8.2.1"
+    "pg": "^8.2.1",
+    "@prisma/client": "^2.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/test/fixtures/schemas/mysql.json
+++ b/test/fixtures/schemas/mysql.json
@@ -15,7 +15,7 @@
       "default": null
     },
     "email_verified": {
-      "type": "timestamp",
+      "type": "timestamp(6)",
       "nullable": true,
       "default": null
     },
@@ -69,7 +69,7 @@
       "default": null
     },
     "access_token_expires": {
-      "type": "timestamp",
+      "type": "timestamp(6)",
       "nullable": true,
       "default": null
     },
@@ -92,7 +92,7 @@
       "nullable": false
     },
     "expires": {
-      "type": "timestamp",
+      "type": "timestamp(6)",
       "nullable": false
     },
     "session_token": {
@@ -126,7 +126,7 @@
       "nullable": false
     },
     "expires": {
-      "type": "timestamp",
+      "type": "timestamp(6)",
       "nullable": false
     },
     "created_at": {

--- a/test/fixtures/sql/mysql.sql
+++ b/test/fixtures/sql/mysql.sql
@@ -1,0 +1,74 @@
+CREATE TABLE accountsshould be
+  (
+    id                   INT NOT NULL AUTO_INCREMENT,
+    compound_id          VARCHAR(255) NOT NULL,
+    user_id              INTEGER NOT NULL,
+    provider_type        VARCHAR(255) NOT NULL,
+    provider_id          VARCHAR(255) NOT NULL,
+    provider_account_id  VARCHAR(255) NOT NULL,
+    refresh_token        TEXT,
+    access_token         TEXT,
+    access_token_expires TIMESTAMP(6),
+    created_at           TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at           TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
+
+CREATE TABLE sessions
+  (
+    id            INT NOT NULL AUTO_INCREMENT,
+    user_id       INTEGER NOT NULL,
+    expires       TIMESTAMP(6) NOT NULL,
+    session_token VARCHAR(255) NOT NULL,
+    access_token  VARCHAR(255) NOT NULL,
+    created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
+
+CREATE TABLE users
+  (
+    id             INT NOT NULL AUTO_INCREMENT,
+    name           VARCHAR(255),
+    email          VARCHAR(255),
+    email_verified TIMESTAMP(6),
+    image          VARCHAR(255),
+    created_at     TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at     TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
+
+CREATE TABLE verification_requests
+  (
+    id         INT NOT NULL AUTO_INCREMENT,
+    identifier VARCHAR(255) NOT NULL,
+    token      VARCHAR(255) NOT NULL,
+    expires    TIMESTAMP(6) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
+
+CREATE UNIQUE INDEX compound_id
+  ON accounts(compound_id);
+
+CREATE INDEX provider_account_id
+  ON accounts(provider_account_id);
+
+CREATE INDEX provider_id
+  ON accounts(provider_id);
+
+CREATE INDEX user_id
+  ON accounts(user_id);
+
+CREATE UNIQUE INDEX session_token
+  ON sessions(session_token);
+
+CREATE UNIQUE INDEX access_token
+  ON sessions(access_token);
+
+CREATE UNIQUE INDEX email
+  ON users(email);
+
+CREATE UNIQUE INDEX token
+  ON verification_requests(token);

--- a/test/fixtures/sql/postgres.sql
+++ b/test/fixtures/sql/postgres.sql
@@ -1,0 +1,74 @@
+CREATE TABLE accounts
+  (
+    id                   SERIAL,
+    compound_id          VARCHAR(255) NOT NULL,
+    user_id              INTEGER NOT NULL,
+    provider_type        VARCHAR(255) NOT NULL,
+    provider_id          VARCHAR(255) NOT NULL,
+    provider_account_id  VARCHAR(255) NOT NULL,
+    refresh_token        TEXT,
+    access_token         TEXT,
+    access_token_expires TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
+
+CREATE TABLE sessions
+  (
+    id            SERIAL,
+    user_id       INTEGER NOT NULL,
+    expires       TIMESTAMPTZ NOT NULL,
+    session_token VARCHAR(255) NOT NULL,
+    access_token  VARCHAR(255) NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
+
+CREATE TABLE users
+  (
+    id             SERIAL,
+    name           VARCHAR(255),
+    email          VARCHAR(255),
+    email_verified TIMESTAMPTZ,
+    image          VARCHAR(255),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
+
+CREATE TABLE verification_requests
+  (
+    id         SERIAL,
+    identifier VARCHAR(255) NOT NULL,
+    token      VARCHAR(255) NOT NULL,
+    expires    TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
+
+CREATE UNIQUE INDEX compound_id
+  ON accounts(compound_id);
+
+CREATE INDEX provider_account_id
+  ON accounts(provider_account_id);
+
+CREATE INDEX provider_id
+  ON accounts(provider_id);
+
+CREATE INDEX user_id
+  ON accounts(user_id);
+
+CREATE UNIQUE INDEX session_token
+  ON sessions(session_token);
+
+CREATE UNIQUE INDEX access_token
+  ON sessions(access_token);
+
+CREATE UNIQUE INDEX email
+  ON users(email);
+
+CREATE UNIQUE INDEX token
+  ON verification_requests(token);

--- a/test/mongodb.js
+++ b/test/mongodb.js
@@ -4,15 +4,17 @@ const Adapters = require('../adapters')
 
 ;(async () => {
   try {
-    // @FIXME Does not actally bail on connection error, adapter *should* throw exception
-    // Before that is addressed, we should make sure all routes in the app that
-    // call getAdapter() or rely on methods that use getAdapter() will handle
-    // a connection error gracefully.
-    const adapter1 = Adapters.Default('mongodb+srv://nextauth:password@127.0.0.1:27017/nextauth?ssl=false&retryWrites=true')
-    await adapter1.getAdapter()
+    // We can't connection a local MongoDB SRV instance but we can at least see if the URLs cause an error
+    Adapters.Default('mongodb+srv://nextauth:password@127.0.0.1/nextauth?ssl=false&retryWrites=true')
 
-    const adapter2 = Adapters.Default('mongodb://nextauth:password@127.0.0.1:27017/nextauth?synchronize=true')
-    await adapter2.getAdapter()
+    // Connect to local MongoDB instance
+    // Note: MongoDB doesn't thrown a connection error right away if is a 
+    // problem with the credentials or host configuration, but after a few
+    // seconds it throws a Timeout error (which is caught by the adapter).
+    const adapter = Adapters.Default('mongodb://nextauth:password@127.0.0.1:27017/nextauth?synchronize=true')
+    await adapter.getAdapter()
+
+    // @TODO create objects in database, check format of objects returned
 
     console.log('MongoDB loaded ok')
     process.exit()

--- a/www/docs/configuration/databases.md
+++ b/www/docs/configuration/databases.md
@@ -3,70 +3,45 @@ id: databases
 title: Databases
 ---
 
-## About databases in NextAuth.js
+NextAuth.js comes with multiple ways of connecting to a database:
 
-### What is a database used for?
+* **TypeORM** (default) - MySQL, Postgres, SQLite, MongoDB
+* **Prisma** - MySQL, Postgres, SQLite
+* **Custom Adapter** - Connect to any database
 
-Databases in NextAuth.js are used for persisting users, oauth accounts, email sign in tokens and sessions.
+**This document covers the default adapter (TypeORM).**
 
-Specifying a database is optional if you don't need to persist user data or support email sign in - if you don't specify a database then JSON Web Tokens will be enabled for session storage and used to store session data.
+See the [documentation for adapters](/schemas/adapters) to learn more about using Prisma adapter or using a custom adapter.
 
-:::note
-If you do specify a database then database sessions are be enabled by default, unless you explicitly enable JSON Web Tokens for sessions by passing the option `sessions { jwt: true }`.
+To learn more about databases in NextAuth.js and how they are used, check out [databases in the FAQ](/faq#databases).
 
-If you enable JWT sessions when using a database then accounts will still be persisted in database but stateless sessions will be used on the client. Using JSON Web Tokens in Serverless applications is often less expensive and performs better than database sessions.
-:::
+---
 
-### Should I use a database?
-
-* Using NextAuth.js without a database works well for internal tools - where you need to control who is able to sign in, but when you do not need to create user accounts for them in your application.
-
-* Using NextAuth.js with a database is usually a better approach for a consumer facing application where you need to persist accounts (e.g. for billing, to contact customers, etc).
-
-### What database should I use?
-
-Managed database solutions for MySQL, Postgres and MongoDB are well supported from cloud providers such as Amazon, Google, Microsoft and Atlas. If you are deploying directly to a particular cloud platform you may also want to consider serverless database offerings they have (e.g. [Amazon Aurora Serverless on AWS](https://aws.amazon.com/rds/aurora/serverless/)).
-
-## How to specify a database
+## How to use a database
 
 You can specify database credentials as as a connection string or a [TypeORM configuration](https://github.com/typeorm/typeorm/blob/master/docs/using-ormconfig.md) object.
 
 The following approaches are exactly equivalent:
 
 ```js
-database: 'mysql://username:password@127.0.0.1:3306/database_name?synchronize=true'
+database: 'mysql://username:password@127.0.0.1:3306/database_name'
 ```
 
 ```js
 database: {
   type: 'mysql',
-  host: "127.0.0.1",
+  host: '127.0.0.1',
   port: 3306,
-  username: "nextauth",
-  password: "password",
-  database: "nextauth",
-  synchronize: true
+  username: 'nextauth',
+  password: 'password',
+  database: 'nextauth'
 }
 ```
 
-:::note
-See the [TypeORM configuration documentation](https://github.com/typeorm/typeorm/blob/master/docs/using-ormconfig.md) for all the supported database options.
-:::
-
-## Setting up a database
-
-NextAuth.js will configure your database with tables / collections automatically if `synchronize: true` is set.
-
-If you are having problems connecting to your database, try enabling debug message with the `debug: true` option when initializing NextAuth.js.
-
-:::warning
-The option **?synchronize=true** automatically synchronizes the database schema with what NextAuth.js expects. It is useful to create the tables you need in the database on first run against a test database but it should not be enabled in production as it may result in data loss.
-:::
-
 :::tip
-If you want to set a prefix for all table names you can use the TypeORM **entityPrefix** option.
+You can pass in any valid [TypeORM configuration option](https://github.com/typeorm/typeorm/blob/master/docs/using-ormconfig.md).
 
-*For example:*
+*e.g. To set a prefix for all table names you can use the **entityPrefix** option as connection string parameter:*
 
 ```js
 'mysql://username:password@127.0.0.1:3306/database_name?entityPrefix=nextauth_'
@@ -77,25 +52,106 @@ If you want to set a prefix for all table names you can use the TypeORM **entity
 ```js
 database: {
   type: 'mysql',
-  host: "127.0.0.1",
+  host: '127.0.0.1',
   port: 3306,
-  username: "nextauth",
-  password: "password",
-  database: "nextauth",
-  synchronize: true,
+  username: 'nextauth',
+  password: 'password',
+  database: 'nextauth'
   entityPrefix: 'nextauth_'
 }
 ```
-
 :::
+
+---
+
+## Setting up a database
+
+Running SQL to create your tables and columns is the recommended way to set up an SQL database.
+
+* [MySQL Schema](/schemas/mysql)
+* [Postgress Schema](/schemas/mysql)
+
+_If you are running SQLite, MongoDB or a Document database you can skip this step._
+
+You can also have your tables and schemas created automatically using the `synchronize: true` option:
+
+```js
+database: 'mysql://username:password@127.0.0.1:3306/database_name?synchronize=true'
+```
+
+```js
+database: {
+  type: 'mysql',
+  host: '127.0.0.1',
+  port: 3306,
+  username: 'nextauth',
+  password: 'password',
+  database: 'nextauth',
+  synchronize: true
+}
+```
+
+:::warning
+**The `synchronize` option should not be used against production databases.**
+
+It is useful to create the tables you need in the database when setting one up for the first time, but it should not be enabled against production databases as it may result in data loss if there is a difference between the schema on in the database and the schema that NextAuth.js is expecting.
+:::
+
+---
 
 ## Supported databases
 
-NextAuth.js uses TypeORM as the default database adapter, but only some databases supported by TypeORM are supported by NextAuth.js (as custom logic for creating indexes and date/time handling is required).
+The default database adapter is TypeORM, but only some databases supported by TypeORM are supported by NextAuth.js as custom logic needs to be handled by NextAuth.js.
+
+Databases compatible with MySQL, Postgres and MongoDB should work out of the box with NextAuth.js. When used with any other database, NextAuth.js will assume an ANSI SQL compatible database.
 
 :::tip
 When configuring your database you also need to install an appropriate **node module** for your database.
 :::
+
+### MySQL
+
+Install module:
+`npm i mysql`
+
+#### Example
+
+```js
+database: 'mysql://username:password@127.0.0.1:3306/database_name'
+```
+
+### MariaDB
+
+Install module:
+`npm i mariadb`
+
+#### Example
+
+```js
+database: 'mariadb://username:password@127.0.0.1:3306/database_name'
+```
+
+### Postgres
+
+Install module:
+`npm i pg`
+
+#### Example
+
+```js
+database: 'postgres://username:password@127.0.0.1:3306/database_name'
+```
+
+### MongoDB
+
+Install module:
+`npm i mongodb`
+
+#### Example
+
+```js
+database: 'mongodb://username:password@127.0.0.1:3306/database_name'
+```
 
 ### SQLite
 
@@ -107,54 +163,11 @@ Install module:
 #### Example
 
 ```js
-database: 'sqlite://localhost/:memory:?synchronize=true'
+database: 'sqlite://localhost/:memory:'
 ```
 
-### MySQL
+---
 
-Install module:
-`npm i mysql`
-
-#### Example
-
-```js
-database: 'mysql://username:password@127.0.0.1:3306/database_name?synchronize=true'
-```
-
-### MariaDB
-
-Install module:
-`npm i mariadb`
-
-#### Example
-
-```js
-database: 'mariadb://username:password@127.0.0.1:3306/database_name?synchronize=true'
-```
-
-### Postgres
-
-Install module:
-`npm i pg`
-
-#### Example
-
-```js
-database: 'postgres://username:password@127.0.0.1:3306/database_name?synchronize=true'
-```
-
-### MongoDB
-
-Install module:
-`npm i mongodb`
-
-#### Example
-
-```js
-database: 'mongodb://username:password@127.0.0.1:3306/database_name?synchronize=true'
-```
-
-## Using other databases
+## Other databases
 
 See the [documentation for adapters](/schemas/adapters) for more information on advanced configuration, including how to use NextAuth.js with other databases using a [custom adapter](/tutorials/creating-a-database-adapter).
-

--- a/www/docs/configuration/databases.md
+++ b/www/docs/configuration/databases.md
@@ -69,7 +69,7 @@ database: {
 Running SQL to create your tables and columns is the recommended way to set up an SQL database.
 
 * [MySQL Schema](/schemas/mysql)
-* [Postgress Schema](/schemas/mysql)
+* [Postgres Schema](/schemas/postgres)
 
 _If you are running SQLite, MongoDB or a Document database you can skip this step._
 

--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -47,17 +47,7 @@ See the [providers documentation](/configuration/providers) for a list of suppor
 
 #### Description 
 
-A database connection string or [TypeORM](https://github.com/typeorm/typeorm/blob/master/docs/using-ormconfig.md) configuration object.
-
-NextAuth.js has built in support for MySQL, MariaDB, Postgress, MongoDB and SQLite databases.
-
-The default database provider is also compatible with other ANSI SQL compatible databases.
-
-NextAuth.js can can be used with any database by specifying a custom `adapter` option.
-
-:::tip
-The Email provider requires a database to be configured to store single use sign in tokens.
-:::
+[A database connection string or configuration object.](/configuration/databases)
 
 ---
 

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -3,18 +3,6 @@ id: providers
 title: Providers
 ---
 
-export const Image = ({ children, src, alt = '' }) => ( 
-  <div
-    style={{
-      padding: '0.2rem',
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'center'
-    }}>
-    <img alt={alt} src={src} />
-  </div>
- )
-
 Authentication Providers in NextAuth.js are how you define services can be used to sign in.
 
 NextAuth.js is designed to work with any OAuth service, it supports OAuth 1.0, 1.0A and 2.0 and has built-in support for many popular OAuth sign-in services. It also supports email / passwordless authentication.
@@ -226,3 +214,16 @@ See the [Credentials provider documentation](/providers/credentials) for more in
 :::note
 The Credentials provider can only be used if JSON Web Tokens are enabled for sessions. Users authenticated with the Credentials provider are not persisted in the database.
 :::
+
+<!-- React Image Component -->
+export const Image = ({ children, src, alt = '' }) => ( 
+  <div
+    style={{
+      padding: '0.2rem',
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'center'
+    }}>
+    <img alt={alt} src={src} />
+  </div>
+ )

--- a/www/docs/faq.md
+++ b/www/docs/faq.md
@@ -55,6 +55,37 @@ It is not intended to be used in native applications on desktop or mobile applic
 
 ---
 
+## Databases
+
+### What databases are supported by NextAuth.js?
+
+NextAuth.js can be used with MySQL, Postgres, MongoDB, SQLite and compatible databases (e.g. MariaDB, Amazon Aurora, Amazon DocumentDB…) or with no database.
+
+It also provides an Adapter API which allows you to connect it to any database.
+
+### What does NextAuth.js use databases for?
+
+Databases in NextAuth.js are used for persisting users, oauth accounts, email sign in tokens and sessions.
+
+Specifying a database is optional if you don't need to persist user data or support email sign in. If you don't specify a database then JSON Web Tokens will be enabled for session storage and used to store session data.
+
+If you are using a database with NextAuth.js, you can still explicitly enable JSON Web Tokens for sessions (instead of using database sessions).
+
+### Should I use a database?
+
+* Using NextAuth.js without a database works well for internal tools - where you need to control who is able to sign in, but when you do not need to create user accounts for them in your application.
+
+* Using NextAuth.js with a database is usually a better approach for a consumer facing application where you need to persist accounts (e.g. for billing, to contact customers, etc).
+
+### What database should I use?
+
+Managed database solutions for MySQL, Postgres and MongoDB (and compatible databases) are well supported from cloud providers such as Amazon, Google, Microsoft and Atlas.
+
+If you are deploying directly to a particular cloud platform you may also want to consider serverless database offerings they have (e.g. [Amazon Aurora Serverless on AWS](https://aws.amazon.com/rds/aurora/serverless/)).
+
+
+---
+
 ## Security 
 
 ### I think I've found a security problem, what should I do?

--- a/www/docs/schemas/adapters.md
+++ b/www/docs/schemas/adapters.md
@@ -1,6 +1,6 @@
 ---
 id: adapters
-title: Database Adapters
+title: Adapters
 ---
 
 An **Adapter** in NextAuth.js connects your application to whatever database or backend system you want to use to store data for user accounts, sessions, etc.
@@ -10,12 +10,6 @@ You do not need to specify an adapter explicltly unless you want to use advanced
 ## TypeORM Adapter
 
 NextAuth.js comes with a default adapter that uses [TypeORM](https://typeorm.io/) so that it can be used with many different databases without any further configuration, you simply add the node module for the database driver you want to use to your project and pass a database connection string to NextAuth.js.
-
-The default adapter comes with predefined models for **Users**, **Sessions**, **Account Linking** and **Verification Emails**. You can extend or replace the default models and schemas, or even provide your adapter to handle reading/writing from the database (or from multiple databases).
-
-If you have an existing database / user management system or want to use a database that isn't supported out of the box you can create and pass your own adapter to handle actions like `createAccount`, `deleteAccount`, (etc) and do not have to use the built in models.
-
-If you are using a database that is not supported out of the box, or if you want to use  NextAuth.js with an existing database, or have a more complex setup with accounts and sessions spread across different systems then you can pass your own methods to be called for user and session creation / deletion (etc).
 
 The default adapter is the TypeORM adapter, the following configuration options are exactly equivalent.
 
@@ -42,6 +36,8 @@ adapter: Adapters.TypeORM.Adapter({
   synchronize: true
 })
 ```
+
+The tutorial [Custom models with TypeORM](/tutorials/typeorm-custom-models) explains how to extend the built in models and schemas used by the TypeORM adapter.
 
 ## Prisma Adapter
 
@@ -81,14 +77,14 @@ export default (req, res) => NextAuth(req, res, options)
 
 Create a `schema.prisma` file similar to this one:
 
-``` title="prisma/schema.prisma"
+```json title="schema.prisma"
 generator client {
   provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider = "sqlite"
+  url      = "file:./dev.db"
 }
 
 model Account {
@@ -147,9 +143,25 @@ model VerificationRequest {
 }
 ```
 
-:::tip
-You can add properties to the schema, but do not change the base properties or types.
+:::note
+Set the `datasource` option appropriately for your database:
+
+```json title="schema.prisma"
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+```
+
+```json title="schema.prisma"
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+```
 :::
+
+### Generate Client
 
 Once you have saved your schema, you can run the Prisma CLI to generate the Prisma Client:
 
@@ -157,9 +169,13 @@ Once you have saved your schema, you can run the Prisma CLI to generate the Pris
 npx @prisma/cli generate
 ```
 
-#### Using custom model names
+### Custom Models
 
-The properties in the models need to be defined as above, but the model names themselves can be changed with a configuration option, and the datasource can be changed to anything supported by Prisma. You can use custom model names by using the `modelMapping` option (shown here with default values).
+You can add properties to the schema and map them to any database colum names you wish, but you should not change the base properties or types defined in the example schema.
+
+The model names themselves can be changed with a configuration option, and the datasource can be changed to anything supported by Prisma. 
+
+You can use custom model names by using the `modelMapping` option (shown here with default values).
 
 ```javascript title="pages/api/auth/[...nextauth].js"
 ...

--- a/www/docs/schemas/adapters.md
+++ b/www/docs/schemas/adapters.md
@@ -9,7 +9,7 @@ You do not need to specify an adapter explicltly unless you want to use advanced
 
 ## TypeORM Adapter
 
-NextAuth.js comes with a default adapter that uses [TypeORM](https://typeorm.io/) so that it can be used with many different databases without any further configuration, you simply add the database driver you want to use to your project and tell  NextAuth.js to use it.
+NextAuth.js comes with a default adapter that uses [TypeORM](https://typeorm.io/) so that it can be used with many different databases without any further configuration, you simply add the node module for the database driver you want to use to your project and pass a database connection string to NextAuth.js.
 
 The default adapter comes with predefined models for **Users**, **Sessions**, **Account Linking** and **Verification Emails**. You can extend or replace the default models and schemas, or even provide your adapter to handle reading/writing from the database (or from multiple databases).
 

--- a/www/docs/schemas/models.md
+++ b/www/docs/schemas/models.md
@@ -3,19 +3,18 @@ id: models
 title: Models
 ---
 
-## Overview
+Models in NextAuth.js are built for ANSI SQL but are polymorphic and are transformed to adapt to the database being used; there is some variance in specific data types (e.g. for datetime, text fields, etc) but they are functionally the same with as much parity in behaviour as possible.
 
-This a description of the models and data structure used by NextAuth.js default database adapter (TypeORM).
+All table/collection names in the built in models are are plural, and all table names and column names use `snake_case` when used with an SQL database and `camelCase` when used with Document database.
 
-You can define your own models and schemas or [create your own database adapter](/tutorials/creating-a-database-adapter).
-
-In NextAuth.js all table/collection names are plural, and all table names and column names use snake_case when used with an SQL database and camelCase when used with Document database. Indexes are declared on properties where appropriate.
-
-:::tip
-Models in NextAuth.js are built for ANSI SQL but are polymorphic and are transformed to adapt to the database being used; there is some variance in specific data types (e.g. for datetime, text fields, etc).
+:::note
+You can [extend the built in models](/tutorials/typeorm-custom-models) and even [create your own database adapter](/tutorials/creating-a-database-adapter) if you want to use NextAuth.js with a database that is not supported out of the box.
 :::
 
-### User
+
+---
+
+## User
 
 Table: `users`
 
@@ -31,7 +30,7 @@ If a user first signs in with OAuth then their email address is automatically po
 This provides a way to contact users and for users to maintain access to their account and sign in using email in the event they are unable to sign in with the OAuth provider in future (if email sign in is configured).
 :::
 
-### Account 
+## Account 
 
 Table: `accounts`
 
@@ -41,7 +40,7 @@ The Account model is for information about OAuth accounts associated with a User
 
 A single User can have multiple Accounts, each Account can only have one User.
 
-### Session
+## Session
 
 Table: `sessions`
 
@@ -51,7 +50,7 @@ The Session model is used for database sessions. It is not used if JSON Web Toke
 
 A single User can have multiple Sessions, each Session can only have one User.
 
-### Verification Request
+## Verification Request
 
 Table: `verification_requests`
 
@@ -62,25 +61,3 @@ The Verification Request model is used to store tokens for passwordless sign in 
 A single User can have multiple open Verification Requests (e.g. to sign in to different devices).
 
 It has been designed to be extendable for other verification purposes in future (e.g. 2FA / short codes).
-
-:::note
-See `src/adapters/typeorm/models` for the source for the current models and schemas.
-:::
-
----
-
-## Schemas
-
-NextAuth.js uses a different schemas to implement the model for each database.
-
-They are all functionally equivalent but the syntax is specific to each database. 
-
-For more information, refer to the schema documentation for each database.
-
-### [MySQL](/schemas/mysql)
-### [Postgres](/schemas/postgres)
-### [MongoDB](/schemas/mongodb)
-
-:::note
-There is no schema documentation for SQLite. It functions similarly to the other SQL databases. SQLite support is intended for local development and testing.
-:::

--- a/www/docs/schemas/mongodb.md
+++ b/www/docs/schemas/mongodb.md
@@ -5,11 +5,18 @@ title: MongoDB
 
 MongoDB is a document database and does not use schemas in the same way as most RDBMS databases.
 
-However, objects stored in MongoDB use similar datatypes to SQL, with some differences.
+**In MongoDB as collections and indexes are created automatically.**
 
-* ID fields are of type `ObjectID` rather than type `int`.
-* All collection names and property names use `camelCase` rather than `snake_case`.
-* All timestamps are stored as `ISODate()` in MongoDB and all date/time values are stored in UTC.
-* A sparse index is used on the User `email` property to allow it to not be specified, while still enforcing uniqueness if it is present on a User object.
+## Objects in MonogDB
 
-  This ensures the behaviour functionally equivalent to the ANSI SQL behaviour for a `unique` but `nullable` property, so that it works the same way as the MySQL and Postgres schemas.
+Objects stored in MongoDB use similar datatypes to SQL, with some differences:
+
+1. ID fields are of type `ObjectID` rather than type `int`.
+
+2. All collection names and property names use `camelCase` rather than `snake_case`.
+
+3. All timestamps are stored as `ISODate()` in MongoDB and all date/time values are stored in UTC.
+
+4. A sparse index is used on the User `email` property to allow it to be optional, while still enforcing uniqueness if it is specified.
+
+  This is functionally equivalent to the ANSI SQL behaviour for a `unique` but `nullable` property.

--- a/www/docs/schemas/mysql.md
+++ b/www/docs/schemas/mysql.md
@@ -3,167 +3,85 @@ id: mysql
 title: MySQL
 ---
 
-The schema generated for a MySQL database when using the built-in models.
+Schema for a MySQL database.
 
 :::note
-When using a MySQL database with the default adapter the timezone is set to `Z` (aka Zulu Time / UTC) and all timestamps are stored in UTC.
+When using a MySQL database with the default adapter (TypeORM) all timestamp columns use 6 digits of precision (unless another value for `precision` is specified in the schema) and the timezone is set to `Z` (aka Zulu Time / UTC) and all timestamps are stored in UTC.
 :::
 
-## User
+```sql
+CREATE TABLE accounts
+  (
+    id                   INT NOT NULL AUTO_INCREMENT,
+    compound_id          VARCHAR(255) NOT NULL,
+    user_id              INTEGER NOT NULL,
+    provider_type        VARCHAR(255) NOT NULL,
+    provider_id          VARCHAR(255) NOT NULL,
+    provider_account_id  VARCHAR(255) NOT NULL,
+    refresh_token        TEXT,
+    access_token         TEXT,
+    access_token_expires TIMESTAMP(6),
+    created_at           TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at           TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
 
-```json
-"users": {
-  "id": {
-    "type": "int",
-    "nullable": false
-  },
-  "name": {
-    "type": "varchar(255)",
-    "nullable": true,
-    "default": null
-  },
-  "email": {
-    "type": "varchar(255)",
-    "nullable": true,
-    "default": null
-  },
-  "email_verified": {
-    "type": "timestamp",
-    "nullable": true,
-    "default": null
-  },
-  "image": {
-    "type": "varchar(255)",
-    "nullable": true,
-    "default": null
-  },
-  "created_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  }
-}
-```
+CREATE TABLE sessions
+  (
+    id            INT NOT NULL AUTO_INCREMENT,
+    user_id       INTEGER NOT NULL,
+    expires       TIMESTAMP(6) NOT NULL,
+    session_token VARCHAR(255) NOT NULL,
+    access_token  VARCHAR(255) NOT NULL,
+    created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
 
-## Account
+CREATE TABLE users
+  (
+    id             INT NOT NULL AUTO_INCREMENT,
+    name           VARCHAR(255),
+    email          VARCHAR(255),
+    email_verified TIMESTAMP(6),
+    image          VARCHAR(255),
+    created_at     TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at     TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
 
-```json
-"accounts": {
-  "id": {
-    "type": "int",
-    "nullable": false
-  },
-  "compound_id": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "user_id": {
-    "type": "int",
-    "nullable": false
-  },
-  "provider_type": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "provider_id": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "provider_account_id": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "refresh_token": {
-    "type": "text",
-    "nullable": true,
-    "default": null
-  },
-  "access_token": {
-    "type": "text",
-    "nullable": true,
-    "default": null
-  },
-  "access_token_expires": {
-    "type": "timestamp",
-    "nullable": true,
-    "default": null
-  },
-  "created_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  }
-}
-```
+CREATE TABLE verification_requests
+  (
+    id         INT NOT NULL AUTO_INCREMENT,
+    identifier VARCHAR(255) NOT NULL,
+    token      VARCHAR(255) NOT NULL,
+    expires    TIMESTAMP(6) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+  );
 
-## Session
+CREATE UNIQUE INDEX compound_id
+  ON accounts(compound_id);
 
-```json
-"sessions": {
-  "id": {
-    "type": "int",
-    "nullable": false
-  },
-  "user_id": {
-    "type": "int",
-    "nullable": false
-  },
-  "expires": {
-    "type": "timestamp",
-    "nullable": false
-  },
-  "session_token": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "access_token": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "created_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  }
-}
-```
+CREATE INDEX provider_account_id
+  ON accounts(provider_account_id);
 
-## Verification Request
+CREATE INDEX provider_id
+  ON accounts(provider_id);
 
-```json
- "verification_requests": {
-  "id": {
-    "type": "int",
-    "nullable": false
-  },
-  "identifier": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "token": {
-    "type": "varchar(255)",
-    "nullable": false
-  },
-  "expires": {
-    "type": "timestamp",
-    "nullable": false
-  },
-  "created_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp(6)",
-    "nullable": false
-  }
-}
+CREATE INDEX user_id
+  ON accounts(user_id);
+
+CREATE UNIQUE INDEX session_token
+  ON sessions(session_token);
+
+CREATE UNIQUE INDEX access_token
+  ON sessions(access_token);
+
+CREATE UNIQUE INDEX email
+  ON users(email);
+
+CREATE UNIQUE INDEX token
+  ON verification_requests(token);
 ```

--- a/www/docs/schemas/postgres.md
+++ b/www/docs/schemas/postgres.md
@@ -3,169 +3,88 @@ id: postgres
 title: Postgres
 ---
 
-The schema generated for a Postgres database when using the built-in models.
+Schema for a Postgres database.
 
 :::note
-When using a Postgres database with the default adapter all properties of type `timestamp` are transformed to `timestamp with time zone`/`timestamptz` and all timestamps are stored in UTC.
+When using a Postgres database with the default adapter (TypeORM) all properties of type `timestamp` are transformed to `timestamp with time zone`/`timestamptz` and all timestamps are stored in UTC.
 
 This transform is also applied to any properties of type `timestamp` when using custom models.
 :::
 
-## User
+```sql
+CREATE TABLE accounts
+  (
+    id                   SERIAL,
+    compound_id          VARCHAR(255) NOT NULL,
+    user_id              INTEGER NOT NULL,
+    provider_type        VARCHAR(255) NOT NULL,
+    provider_id          VARCHAR(255) NOT NULL,
+    provider_account_id  VARCHAR(255) NOT NULL,
+    refresh_token        TEXT,
+    access_token         TEXT,
+    access_token_expires TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
 
-```json
-"users": {
-  "id": {
-    "type": "integer",
-    "nullable": false
-  },
-  "name": {
-    "type": "character varying",
-    "nullable": true,
-    "default": null
-  },
-  "email": {
-    "type": "character varying",
-    "nullable": true,
-    "default": null
-  },
-  "email_verified": {
-    "type": "timestamp with time zone",
-    "nullable": true,
-    "default": null
-  },
-  "image": {
-    "type": "character varying",
-    "nullable": true,
-    "default": null
-  },
-  "created_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  }
-}
-```
+CREATE TABLE sessions
+  (
+    id            SERIAL,
+    user_id       INTEGER NOT NULL,
+    expires       TIMESTAMPTZ NOT NULL,
+    session_token VARCHAR(255) NOT NULL,
+    access_token  VARCHAR(255) NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
 
-## Account
+CREATE TABLE users
+  (
+    id             SERIAL,
+    name           VARCHAR(255),
+    email          VARCHAR(255),
+    email_verified TIMESTAMPTZ,
+    image          VARCHAR(255),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
 
-```json
-"accounts": {
-  "id": {
-    "type": "integer",
-    "nullable": false
-  },
-  "compound_id": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "user_id": {
-    "type": "integer",
-    "nullable": false
-  },
-  "provider_type": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "provider_id": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "provider_account_id": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "refresh_token": {
-    "type": "text",
-    "nullable": true,
-    "default": null
-  },
-  "access_token": {
-    "type": "text",
-    "nullable": true,
-    "default": null
-  },
-  "access_token_expires": {
-    "type": "timestamp with time zone",
-    "nullable": true,
-    "default": null
-  },
-  "created_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  }
-}
-```
+CREATE TABLE verification_requests
+  (
+    id         SERIAL,
+    identifier VARCHAR(255) NOT NULL,
+    token      VARCHAR(255) NOT NULL,
+    expires    TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  );
 
-## Session
+CREATE UNIQUE INDEX compound_id
+  ON accounts(compound_id);
 
-```json
-"sessions": {
-  "id": {
-    "type": "integer",
-    "nullable": false
-  },
-  "user_id": {
-    "type": "integer",
-    "nullable": false
-  },
-  "expires": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  },
-  "session_token": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "access_token": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "created_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  }
-}
-```
+CREATE INDEX provider_account_id
+  ON accounts(provider_account_id);
 
-## Verification Request
+CREATE INDEX provider_id
+  ON accounts(provider_id);
 
-```json
-"verification_requests": {
-  "id": {
-    "type": "integer",
-    "nullable": false
-  },
-  "identifier": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "token": {
-    "type": "character varying",
-    "nullable": false
-  },
-  "expires": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  },
-  "created_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  },
-  "updated_at": {
-    "type": "timestamp with time zone",
-    "nullable": false
-  }
-}
+CREATE INDEX user_id
+  ON accounts(user_id);
+
+CREATE UNIQUE INDEX session_token
+  ON sessions(session_token);
+
+CREATE UNIQUE INDEX access_token
+  ON sessions(access_token);
+
+CREATE UNIQUE INDEX email
+  ON users(email);
+
+CREATE UNIQUE INDEX token
+  ON verification_requests(token);
+
 ```

--- a/www/docs/tutorials/typeorm-custom-models.md
+++ b/www/docs/tutorials/typeorm-custom-models.md
@@ -3,7 +3,7 @@ id: typeorm-custom-models
 title: Custom models with TypeORM
 ---
 
-NextAuth.js provides a set of [models and schemas](https://next-auth.js.org/schemas/models) for the built-in TypeORM adapter that you can easily extend.
+NextAuth.js provides a set of [models and schemas](/schemas/models) for the built-in TypeORM adapter that you can easily extend.
 
 You can use these models with MySQL, MariaDB, Postgres, MongoDB and SQLite.
 


### PR DESCRIPTION
I've been trying out the Prisma adapter and addressing some minor issues - for context, I just did the same for TypeORM adapter in #460.

**I've now done quite a bit of testing with Prisma with both MySQL and Postgres and found it works really well.**

This PR includes some enhancements / fixes to the Prisma adapter, a change to the TypeORM adapter for MySQL databases to improve it (addressing an issue with different timestamp fields using different levels of precision) and includes updated documentation useful for all users that has come off the back of testing.

### Changes

#### Prisma Adapter

* **Updated `getUserByProviderAccountId` to use `compoundId` when searching for accounts.**
  As different providers might use the same ID, the provider name should also be taken into account when searching by account ID and this achieves that.
* **Updated how `linkAccount` and `createSession` store `userId` as ran into issues with it.**
  Similar to the TypeORM have refactored it in a simpler way that avoids a relationship between entities. I appreciate not using relationships is less elegant and atypical with an RDBMS, but it makes compatibility with different databases much easier and has very little performance impact as it's not invoked often (only on sign in) which is why the TypeORM adapter makes this tradeoff. I think this is something that could be more sophisticated later if/when we split off the adapter code.
* **Updated example schema in docs to show how to use it with Postgres.**
  Now includes mappings for the default table/column names and indexes. I think having parity in the expected database schemas will make it easier to keep the documentation up to date in the long run

#### TypeORM Adapter

* **Timestamps in MySQL all consistently declared with `TIMESTAMP(6)` unless a different level of precision is specified.**
   This is consistent with behaviour for created/updated fields in TypeORM for MySQL, and with timestamp fields in Postgres.

#### Documentation

* [Added database questions to FAQ](https://next-auth-docs-git-feature-prisma-adaptor-refactor.iaincollins.vercel.app/faq#databases)
* [Improved database option documentation](https://next-auth-docs-git-feature-prisma-adaptor-refactor.iaincollins.vercel.app/configuration/databases)
* [Added MySQL SQL schema to documentation](https://next-auth-docs-git-feature-prisma-adaptor-refactor.iaincollins.vercel.app/schemas/mysql)
* [Added Postgres SQL schema to documentation](https://next-auth-docs-git-feature-prisma-adaptor-refactor.iaincollins.vercel.app/schemas/postgres)
* [Improved adapter documentation](https://next-auth-docs-git-feature-prisma-adaptor-refactor.iaincollins.vercel.app/schemas/adapters)

I think there is scope to feature the Prisma adapter more prominently in future, but I think this is quite a big improvement for now, especially around transparency of databases schemas and ease of getting started.

The SQL schemas I've added should match up with the schemas generated by TypeORM for the built in models if it's allowed to generate the schema from the modes (I've done some testing to confirm this). This approach informs some of the default types for MySQL as it seems best to be consistent and transparent about it.

For those who know what they are doing, it's fine to use different types for IDs and for timestamps (etc). as long as you don't use the option to `sync` which the default adapter. As we have more comprehensive documentation (with copy+paste SQL schemas), I have made using the `sync` option less prominent in the documentation.

Note: If using Prisma to generate the SQL from scratch with `npx @prisma/cli migrate save --experimental` it will create slightly different SQL to that generate by TypeORM, but the example schema is completely compatible with the SQL schemas provided for MySQL and Postgres (i.e. the schemas in the documentation are valid for both).

