### PR TITLE
fix: capitalization of errors in url params

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -36,7 +36,7 @@ export default async (req, res, options, done) => {
         try {
           if (error) {
             logger.error('CALLBACK_OAUTH_ERROR', error)
-            return redirect(`${baseUrl}${basePath}/error?error=oAuthCallback`)
+            return redirect(`${baseUrl}${basePath}/error?error=OAuthCallback`)
           }
 
           // Make it easier to debug when adding a new provider

--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -26,7 +26,7 @@ export default async (req, res, options, done) => {
     oAuthSignin(provider, csrfToken, (error, oAuthSigninUrl) => {
       if (error) {
         logger.error('SIGNIN_OAUTH_ERROR', error)
-        return redirect(`${baseUrl}${basePath}/error?error=oAuthSignin`)
+        return redirect(`${baseUrl}${basePath}/error?error=OAuthSignin`)
       }
 
       return redirect(oAuthSigninUrl)


### PR DESCRIPTION
Due to the bad casing of `oAuthCallback` and `oAuthSignin`, they couldn't have been caught properly by error handler mechanisms.