### PR TITLE
[providers]: Updating Discord provider domain

### DIFF
--- a/src/providers/discord.js
+++ b/src/providers/discord.js
@@ -6,10 +6,10 @@ export default (options) => {
     version: '2.0',
     scope: 'identify email',
     params: { grant_type: 'authorization_code' },
-    accessTokenUrl: 'https://discordapp.com/api/oauth2/token',
+    accessTokenUrl: 'https://discord.com/api/oauth2/token',
     authorizationUrl:
-      'https://discordapp.com/api/oauth2/authorize?response_type=code&prompt=consent',
-    profileUrl: 'https://discordapp.com/api/users/@me',
+      'https://discord.com/api/oauth2/authorize?response_type=code&prompt=consent',
+    profileUrl: 'https://discord.com/api/users/@me',
     profile: (profile) => {
       return {
         id: profile.id,


### PR DESCRIPTION
Discord is migrating to discord.com, including their OAuth2 API routes. Support for the old domain, discordapp.com, will be dropped on 7 Nov 2020.

Note that the cdn.discordapp.com domain is unchanged. This is intentional, as the cdn domain will not be migrated due to technical restraints on Discord's side.