### PR TITLE
Add missing comma in type object

### DIFF
--- a/www/docs/configuration/databases.md
+++ b/www/docs/configuration/databases.md
@@ -59,7 +59,7 @@ database: {
   port: 3306,
   username: 'nextauth',
   password: 'password',
-  database: 'database_name'
+  database: 'database_name',
   entityPrefix: 'nextauth_'
 }
 ```


### PR DESCRIPTION
This PR adds a missing comma to the database type object to make it work when copy-pasted