### PR TITLE
Spotify provider: fix error occurred when profile image is not set

### DIFF
--- a/src/providers/spotify.js
+++ b/src/providers/spotify.js
@@ -15,7 +15,7 @@ export default (options) => {
         id: profile.id,
         name: profile.display_name,
         email: profile.email,
-        image: profile.images[0].url
+        image: profile.images.length > 0 ? profile.images[0].url : undefined
       }
     },
     ...options


### PR DESCRIPTION
> [next-auth][error][oauth_parse_profile_error] [ TypeError: Cannot read property 'url' of undefined