### PR TITLE
Add: warnings page

### DIFF
--- a/www/docs/warnings.md
+++ b/www/docs/warnings.md
@@ -1,0 +1,50 @@
+---
+id: warnings
+title: Warnings
+---
+
+This is a list of warning output from NextAuth.js.
+
+All warnings indicate things which you should take a look at, but do not inhibit normal operation.
+
+---
+
+## Client
+
+#### NEXTAUTH_URL
+
+Environment variable `NEXTAUTH_URL` missing. Please set it in your `.env` file.
+
+---
+
+## Server
+
+These warnings are displayed on the terminal.
+
+#### JWT_AUTO_GENERATED_SIGNING_KEY
+
+To remedy this warning, you can either:
+
+**Option 1**: Pass a pre-regenerated Private Key (and, optionally a Public Key) in the jwt options.
+```js title="/pages/api/auth/[...nextauth].js"
+jwt: {
+  signingKey: process.env.JWT_SIGNING_PRIVATE_KEY,
+
+  // You can also specify a public key for verification if using public/private key (but private only is fine)
+  // verificationKey: process.env.JWT_SIGNING_PUBLIC_KEY,
+
+  // If you want to use some key format other than HS512 you can specify custom options to use
+  // when verifying (note: verificationOptions should include a value for maxTokenAge as well).
+  // verificationOptions = {
+  //   maxTokenAge: `${maxAge}s`, // e.g. `${30 * 24 * 60 * 60}s` = 30 days
+  //   algorithms: ['HS512']
+  // },
+}
+```
+
+You can use [node-jose-tools](https://www.npmjs.com/package/node-jose-tools) to generate keys on the command line and set them as environment variables, i.e. `jose newkey -s 256 -t oct -a HS512`.
+
+**Option 2**: Specify custom encode/decode functions on the jwt object. This gives you complete control over signing / verification / etc.
+
+#### JWT_AUTO_GENERATED_ENCRYPTION_KEY
+


### PR DESCRIPTION
In the logger.js you also have warning URLs being printed, but the page for it had not been created yet so people were getting 404s.

With this PR we have a basic warnings page, modeled after the error one, with all the warnings I could find in the codebase. 

