### PR TITLE
feat: forward auth params from signin to provider

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -235,7 +235,7 @@ const signIn = async (provider, args = {}, authParams = {}) => {
     let signInUrl = (providers[provider].type === 'credentials')
       ? `${baseUrl}/callback/${provider}`
       : `${baseUrl}/signin/${provider}`
-    
+
     if (authParams) {
       signInUrl += `?${new URLSearchParams(authParams).toString()}`
     }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -222,7 +222,7 @@ const _useSessionHook = (session) => {
 }
 
 // Client side method
-const signIn = async (provider, args = {}) => {
+const signIn = async (provider, args = {}, authParams = {}) => {
   const baseUrl = _apiBaseUrl()
   const callbackUrl = (args && args.callbackUrl) ? args.callbackUrl : window.location
   const providers = await getProviders()
@@ -232,9 +232,14 @@ const signIn = async (provider, args = {}) => {
     // If Provider not recognized, redirect to sign in page
     window.location = `${baseUrl}/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`
   } else {
-    const signInUrl = (providers[provider].type === 'credentials')
+    let signInUrl = (providers[provider].type === 'credentials')
       ? `${baseUrl}/callback/${provider}`
       : `${baseUrl}/signin/${provider}`
+    
+    if (authParams) {
+      signInUrl += `?${new URLSearchParams(authParams).toString()}`
+    }
+
     // If is any other provider type, POST to provider URL with CSRF Token,
     // callback URL and any other parameters supplied.
     const fetchOptions = {

--- a/src/server/lib/signin/oauth.js
+++ b/src/server/lib/signin/oauth.js
@@ -2,7 +2,7 @@ import oAuthClient from '../oauth/client'
 import { createHash } from 'crypto'
 import logger from '../../../lib/logger'
 
-export default (provider, csrfToken, callback) => {
+export default (provider, csrfToken, callback, authParams) => {
   const { callbackUrl } = provider
   const client = oAuthClient(provider)
   if (provider.version && provider.version.startsWith('2.')) {
@@ -11,7 +11,8 @@ export default (provider, csrfToken, callback) => {
       redirect_uri: provider.callbackUrl,
       scope: provider.scope,
       // A hash of the NextAuth.js CSRF token is used as the state
-      state: createHash('sha256').update(csrfToken).digest('hex')
+      state: createHash('sha256').update(csrfToken).digest('hex'),
+      ...authParams
     })
 
     // If the authorizationUrl specified in the config has query parameters on it

--- a/src/server/lib/signin/oauth.js
+++ b/src/server/lib/signin/oauth.js
@@ -8,11 +8,11 @@ export default (provider, csrfToken, callback, authParams) => {
   if (provider.version && provider.version.startsWith('2.')) {
     // Handle oAuth v2.x
     let url = client.getAuthorizeUrl({
+      ...authParams,
       redirect_uri: provider.callbackUrl,
       scope: provider.scope,
       // A hash of the NextAuth.js CSRF token is used as the state
-      state: createHash('sha256').update(csrfToken).digest('hex'),
-      ...authParams
+      state: createHash('sha256').update(csrfToken).digest('hex')
     })
 
     // If the authorizationUrl specified in the config has query parameters on it

--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -23,6 +23,9 @@ export default async (req, res, options, done) => {
   }
 
   if (type === 'oauth' && req.method === 'POST') {
+    const authParams = {...req.query}
+    delete authParams.nextauth // This is probably not intended to be sent to the provider, remove
+
     oAuthSignin(provider, csrfToken, (error, oAuthSigninUrl) => {
       if (error) {
         logger.error('SIGNIN_OAUTH_ERROR', error)
@@ -30,7 +33,7 @@ export default async (req, res, options, done) => {
       }
 
       return redirect(oAuthSigninUrl)
-    })
+    }, authParams)
   } else if (type === 'email' && req.method === 'POST') {
     if (!adapter) {
       logger.error('EMAIL_REQUIRES_ADAPTER_ERROR')

--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -23,7 +23,7 @@ export default async (req, res, options, done) => {
   }
 
   if (type === 'oauth' && req.method === 'POST') {
-    const authParams = {...req.query}
+    const authParams = { ...req.query }
     delete authParams.nextauth // This is probably not intended to be sent to the provider, remove
 
     oAuthSignin(provider, csrfToken, (error, oAuthSigninUrl) => {


### PR DESCRIPTION
According to the spec, additional parameters can be sent to the authorization url, please see the spec:

https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

I would like to send the `prompt: "login"` param, so my users will be forced to log in on the Provider, whenever they click on a button with the handler
```js
signIn("identity-server4", {}, {
  prompt: "login"
})
```

NOTE: These params should not be sent in the body as `args` here:
https://github.com/nextauthjs/next-auth/blob/5126f4e3428f2b4b8ebdd38b10066edfdd4ea2fa/src/client/index.js#L238-L251

This is why I decided to add a third argument to the `signIn` function instead. This also keeps this change **backward compatible**.

**Tested this locally, and it works as intended**

This fixes #737, as far as I can tell.