### PR TITLE
Error if we don't install mongodb driver

### DIFF
--- a/www/docs/schemas/mongodb.md
+++ b/www/docs/schemas/mongodb.md
@@ -7,6 +7,11 @@ MongoDB is a document database and does not use schemas in the same way as most 
 
 **In MongoDB as collections and indexes are created automatically.**
 
+## Add MongoDB Driver to your dependencies:
+```
+npm install --save mongodb
+```
+
 ## Objects in MongoDB
 
 Objects stored in MongoDB use similar datatypes to SQL, with some differences:


### PR DESCRIPTION
I am getting this error when i don't install the MongoDB driver
```
[next-auth][error][adapter_connection_error] DriverPackageNotInstalledError: MongoDB package has not been found installed. Try to install it: npm install mongodb --save
     at new DriverPackageNotInstalledError (myproject\node_modules\typeorm\error\DriverPackageNotInstalledError.js:10:28)
     at MongoDriver.loadDependencies (myproject\node_modules\typeorm\driver\mongodb\MongoDriver.js:340:19)
```
After installing it everything is working great