### PR TITLE
docs: remove redundant 3rd arg to sessions example

### DIFF
--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -125,7 +125,7 @@ callbacks: {
    *                               JSON Web Token (if not using database sessions)
    * @return {object}              Session that will be returned to the client 
    */
-  session: async (session, user, sessionToken) => {
+  session: async (session, user) => {
     session.foo = 'bar' // Add property to session
     return Promise.resolve(session)
   }


### PR DESCRIPTION
There is no third argument as per https://github.com/nextauthjs/next-auth/blob/8115a7c66cdb1d86b0d2a0d76b9aa33c2bfaa33b/src/server/routes/session.js#L82