### PR TITLE
send signInCallbackResponse to jwt callback

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -67,8 +67,9 @@ export default async (req, res, options, done) => {
             }
           }
 
+          let signInCallbackResponse
           try {
-            const signInCallbackResponse = await callbacks.signIn(userOrProfile, account, OAuthProfile)
+            signInCallbackResponse = await callbacks.signIn(userOrProfile, account, OAuthProfile)
             if (signInCallbackResponse === false) {
               return redirect(`${baseUrl}${basePath}/error?error=AccessDenied`)
             }
@@ -87,7 +88,8 @@ export default async (req, res, options, done) => {
             const defaultJwtPayload = {
               name: user.name,
               email: user.email,
-              picture: user.image
+              picture: user.image,
+              ...(typeof signInCallbackResponse === "object" ? signInCallbackResponse : {})
             }
             const jwtPayload = await callbacks.jwt(defaultJwtPayload, user, account, OAuthProfile, isNewUser)
 

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -44,8 +44,8 @@ callbacks: {
    * @param  {object} user      User object
    * @param  {object} account   Provider account
    * @param  {object} profile   Provider profile 
-   * @return {boolean | object} Return `true` (or a modified JWT) to allow sign in
-   *                            Return `false` to deny access
+   * @return {boolean | object} Return `true` (or a modified JWT, that will be passed to the jwt() callback)
+   *                            to allow sign in. Return `false` to deny access
    */
   signIn: async (user, account, profile) => {
     const isAllowedToSignIn = true

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -41,11 +41,11 @@ Use the `signIn()` callback to control if a user is allowed to sign in.
 ```js title="pages/api/auth/[...nextauth.js]"
 callbacks: {
   /**
-   * @param  {object} user     User object
-   * @param  {object} account  Provider account
-   * @param  {object} profile  Provider profile 
-   * @return {boolean}         Return `true` (or a modified JWT) to allow sign in
-   *                           Return `false` to deny access
+   * @param  {object} user      User object
+   * @param  {object} account   Provider account
+   * @param  {object} profile   Provider profile 
+   * @return {boolean | object} Return `true` (or a modified JWT) to allow sign in
+   *                            Return `false` to deny access
    */
   signIn: async (user, account, profile) => {
     const isAllowedToSignIn = true


### PR DESCRIPTION
According to [the docs](https://next-auth.js.org/configuration/callbacks#sign-in-callback), it should be possible to return a modified JWT token in the `signIn` callback, which (if it is an object) should probably be sent further to the `jwt` callback.


Fixes #728