### PR TITLE
enhancement: fix: Mail.ru OAuth Service Provider

### DIFF
--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -13,6 +13,7 @@ import GitLab from './gitlab'
 import Google from './google'
 import IdentityServer4 from './identity-server4'
 import LinkedIn from './linkedin'
+import MailRu from './mailru'
 import Mixer from './mixer'
 import Okta from './okta'
 import Slack from './slack'
@@ -37,6 +38,7 @@ export default {
   Google,
   IdentityServer4,
   LinkedIn,
+  MailRu,
   Mixer,
   Okta,
   Slack,

--- a/src/providers/mailru.js
+++ b/src/providers/mailru.js
@@ -1,0 +1,26 @@
+export default (options) => {
+  return {
+    id: 'mailru',
+    name: 'Mail.ru',
+    type: 'oauth',
+    version: '2.0',
+    scope: 'userinfo',
+    params: {
+      grant_type: 'authorization_code'
+    },
+    accessTokenUrl: 'https://oauth.mail.ru/token',
+    requestTokenUrl: 'https://oauth.mail.ru/token',
+    authorizationUrl: 'https://oauth.mail.ru/login?response_type=code',
+    profileUrl: 'https://oauth.mail.ru/userinfo',
+    profile: (profile) => {
+      return {
+        id: profile.id,
+        name: profile.name,
+        email: profile.email,
+        image: profile.image,
+      }
+    },
+    setGetAccessTokenProfileUrl: true,
+    ...options
+  }
+}

--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -255,9 +255,17 @@ async function _getOAuthAccessToken (code, provider, callback) {
 function _get (provider, accessToken, callback) {
   const url = provider.profileUrl
   const headers = provider.headers || {}
+  const setGetAccessTokenProfileUrl = provider.setGetAccessTokenProfileUrl !== null ? provider.setGetAccessTokenProfileUrl : true
 
   if (this._useAuthorizationHeaderForGET) {
     headers.Authorization = this.buildAuthHeader(accessToken)
+
+    // Mail.ru requires 'access_token' as URL request parameter
+    if (setGetAccessTokenProfileUrl) {
+      if (provider.profileUrl) {
+        url = provider.profileUrl + '?access_token=' + accessToken
+      }
+    }
 
     // This line is required for Twitch
     headers['Client-ID'] = provider.clientId

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -24,6 +24,7 @@ NextAuth.js is designed to work with any OAuth service, it supports OAuth 1.0, 1
 * [Google](/providers/google)
 * [IdentityServer4](/providers/identity-server4)
 * [LinkedIn](/providers/LinkedIn)
+* [Mail.ru](/providers/MailRu)
 * [Mixer](/providers/Mixer)
 * [Okta](/providers/Okta)
 * [Slack](/providers/slack)
@@ -218,7 +219,7 @@ The Credentials provider can only be used if JSON Web Tokens are enabled for ses
 :::
 
 <!-- React Image Component -->
-export const Image = ({ children, src, alt = '' }) => ( 
+export const Image = ({ children, src, alt = '' }) => (
   <div
     style={{
       padding: '0.2rem',

--- a/www/docs/providers/mailru.md
+++ b/www/docs/providers/mailru.md
@@ -1,0 +1,25 @@
+---
+id: mailru
+title: Mail.ru
+---
+
+## Documentation
+
+https://o2.mail.ru/docs
+
+## Configuration
+
+https://o2.mail.ru/app/
+
+## Example
+
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.MailRu({
+    clientId: process.env.MAILRU_CLIENT_ID,
+    clientSecret: process.env.MAILRU_CLIENT_SECRET
+  })
+]
+...

--- a/www/docs/providers/mailru.md
+++ b/www/docs/providers/mailru.md
@@ -1,5 +1,5 @@
 ---
-id: mailru
+id: mail.ru
 title: Mail.ru
 ---
 

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -38,6 +38,7 @@ module.exports = {
       'providers/google',
       'providers/identity-server4',
       'providers/linkedin',
+      'providers/mailru',
       'providers/mixer',
       'providers/okta',
       'providers/slack',


### PR DESCRIPTION
- Fix Mail.ru bug #308 (missing request parameter: access_token).

Documentation available at https://next-auth.js.org/configuration/providers#using-a-custom-provider for configuration of a custom OAuth service provider.

How to use Mail.ru as custom OAuth service provider;

```js
// pages/api/auth/[...nextauth].js
{
  id: 'mailru',
  name: 'Mail.ru',
  type: 'oauth',
  version: '2.0',
  scope: 'userinfo',
  params: {
    grant_type: 'authorization_code'
  },
  accessTokenUrl: 'https://oauth.mail.ru/token',
  requestTokenUrl: 'https://oauth.mail.ru/token',
  authorizationUrl: 'https://oauth.mail.ru/login?response_type=code',
  profileUrl: 'https://oauth.mail.ru/userinfo',
  profile: (profile) => {
    return {
      id: profile.id,
      name: profile.name,
      email: profile.email,
      image: profile.image,
    }
  },
  setGetAccessTokenProfileUrl: true, // Should be add for Mail.ru as custom OAuth service provider.
  clientId: process.env.MAILRU_ID,
  clientSecret: process.env.MAILRU_SECRET
}
```
Define both client ID and client secret values in `.env` file;
```sh
# .env
MAILRU_ID=
MAILRU_SECRET=
```