### PR TITLE
jst -> jwt

### DIFF
--- a/www/docs/providers/apple.md
+++ b/www/docs/providers/apple.md
@@ -179,7 +179,7 @@ app.prepare().then(() => {
 If you want to pre-generate your secret, this is an example of the code you will need:
 
 ```js
-const jst = require('jsonwebtoken')
+const jwt = require('jsonwebtoken')
 const fs = require('fs')
 
 const appleId = 'myapp.example.com'


### PR DESCRIPTION
This PR fixes a small typo in the Sign in with Apple docs where `require('jsonwebtoken')` is imported as `jst` but later used as `jwt`