### PR TITLE
Add stalebot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - priority
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Hi there! It looks like this issue hasn't had any activity for a while.
+  It will be closed if no further activity occurs. If you think your issue
+  is still relevant, feel free to comment on it to keep ot open. Thanks!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Hi there! It looks like this issue hasn't had any activity for a while.
+  To keep things tidy, I am going to close this issue for now.
+  If you think your issue is still relevant, just leave a comment
+  and I will reopen it. Thanks!


### PR DESCRIPTION
Recently, the number of issues has grown significantly. To tackle this problem, I set up stalebot, that will take care of issues that do not receive any activity for 60 days, and add a stale label to them. If no further action for an additional 7 days, the issue will be closed. The issue author will receive a notification from GitHub, and if they think their issue is still relevant, a simple comment will re-poen the issue.


Issues with certain labels (`priority`, `security`, `pinned`) will never be marked as stale, nor will be closed.