### PR TITLE
Fix error updating user in TypeORM adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Authentication for Next.js",
   "homepage": "https://next-auth.js.org",
   "repository": "https://github.com/nextauthjs/next-auth.git",

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -171,7 +171,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
 
     async function updateUser (user) {
       debug('UPDATE_USER', user)
-      return manager.save(user)
+      return manager.save(User, user)
     }
 
     async function deleteUser (userId) {

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -266,7 +266,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
           if (!force) { return null }
         }
 
-        return manager.save(session)
+        return manager.save(Session, session)
       } catch (error) {
         logger.error('UPDATE_SESSION_ERROR', error)
         return Promise.reject(new Error('UPDATE_SESSION_ERROR', error))


### PR DESCRIPTION
### Problem

When signing in a second time with email, this causes an error on sign in because it tries to update the `emailVerified` timestamp on the User object. (This is the only scenario when `updateUser` is currently called.)

When `updateUser()` is called in the TypeORM adapter the connection manager does not know what type of object the user is unless this is explicitly specified. This bug was introduced with refactoring in 3.0.0.

### Solution

This fix addresses that issue by passing in the User model when saving so that the `updateUser` operation does not fail.

This doesn't seem to be a problem for any of the other calls, but have primitively explicitly passed the model to `updateSession` too in case we accidentally introduce a similar issue with refactoring future. In all other cases, the model is used to instantiate an object before saving, so isn't an issue.

Resolves #493