### PR TITLE
Update Google Provider example to be functional

### DIFF
--- a/www/docs/providers/google.md
+++ b/www/docs/providers/google.md
@@ -51,7 +51,7 @@ const options = {
 :::
 
 :::tip
-Google also return an `email_verified` boolean property in the OAuth profile.
+Google also return an `verified_email` boolean property in the OAuth profile.
 
 You can use this property to restrict access to people with verified accounts at a particular domain.
 
@@ -61,7 +61,7 @@ const options = {
   callbacks: {
     signIn: async (user, account, profile) => {
       if (account.provider === 'google' &&
-          profile.email_verified === true &&
+          profile.verified_email === true &&
           profile.email.endsWith('@example.com')) {
         return Promise.resolve(true)
       } else {


### PR DESCRIPTION
Currently the Google Provider example will always fail due to checking for `email_verified` when the correct response from the server is `verified_email`

next-auth debug output for validation:

```
[next-auth][debug][profile_data] {
  id: 'XXXXXXX',
  email: 'nick@example',
  verified_email: true,
  name: 'Nick Parks',
  given_name: 'Nick',
  family_name: 'XXXX',
  picture: 'XXXX,
  locale: 'en',
  hd: 'example.com'
}
```