### PR TITLE
Set Discord to Prompt = None

### DIFF
--- a/src/providers/discord.js
+++ b/src/providers/discord.js
@@ -8,7 +8,7 @@ export default (options) => {
     params: { grant_type: 'authorization_code' },
     accessTokenUrl: 'https://discordapp.com/api/oauth2/token',
     authorizationUrl:
-      'https://discordapp.com/api/oauth2/authorize?response_type=code&prompt=consent',
+      'https://discordapp.com/api/oauth2/authorize?response_type=code&prompt=none',
     profileUrl: 'https://discordapp.com/api/users/@me',
     profile: (profile) => {
       return {

--- a/src/providers/discord.js
+++ b/src/providers/discord.js
@@ -8,8 +8,8 @@ export default (options) => {
     params: { grant_type: 'authorization_code' },
     accessTokenUrl: 'https://discord.com/api/oauth2/token',
     authorizationUrl:
-      'https://discordapp.com/api/oauth2/authorize?response_type=code&prompt=none',
-    profileUrl: 'https://discordapp.com/api/users/@me',
+      'https://discord.com/api/oauth2/authorize?response_type=code&prompt=none',
+    profileUrl: 'https://discord.com/api/users/@me',
     profile: (profile) => {
       return {
         id: profile.id,


### PR DESCRIPTION
When you set the value of `prompt` to `none` in the get params, Discord will not prompt the user if they have auth'd with your app before. (It will just display the page and then the page disappears and they are in.)

Docs: https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-authorization-url-example