### PR TITLE
Enable login hinting for OAuth services like Google

### DIFF
--- a/src/providers/google.js
+++ b/src/providers/google.js
@@ -18,6 +18,11 @@ export default (options) => {
         image: profile.picture
       }
     },
+    authorizationParams: (body) => {
+      return {
+        login_hint: body.email || undefined
+      }
+    },
     ...options
   }
 }

--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -29,9 +29,9 @@ export default async (req, res, options, done) => {
         return redirect(`${baseUrl}${basePath}/error?error=OAuthSignin`)
       }
 
-      const authorizationParams = retrieveAuthorizationParams(provider, req.body);
-      const delimiter = oAuthSigninUrl.includes('?') ? '&' : '?';
-      oAuthSigninUrl += delimiter + authorizationParams;      
+      const authorizationParams = retrieveAuthorizationParams(provider, req.body)
+      const delimiter = oAuthSigninUrl.includes('?') ? '&' : '?'
+      oAuthSigninUrl += delimiter + authorizationParams
 
       return redirect(oAuthSigninUrl)
     })
@@ -75,8 +75,8 @@ export default async (req, res, options, done) => {
     }
 
     return redirect(`${baseUrl}${basePath}/verify-request?provider=${encodeURIComponent(
-        provider.id
-      )}&type=${encodeURIComponent(provider.type)}`)
+      provider.id
+    )}&type=${encodeURIComponent(provider.type)}`)
   } else {
     return redirect(`${baseUrl}${basePath}/signin`)
   }
@@ -86,15 +86,15 @@ export default async (req, res, options, done) => {
  * Parses and turns the request-based authorization parameters
  * into a query string (without an initial delimiter).
  */
-function retrieveAuthorizationParams(provider, requestBody) {
-  let stringifiedParams = "";
-  let additionalParams = provider.authorizationParams;
+function retrieveAuthorizationParams (provider, requestBody) {
+  let stringifiedParams = ''
+  let additionalParams = provider.authorizationParams
 
-  if (typeof additionalParams === "function") {
-    additionalParams = additionalParams(requestBody);
+  if (typeof additionalParams === 'function') {
+    additionalParams = additionalParams(requestBody)
   }
 
-  if (additionalParams && typeof additionalParams === "object") {
+  if (additionalParams && typeof additionalParams === 'object') {
     for (const key of Object.keys(additionalParams)) {
       if (typeof additionalParams[key] !== 'string') continue
 
@@ -104,5 +104,5 @@ function retrieveAuthorizationParams(provider, requestBody) {
   }
 
   // Axe the first & so it can be appended properly.
-  return stringifiedParams.substring(1);
+  return stringifiedParams.substring(1)
 }

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -99,6 +99,11 @@ As an example of what this looks like, this is the the provider object returned 
       image: profile.picture
     }
   },
+  authorizationParams: (body) => {
+    return {
+      login_hint: body.email || undefined
+    }
+  },
   clientId: '',
   clientSecret: ''
 }
@@ -133,7 +138,8 @@ providers: [
 |       type       | Type of provider, in this case it should be `oauth` |   Yes    |
 |     version      |     OAuth version (e.g. '1.0', '1.0a', '2.0')       |   Yes    |
 |      scope       |       OAuth access scopes (expects array or string) |    No    |
-|      params      |       Additional authorization URL parameters       |    No    |
+|      params      |       Additional access token URL parameters        |    No    |
+| authorizationParams | Additional authorization URL parameters (expects object or function) |    No    |
 |  accessTokenUrl  |        Endpoint to retrieve an access token         |   Yes    |
 | requestTokenUrl  |        Endpoint to retrieve a request token         |    No    |
 | authorizationUrl |   Endpoint to request authorization from the user   |   Yes    |
@@ -143,6 +149,10 @@ providers: [
 |   clientSecret   |         Client Secret of the OAuth provider         |    No    |
 |      idToken     |  Set to `true` for services that use ID Tokens (e.g. OpenID)     |    No    |
 |      state     | Set to `false` for services that do not support `state` verfication |    No    |
+
+Note that `authorizationParams` can be a function taking a request body object, which includes
+additional parameters passed to [`signIn`](/getting-started/client#signin). This is used in the
+Google provider to optionally provide a login_hint that can pre-fill a user's email.
 
 :::note
 Feel free to open a PR for your custom configuration if you've created one for a provider that others may be interested in so we can add it to the list of built-in OAuth providers!


### PR DESCRIPTION
tl;dr: Allows additional options passed from `signIn` to be used in order to build additional query params that are eventually passed to the OAuth authorization URL.

Some OAuth providers, like Google, allow you to customize the login flow on their side of things by adding additional query parameters. In particular, for Google, if you know the email of the user trying to sign in, you can give them a `login_hint` parameter that pre-fills that email address when logging in, or pre-selects that account if the user is already signed into multiple.

Pull request includes a modification to the google provider that allows the above if `email` is passed in as extra data to the `signIn` function. Also updated the docs with information about this usage. (While doing so, I also discovered that the docs claim that the `params` provider option affects the authorization URL, when it actually affects the access token URL – that was fixed to avoid confusion.)

I'm using a sign-in flow on my site where users are first asked to enter their email before being redirected to their sign-in method of choice – this just helps with the user experience on their end!

If this gets merged I'm happy to update the typings over at DefinitelyTyped.

Thank you all!!