### PR TITLE
JWT auth_time must be a numeric value

### DIFF
--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -170,7 +170,7 @@ callbacks: {
   jwt: async (token, user, account, profile, isNewUser) => {
     const isSignIn = (user) ? true : false
     // Add auth_time to token on signin in
-    if (isSignIn) { token.auth_time = new Date().toISOString() }
+    if (isSignIn) { token.auth_time = Date.now() }
     return Promise.resolve(token)
   }
 }


### PR DESCRIPTION
I was getting this error due to it being a string value.
```sh
[next-auth][error][jwt_session_error] JWTClaimInvalid: "auth_time" claim must be a JSON numeric value
    at isTimestamp (/Users/alex/code/trufans/node_modules/jose/lib/jwt/verify.js:24:11)
    at validateTypes (/Users/alex/code/trufans/node_modules/jose/lib/jwt/verify.js:159:3)
    at Object.module.exports [as verify] (/Users/alex/code/trufans/node_modules/jose/lib/jwt/verify.js:236:3)
    at Object.<anonymous> (/Users/alex/code/trufans/node_modules/next-auth/dist/lib/jwt.js:100:30)
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/alex/code/trufans/node_modules/next-auth/dist/lib/jwt.js:22:103)
    at _next (/Users/alex/code/trufans/node_modules/next-auth/dist/lib/jwt.js:24:194)
    at /Users/alex/code/trufans/node_modules/next-auth/dist/lib/jwt.js:24:364
    at new Promise (<anonymous>)
    at Object.<anonymous> (/Users/alex/code/trufans/node_modules/next-auth/dist/lib/jwt.js:24:97) {
  code: 'ERR_JWT_CLAIM_INVALID',
  claim: 'auth_time',
  reason: 'invalid'
}
```