### PR TITLE
Revert "feat: simplify NextAuth instantiation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Alternatively you can raise a PR directly with your fixes on [**DefinitelyTyped*
 import NextAuth from 'next-auth'
 import Providers from 'next-auth/providers'
 
-export default NextAuth({
+const options = {
   providers: [
     // OAuth authentication providers
     Providers.Apple({
@@ -87,7 +87,9 @@ export default NextAuth({
   ],
   // SQL or MongoDB database (or leave empty)
   database: process.env.DATABASE_URL
-})
+}
+
+export default (req, res) => NextAuth(req, res, options)
 ```
 
 ### Add React Component

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -21,7 +21,7 @@ if (!process.env.NEXTAUTH_URL) {
   logger.warn('NEXTAUTH_URL', 'NEXTAUTH_URL environment variable not set')
 }
 
-async function NextAuth (req, res, userSuppliedOptions) {
+export default async (req, res, userSuppliedOptions) => {
   // To the best of my knowledge, we need to return a promise here
   // to avoid early termination of calls to the serverless function
   // (and then return that promise when we are done) - eslint
@@ -312,12 +312,4 @@ async function NextAuth (req, res, userSuppliedOptions) {
       return done()
     }
   })
-}
-
-export default async (...args) => {
-  if (args.length === 1) {
-    return (req, res) => NextAuth(req, res, args[0])
-  }
-
-  return NextAuth(...args)
 }

--- a/www/docs/getting-started/example.md
+++ b/www/docs/getting-started/example.md
@@ -21,7 +21,7 @@ To add NextAuth.js to a project create a file called `[...nextauth].js` in `page
 import NextAuth from 'next-auth'
 import Providers from 'next-auth/providers'
 
-export default NextAuth({
+const options = {
   // Configure one or more authentication providers
   providers: [
     Providers.GitHub({
@@ -33,7 +33,9 @@ export default NextAuth({
 
   // A database is optional, but required to persist accounts in a database
   database: process.env.DATABASE_URL,
-})
+}
+
+export default (req, res) => NextAuth(req, res, options)
 ```
 
 All requests to `/api/auth/*` (signin, callback, signout, etc) will automatically be handed by NextAuth.js.

--- a/www/docs/schemas/adapters.md
+++ b/www/docs/schemas/adapters.md
@@ -74,7 +74,7 @@ import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
-export default NextAuth({
+const options = {
   providers: [
     Providers.Google({
       clientId: process.env.GOOGLE_CLIENT_ID,
@@ -82,7 +82,9 @@ export default NextAuth({
     })
   ],
   adapter: Adapters.Prisma.Adapter({ prisma }),
-})
+}
+
+export default (req, res) => NextAuth(req, res, options)
 ```
 
 :::tip

--- a/www/docs/tutorials/ldap-auth.md
+++ b/www/docs/tutorials/ldap-auth.md
@@ -14,7 +14,7 @@ const ldap = require("ldapjs");
 import NextAuth from "next-auth";
 import Providers from "next-auth/providers";
 
-export default NextAuth({
+const options = {
   providers: [
     Providers.Credentials({
       name: "LDAP",
@@ -64,7 +64,9 @@ export default NextAuth({
     secret: process.env.NEXTAUTH_SECRET,
     encryption: true, // Very important to encrypt the JWT, otherwise you're leaking username+password into the browser
   },
-});
+};
+
+export default (req, res) => NextAuth(req, res, options);
 ```
 
 The idea is that once one is authenticated with the LDAP server, one can pass through both the username/DN and password to the JWT stored in the browser. 

--- a/www/docs/tutorials/typeorm-custom-models.md
+++ b/www/docs/tutorials/typeorm-custom-models.md
@@ -62,7 +62,7 @@ import Adapters from "next-auth/adapters"
 
 import Models from "../../../models"
 
-export default NextAuth({
+const options = {
   providers: [
     // Your providers
   ],
@@ -77,7 +77,9 @@ export default NextAuth({
       },
     }
   ),
-})
+}
+
+export default (req, res) => NextAuth(req, res, options)
 ```
 
 

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -219,7 +219,7 @@ const serverlessFunctionCode = `
 import NextAuth from 'next-auth'
 import Providers from 'next-auth/providers'
 
-export default NextAuth({
+const options = {
   providers: [
     // OAuth authentication providers...
     Providers.Apple({
@@ -242,7 +242,9 @@ export default NextAuth({
   ],
   // Optional SQL or MongoDB database to persist users
   database: process.env.DATABASE_URL
-})
+}
+
+export default (req, res) => NextAuth(req, res, options)
 `.trim()
 
 export default Home


### PR DESCRIPTION
Reverts nextauthjs/next-auth#867

Vercel will deploy the docs from `main`. If I add some new functionality and I document it, the docs will automatically update https://next-auth.js.org/, while the latest npm package won't reflect it.

@iaincollins we should either change the behaviour of Vercel docs deployments, or set up a `canary` branch. 

Or I could just *not* document anything while adding features, then we have to remember to do it before releasing `latest` to npm.

**The best option seems to just set up a `canary` branch, and change PR bases to that, as we talked about it earlier.**

Reverting this PR for now, and reopened it on #911.