### PR TITLE
Docs(pages):remove-arrow-syntax

### DIFF
--- a/www/docs/configuration/options.md
+++ b/www/docs/configuration/options.md
@@ -103,9 +103,9 @@ session: {
 
 #### Description
 
-JSON Web Tokens are can be used for session tokens if enabled with `session: { jwt: true }` option. JSON Web Tokens enabled by default if you have not specified a database.
+JSON Web Tokens can be used for session tokens if enabled with `session: { jwt: true }` option. JSON Web Tokens are enabled by default if you have not specified a database.
 
-By default JSON Web Tokens tokens are signed (JWS) but not encrypted (JWE), as JWT encryption adds additional overhead and comes with some caveats. You can enable encryption by setting `encryption: true`.
+By default JSON Web Tokens are signed (JWS) but not encrypted (JWE), as JWT encryption adds additional overhead and comes with some caveats. You can enable encryption by setting `encryption: true`.
 
 #### JSON Web Token Options
 

--- a/www/docs/configuration/pages.md
+++ b/www/docs/configuration/pages.md
@@ -58,7 +58,7 @@ If you create a custom sign in form for email sign in, you will need to submit b
 import React from 'react'
 import { csrfToken } from 'next-auth/client'
 
-export default function SignIn({ csrfToken }) => {
+export default function SignIn({ csrfToken }) {
   return (
     <form method='post' action='/api/auth/signin/email'>
       <input name='csrfToken' type='hidden' defaultValue={csrfToken}/>
@@ -92,7 +92,7 @@ If you create a sign in form for credentials based authentication, you will need
 import React from 'react'
 import { csrfToken } from 'next-auth/client'
 
-export default function SignIn({ csrfToken }) => {
+export default function SignIn({ csrfToken }) {
   return (
     <form method='post' action='/api/auth/callback/credentials'>
       <input name='csrfToken' type='hidden' defaultValue={csrfToken}/>


### PR DESCRIPTION
I removed the arrow syntax (`=>`) from regular functions in the example code