### PR TITLE
refactor: update Prisma calls to support 2.12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "mysql": "^2.18.1",
     "mssql": "^6.2.1",
     "pg": "^8.2.1",
-    "@prisma/client": "^2.3.0"
+    "@prisma/client": "^2.12.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/adapters/prisma/index.js
+++ b/src/adapters/prisma/index.js
@@ -57,7 +57,7 @@ const Adapter = (config) => {
     async function getUser (id) {
       debug('GET_USER', id)
       try {
-        return prisma[User].findOne({ where: { id } })
+        return prisma[User].findUnique({ where: { id } })
       } catch (error) {
         logger.error('GET_USER_BY_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_ID_ERROR', error))
@@ -68,7 +68,7 @@ const Adapter = (config) => {
       debug('GET_USER_BY_EMAIL', email)
       try {
         if (!email) { return Promise.resolve(null) }
-        return prisma[User].findOne({ where: { email } })
+        return prisma[User].findUnique({ where: { email } })
       } catch (error) {
         logger.error('GET_USER_BY_EMAIL_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_EMAIL_ERROR', error))
@@ -78,9 +78,9 @@ const Adapter = (config) => {
     async function getUserByProviderAccountId (providerId, providerAccountId) {
       debug('GET_USER_BY_PROVIDER_ACCOUNT_ID', providerId, providerAccountId)
       try {
-        const account = await prisma[Account].findOne({ where: { compoundId: getCompoundId(providerId, providerAccountId) } })
+        const account = await prisma[Account].findUnique({ where: { compoundId: getCompoundId(providerId, providerAccountId) } })
         if (!account) { return null }
-        return prisma[User].findOne({ where: { id: account.userId } })
+        return prisma[User].findUnique({ where: { id: account.userId } })
       } catch (error) {
         logger.error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error))
@@ -174,7 +174,7 @@ const Adapter = (config) => {
     async function getSession (sessionToken) {
       debug('GET_SESSION', sessionToken)
       try {
-        const session = await prisma[Session].findOne({ where: { sessionToken } })
+        const session = await prisma[Session].findUnique({ where: { sessionToken } })
 
         // Check session has not expired (do not return it if it has)
         if (session && session.expires && new Date() > session.expires) {
@@ -280,7 +280,7 @@ const Adapter = (config) => {
         // Hash token provided with secret before trying to match it with database
         // @TODO Use bcrypt instead of salted SHA-256 hash for token
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')
-        const verificationRequest = await prisma[VerificationRequest].findOne({ where: { token: hashedToken } })
+        const verificationRequest = await prisma[VerificationRequest].findUnique({ where: { token: hashedToken } })
 
         if (verificationRequest && verificationRequest.expires && new Date() > verificationRequest.expires) {
           // Delete verification entry so it cannot be used again

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -144,7 +144,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
       }
 
       try {
-        return manager.findOne(User, { [idKey]: id })
+        return manager.findUnique(User, { [idKey]: id })
       } catch (error) {
         logger.error('GET_USER_BY_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_ID_ERROR', error))
@@ -155,7 +155,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
       debug('GET_USER_BY_EMAIL', email)
       try {
         if (!email) { return Promise.resolve(null) }
-        return manager.findOne(User, { email })
+        return manager.findUnique(User, { email })
       } catch (error) {
         logger.error('GET_USER_BY_EMAIL_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_EMAIL_ERROR', error))
@@ -165,9 +165,9 @@ const Adapter = (typeOrmConfig, options = {}) => {
     async function getUserByProviderAccountId (providerId, providerAccountId) {
       debug('GET_USER_BY_PROVIDER_ACCOUNT_ID', providerId, providerAccountId)
       try {
-        const account = await manager.findOne(Account, { providerId, providerAccountId })
+        const account = await manager.findUnique(Account, { providerId, providerAccountId })
         if (!account) { return null }
-        return manager.findOne(User, { [idKey]: account.userId })
+        return manager.findUnique(User, { [idKey]: account.userId })
       } catch (error) {
         logger.error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error))
@@ -227,7 +227,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
     async function getSession (sessionToken) {
       debug('GET_SESSION', sessionToken)
       try {
-        const session = await manager.findOne(Session, { sessionToken })
+        const session = await manager.findUnique(Session, { sessionToken })
 
         // Check session has not expired (do not return it if it has)
         if (session && session.expires && new Date() > new Date(session.expires)) {
@@ -327,7 +327,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         // Hash token provided with secret before trying to match it with database
         // @TODO Use bcrypt instead of salted SHA-256 hash for token
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')
-        const verificationRequest = await manager.findOne(VerificationRequest, { identifier, token: hashedToken })
+        const verificationRequest = await manager.findUnique(VerificationRequest, { identifier, token: hashedToken })
 
         if (verificationRequest && verificationRequest.expires && new Date() > new Date(verificationRequest.expires)) {
           // Delete verification entry so it cannot be used again


### PR DESCRIPTION
[Prisma 2.12](https://github.com/prisma/prisma/releases/tag/2.12.0) deprecates the `findOne` method in favor of `findUnique`. I've updated the corresponding adapter to reflect these changes.

Please consider releasing a new minor version of NextAuth.js soon, as the current one has severe breakages due to #559 (fixed by #626 but not yet released).