### PR TITLE
docs: update API docs about server-side `getProviders`

### DIFF
--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -134,10 +134,6 @@ It calls `/api/auth/providers` and returns a list of the currently configured au
 
 It can be use useful if you are creating a dynamic custom sign in page.
 
-:::note
-Unlike `getSession()` and `getCsrfToken()`, when calling `getSession()` server side, you don't need to pass anything, just as calling it client side.
-:::
-
 ---
 
 #### API Route
@@ -151,6 +147,10 @@ export default async (req, res) => {
   res.end()
 }
 ```
+
+:::note
+Unlike `getSession()` and `getCsrfToken()`, when calling `getSession()` server side, you don't need to pass anything, just as calling it client side.
+:::
 
 ---
 

--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -134,6 +134,10 @@ It calls `/api/auth/providers` and returns a list of the currently configured au
 
 It can be use useful if you are creating a dynamic custom sign in page.
 
+:::note
+Unlike `getSession()` and `getCsrfToken()`, when calling `getSession()` server side, you don't need to pass anything, just as calling it client side.
+:::
+
 ---
 
 #### API Route
@@ -142,7 +146,7 @@ It can be use useful if you are creating a dynamic custom sign in page.
 import { getProviders } from 'next-auth/client'
 
 export default async (req, res) => {
-  const providers = await getProviders({ req })
+  const providers = await getProviders()
   console.log('Providers', providers)
   res.end()
 }


### PR DESCRIPTION
Server-side `getProviders` accepts zero parameter just as the client-side one. Currently the docs write `const providers = await getProviders({ req })`, which is confusing. If the user uses `@types/next-auth`, she/he will find that the type signature of `getProviders` is `() => Promise<GetProvidersResponse | null>` instead of `(context?: NextContext) => Promise<GetProvidersResponse | null>`