### PR TITLE
fix: update Okta routes

### DIFF
--- a/src/providers/okta.js
+++ b/src/providers/okta.js
@@ -11,9 +11,9 @@ export default (options) => {
       client_secret: options.clientSecret
     },
     // These will be different depending on the Org.
-    accessTokenUrl: `https://${options.domain}/oauth2/v1/token`,
-    authorizationUrl: `https://${options.domain}/oauth2/v1/authorize/?response_type=code`,
-    profileUrl: `https://${options.domain}/oauth2/v1/userinfo/`,
+    accessTokenUrl: `https://${options.domain}/v1/token`,
+    authorizationUrl: `https://${options.domain}/v1/authorize/?response_type=code`,
+    profileUrl: `https://${options.domain}/v1/userinfo/`,
     profile: (profile) => {
       return { ...profile, id: profile.sub }
     },


### PR DESCRIPTION
the current routing for the Okta provider does not follow the standard set by Okta, and as such doesn't allow for custom subdomains. this update amends the routes to allow for customer subdomains, and also aligns next-auth with Okta's documentation (or, at least, the Okta-React docs, [here](https://github.com/okta/okta-oidc-js/tree/master/packages/okta-react))