### PR TITLE
Fix typo in typeorm-custom-models.md

### DIFF
--- a/www/docs/tutorials/typeorm-custom-models.md
+++ b/www/docs/tutorials/typeorm-custom-models.md
@@ -72,7 +72,7 @@ const options = {
     "mysql://username:password@127.0.0.1:3306/database_name",
     // The second argument can be used to pass custom models and schemas
     {
-      models: {
+      customModels: {
         User: Models.User,
       },
     }


### PR DESCRIPTION
[Adapter](https://github.com/nextauthjs/next-auth/blob/main/src/adapters/typeorm/index.js) expects `customModels` property, but doc uses `models`.