### PR TITLE
Correction on getProviders Docs snippet

### DIFF
--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -139,11 +139,11 @@ It can be use useful if you are creating a dynamic custom sign in page.
 #### API Route
 
 ```jsx title="pages/api/example.js"
-import { getSession } from 'next-auth/client'
+import { getProviders } from 'next-auth/client'
 
 export default async (req, res) => {
-  const session = await getSession({ req })
-  console.log('Session', session)
+  const providers = await getProviders({ req })
+  console.log('Providers', providers)
   res.end()
 }
 ```


### PR DESCRIPTION
👋  Hi there! 

I noticed this on the Docs site and figured I would just throw up a PR, happy to follow any PR process necessary to be most helpful.

### What does this PR do?
`getSession` was used where it was meant to be `getProviders` in the docs; this makes the correction