### PR TITLE
Fix redirect reponseAsJson

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -180,7 +180,7 @@ export default async (req, res, userSuppliedOptions) => {
     // @TODO Refactor into a lib instead of passing as an option
     //       e.g. and call as redirect(req, res, url)
     const redirect = (redirectUrl) => {
-      const reponseAsJson = !!((req.body && req.body.json === 'true'))
+      const reponseAsJson = !!((req.body && String(req.body.json) === 'true'))
       if (reponseAsJson) {
         res.json({ url: redirectUrl })
       } else {


### PR DESCRIPTION
**Issue**

```tsx
const res = await fetch("/api/auth/signin/email", {
  method: "post",
  headers: { "Content-Type": "application/json" },
  body: JSON.stringify({ ...values, json: true /* NOTE */ }),
})
console.log(res)
```

**NOTE**
* `json: true` triggers a 302 redirect
* `json: "true"` reponse as JSON

**Expected**

* `json: true` reponse as JSON