### PR TITLE
docs: fix typo in callbacks.md

### DIFF
--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -148,7 +148,7 @@ If using JSON Web Tokens instead of database sessions, you should use the User I
 ## JWT callback
 
 This JSON Web Token callback is called whenever a JSON Web Token is created (i.e. at sign 
-in) or updated (i.e whenever a session is accesed in the client).
+in) or updated (i.e whenever a session is accessed in the client).
 
 e.g. `/api/auth/signin`, `getSession()`, `useSession()`, `/api/auth/session`
 


### PR DESCRIPTION
This is a simple typographical error changed accesed to accessed