### PR TITLE
Add Osso as open source SAML provider

### DIFF
--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -17,6 +17,7 @@ import IdentityServer4 from './identity-server4'
 import LinkedIn from './linkedin'
 import Mixer from './mixer'
 import Okta from './okta'
+import Osso from './osso'
 import Slack from './slack'
 import Spotify from './spotify'
 import Twitch from './twitch'
@@ -43,6 +44,7 @@ export default {
   LinkedIn,
   Mixer,
   Okta,
+  Osso,
   Slack,
   Spotify,
   Twitter,

--- a/src/providers/osso.js
+++ b/src/providers/osso.js
@@ -1,0 +1,21 @@
+export default (options) => {
+  return {
+    id: 'osso',
+    name: 'SAML SSO',
+    type: 'oauth',
+    version: '2.0',
+    params: { grant_type: 'authorization_code' },
+    accessTokenUrl: `https://${options.domain}/oauth/token`,
+    authorizationUrl: `https://${options.domain}/oauth/authorize?response_type=code&domain=vcardme.com`,
+    profileUrl: `https://${options.domain}/oauth/me`,
+    profile: (profile) => {
+      return {
+        id: profile.id,
+        name: null,
+        email: profile.email,
+        image: null
+      }
+    },
+    ...options
+  }
+}


### PR DESCRIPTION
Per https://github.com/nextauthjs/next-auth/issues/311 this adds a Provider [Osso](ossoapp.com) - we're like an open source Auth0, but exclusively for SAML 2.0. Osso provides a UI and persistence for configuring SAML identity providers, and wraps a SAML auth process inside in Oauth 2.0 auth code grant flow, which allows us to easily hook in to projects like this that implement Oauth.

Still TODO is I need to make a decision about how to surface an Identity Provider for the user who wishes to sign in.

Auth0 does this on their hosted sign in page - I think we will probably implement similar.

In previous contexts, we ask the developer integrating Osso to ascertain either the user's email or corporate domain, and use that to look up their IDP(s) and redirect them to the right place. I don't see a way of achieving that here - I need an email input, and then for that value to be passed as a query param to the authorize endpoint in our OAuth flow.

So that's hardcoded for now to one of my emails.

I figured before we went and made those changes I'd at least open this draft PR to see if this would be welcome, and to what extent we might be able to solve the issue of getting the user's email prior to kicking off the oauth flow, so this is draft for now.

Edit: sorry, not really sure whats up with git history here?