### PR TITLE
[providers]: Add FusionAuth provider

### DIFF
--- a/src/providers/fusionauth.js
+++ b/src/providers/fusionauth.js
@@ -1,0 +1,23 @@
+export default (options) => {
+  let authorizationUrl = `https://${options.domain}/oauth2/authorize?response_type=code`;
+  if (options.tenantId) {
+    authorizationUrl += `&tenantId=${options.tenantId}`;
+  }
+
+  return {
+    id: "fusionauth",
+    name: "FusionAuth",
+    type: "oauth",
+    version: "2.0",
+    scope: "openid",
+    params: { grant_type: "authorization_code" },
+    accessTokenUrl: `https://${options.domain}/oauth2/token`,
+    authorizationUrl,
+    profileUrl: `https://${options.domain}/oauth2/userinfo`,
+    profile: (profile) => {
+      return { ...profile, id: profile.sub };
+    },
+    setGetAccessTokenAuthHeader: false,
+    ...options,
+  };
+};

--- a/src/providers/fusionauth.js
+++ b/src/providers/fusionauth.js
@@ -1,0 +1,27 @@
+export default (options) => {
+  let authorizationUrl = `https://${options.domain}/oauth2/authorize?response_type=code`;
+  if (options.tenantId) {
+    authorizationUrl += `&tenantId=${options.tenantId}`;
+  }
+
+  return {
+    id: "fusionauth",
+    name: "FusionAuth",
+    type: "oauth",
+    version: "2.0",
+    scope: "openid",
+    params: { grant_type: "authorization_code" },
+    accessTokenUrl: `https://${options.domain}/oauth2/token`,
+    authorizationUrl,
+    profileUrl: `https://${options.domain}/oauth2/userinfo`,
+    profile: (profile) => {
+      return {
+        id: profile.sub,
+        name: profile.name,
+        email: profile.email,
+        image: profile.picture,
+      };
+    },
+    ...options,
+  };
+};

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -8,6 +8,7 @@ import Cognito from './cognito'
 import Discord from './discord'
 import Email from './email'
 import Facebook from './facebook'
+import FusionAuth from './fusionauth'
 import GitHub from './github'
 import GitLab from './gitlab'
 import Google from './google'
@@ -32,6 +33,7 @@ export default {
   Discord,
   Email,
   Facebook,
+  FusionAuth,
   GitHub,
   GitLab,
   Google,

--- a/www/docs/faq.md
+++ b/www/docs/faq.md
@@ -23,7 +23,7 @@ You can use also NextAuth.js with any database using a custom database adapter, 
 
 ### What authentication services does NextAuth.js support?
 
-NextAuth.js includes built-in support for signing in with Apple, Auth0, Google, Battle.net, Box, AWS Cognito, Discord, Facebook, GitHub, GitLab, Google, Open ID Identity Server, Mixer, Okta, Slack, Spotify, Twitch, Twitter and Yandex.
+NextAuth.js includes built-in support for signing in with Apple, Auth0, Google, Battle.net, Box, AWS Cognito, Discord, Facebook, FusionAuth, GitHub, GitLab, Google, Open ID Identity Server, Mixer, Okta, Slack, Spotify, Twitch, Twitter and Yandex.
 
 NextAuth.js also supports email for passwordless sign in, which is useful for account recovery or for people who are not able to use an account with the configured OAuth services (e.g. due to service outage, account suspension or otherwise becoming locked out of an account).
 

--- a/www/docs/providers/fusionauth.md
+++ b/www/docs/providers/fusionauth.md
@@ -1,0 +1,50 @@
+---
+id: fusionauth
+title: FusionAuth
+---
+
+## Documentation
+
+https://fusionauth.io/docs/v1/tech/oauth/
+
+## Example (Single-Tenant setup)
+
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.FusionAuth({
+    id: "fusionauth", 
+    name: "FusionAuth", 
+    domain:  process.env.FUSIONAUTH_DOMAIN,
+    clientId: process.env.FUSIONAUTH_CLIENT_ID,
+    clientSecret: process.env.FUSIONAUTH_SECRET,
+    tenantId: process.env.FUSIONAUTH_TENANT_ID // Only required if you're using multi-tenancy
+  }),
+}
+...
+```
+
+::: warning
+
+If you're using multi-tenancy, you need to pass in the `tenantId` option to apply the proper theme.
+
+:::
+
+## Instructions
+
+### Configuration
+
+::: tip
+
+An application can be created at https://<your-fusionauth-server-url>/admin/application.
+
+For more information, follow the [FusionAuth 5-minute setup guide](https://fusionauth.io/docs/v1/tech/5-minute-setup-guide).
+
+:::
+
+In the OAuth settings for your application, configure the following information.
+* Redirect URL
+  - https://localhost:3000/api/auth/callback/fusionauth
+* Enabled grants
+  - Make sure *Authorization Code* is enabled.

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
       'providers/email',
       'providers/credentials',
       'providers/facebook',
+      'providers/fusionauth',
       'providers/github',
       'providers/gitlab',
       'providers/google',


### PR DESCRIPTION
I'm working on a project that uses a FusionAuth instance as the OAuth2 server. I wrote a custom provider for next-auth to integrate this, and thought it would be great to have built-in support.