### PR TITLE
Add conditional to integration test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,17 @@ on:
 
 jobs:
   test:
-    # runs-on: ubuntu-latest
+    # Only run tests integration against Pull Requests from branches in
+    # this repository. We do this as integration tests require access to
+    # secrets in GitHub and they are not exposed to tests run against
+    # forks (for security reasons), so integration test against
+    # Pull Requests from external repos just fail and generate noise.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    # We use self-hosted runners as cloud based runnners (e.g. AWS, GPC)
+    # fail due to IP Address checks done by providers, which enforce 
+    # CAPTCHA checks on login request from cloud compute IP addresses to
+    # prevent abuse.
     runs-on: self-hosted
 
     # Target time is under 5 minutes to run all tests. If it takes longer than


### PR DESCRIPTION
Will stop tests appearing as failed when merging in Pull Requests from remote branches. These always fail as GitHub does not expose secrets (required for the tests to run) to Pull Requests run against remote branches for security reasons.

For things like documentation changes this will reduce the noise in GitHub.

When merging in changes that impact the authentication flows or core library, if we want to run tests before we merge them into `main`, we can merge them to a local branch like `next-auth/some-pr-name` *before* we merge them in to `next-auth/main`.