### PR TITLE
Change check on being secure

### DIFF
--- a/src/lib/jwt.js
+++ b/src/lib/jwt.js
@@ -95,8 +95,8 @@ const getToken = async (args) => {
   const {
     req,
     // Use secure prefix for cookie name, unless URL is NEXTAUTH_URL is http://
-    // or not set (e.g. development or test instance) case use unprefixed name
-    secureCookie = !(!process.env.NEXTAUTH_URL || process.env.NEXTAUTH_URL.startsWith('http://')),
+    // If NEXTAUTH_URL is not set, consider it to be production and so secure
+    secureCookie = !(process.env.NEXTAUTH_URL && !process.env.NEXTAUTH_URL.startsWith('http://')),
     cookieName = (secureCookie) ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
     raw = false
   } = args


### PR DESCRIPTION
When calling `jwt.getToken` let's consider the cookie to be secure if `NEXTAUTH_URL` is not set.
Documentation asks the user to set that variable in development and, in production, that variable cannot be set because the url is
dynamically created. That said, the check in getToken function should be changed as in this PR.

I'm opening this PR more as a discussion point. Generally speaking I feel this project should try to work without `NEXTAUTH_URL` at all and use instead `VERCEL_URL` or `req.headers.host` if the domain name is really needed