### PR TITLE
Auth0: added callbackUrl documentation

### DIFF
--- a/www/docs/providers/auth0.md
+++ b/www/docs/providers/auth0.md
@@ -15,6 +15,10 @@ https://manage.auth0.com/dashboard
 Configure your application in Auth0 as a 'Regular Web Application' (not a 'Single Page App').
 :::
 
+:::tip
+`callbackUrl` in Auth0 application needs to be set to `http://localhost:3000/api/auth/callback/auth0`
+:::
+
 ## Example
 
 ```js


### PR DESCRIPTION
Based on callbackUrl [comment](https://github.com/nextauthjs/next-auth/issues/695) and my searching around, thought it'd be helpful to add it to the actual documentation