### PR TITLE
update(docs): postgres.md so the instructions are fit for Spotify as a provider.

### DIFF
--- a/www/docs/schemas/postgres.md
+++ b/www/docs/schemas/postgres.md
@@ -46,7 +46,7 @@ CREATE TABLE users
     name           VARCHAR(255),
     email          VARCHAR(255),
     email_verified TIMESTAMPTZ,
-    image          VARCHAR(255),
+    image          VARCHAR(300),
     created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id)


### PR DESCRIPTION
A typical Spotify avatar URL is as follow:
```
https://scontent-ams4-1.xx.fbcdn.net/v/t1.0-1/c124.0.320.320a/p320x320/44594471_10217288278180083_8889099770203734016_o.jpg?_nc_cat=103&ccb=2&_nc_sid=0c64ff&_nc_ohc=wHUMWDX3V20AX-k8dIO&_nc_ht=scontent-ams4-1.xx&tp=27&oh=c91bd3a69375dfcc6811a75dcb5c3234&oe=5FD3FCAA
```

This is 264 characters long and so this db schema does not work and you get an error. Upping the character count for image URL solves the problem.