### PR TITLE
Add Provider: Basecamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/providers/basecamp.js
+++ b/src/providers/basecamp.js
@@ -1,0 +1,20 @@
+export default (options) => {
+  return {
+    id: 'basecamp',
+    name: 'Basecamp',
+    type: 'oauth',
+    version: '2.0',
+    accessTokenUrl: 'https://launchpad.37signals.com/authorization/token?type=web_server',
+    authorizationUrl: 'https://launchpad.37signals.com/authorization/new?type=web_server',
+    profileUrl: 'https://launchpad.37signals.com/authorization.json',
+    profile: (profile) => {
+      return {
+        id: profile.identity.id,
+        name: `${profile.identity.first_name} ${profile.identity.last_name}`,
+        email: profile.identity.email_address,
+        image: null
+      }
+    },
+    ...options
+  }
+}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,8 +1,9 @@
 import Auth0 from './auth0'
 import Apple from './apple'
+import Basecamp from './basecamp'
+import BattleNet from './battlenet'
 import Box from './box'
 import Credentials from './credentials'
-import BattleNet from './battlenet'
 import Cognito from './cognito'
 import Discord from './discord'
 import Email from './email'
@@ -23,9 +24,10 @@ import Yandex from './yandex'
 export default {
   Auth0,
   Apple,
+  Basecamp,
+  BattleNet,
   Box,
   Credentials,
-  BattleNet,
   Cognito,
   Discord,
   Email,

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -13,6 +13,7 @@ NextAuth.js is designed to work with any OAuth service, it supports OAuth 1.0, 1
 
 * [Apple](/providers/apple)
 * [Auth0](/providers/auth0)
+* [Basecamp](/providers/basecamp)
 * [Battle.net](/providers/battlenet)
 * [Box](/providers/box)
 * [Amazon Cognito](/providers/cognito)

--- a/www/docs/providers/basecamp.md
+++ b/www/docs/providers/basecamp.md
@@ -1,0 +1,60 @@
+---
+id: basecamp
+title: Basecamp
+---
+
+## Documentation
+
+https://github.com/basecamp/api/blob/master/sections/authentication.md
+
+## Configuration
+
+https://launchpad.37signals.com/integrations
+
+## Examples
+
+### Basic profile information
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.Basecamp({
+    clientId: process.env.BASECAMP_CLIENT_ID,
+    clientSecret: process.env.BASECAMP_CLIENT_SECRET
+  })
+]
+...
+```
+
+:::note
+Using the example above, it is only possible to retrieve profile information such as account id, email and name. If you wish to retrieve user data in relation to a specific team, you must provide a different profileUrl and a custom function to handle profile information as shown in the example below. 
+:::
+
+### Profile information in relation to specific team
+
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.Basecamp({
+    clientId: process.env.BASECAMP_CLIENT_ID,
+    clientSecret: process.env.BASECAMP_CLIENT_SECRET,
+    profileUrl: `https://3.basecampapi.com/${process.env.BASECAMP_TEAM_ID}/my/profile.json`,
+    profile: (profile) => {
+      return {
+        id: profile.id,
+        name: profile.name,
+        email: profile.email_address,
+        image: profile.avatar_url,
+        admin: profile.admin,
+        owner: profile.owner
+      }
+    }
+  })
+]
+...
+```
+
+:::tip
+The BASECAMP_TEAM_ID is found in the url path of your team's homepage. For example, if the url is `https://3.basecamp.com/1234567/projects`, then in this case the BASECAMP_TEAM_ID is 1234567
+:::

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -24,6 +24,7 @@ module.exports = {
     'Authentication Providers': [
       'providers/apple',
       'providers/auth0',
+      'providers/basecamp',
       'providers/battle.net',
       'providers/box',
       'providers/cognito',


### PR DESCRIPTION
Currently working on a project where I am making use of the Basecamp OAuth 2.0 Authentication. Managed to get Basecamp working as a custom provider and thought it might be nice to have it as part of the built-in support.

### Major Changes
• Added Basecamp as a provider
• Added documentation for Basecamp provider

### Minor Changes
• Bumped Version to 3.0.1 in package-lock