### PR TITLE
Allow linking oauth with existing unlinked user

### DIFF
--- a/src/server/lib/callback-handler.js
+++ b/src/server/lib/callback-handler.js
@@ -17,7 +17,7 @@ export default async (sessionToken, profile, providerAccount, options) => {
     if (!profile) { throw new Error('Missing profile') }
     if (!providerAccount || !providerAccount.id || !providerAccount.type) { throw new Error('Missing or invalid provider account') }
 
-    const { adapter, jwt, events, linkOAuthWithExistingAccount } = options
+    const { adapter, jwt, events, linkOAuthWithExistingUser } = options
 
     const useJwtSession = options.session.jwt
 
@@ -179,7 +179,7 @@ export default async (sessionToken, profile, providerAccount, options) => {
           // We end up here when we don't have an account with the same [provider].id *BUT*
           // we do already have an account with the same email address as the one in the
           // oAuth profile the user has just tried to sign in with.
-          if (linkOAuthWithExistingAccount) {
+          if (linkOAuthWithExistingUser) {
             await linkAccount(
               userByEmail.id,
               providerAccount.provider,

--- a/src/server/lib/callback-handler.js
+++ b/src/server/lib/callback-handler.js
@@ -17,7 +17,7 @@ export default async (sessionToken, profile, providerAccount, options) => {
     if (!profile) { throw new Error('Missing profile') }
     if (!providerAccount || !providerAccount.id || !providerAccount.type) { throw new Error('Missing or invalid provider account') }
 
-    const { adapter, jwt, events } = options
+    const { adapter, jwt, events, linkOAuthWithExistingAccount } = options
 
     const useJwtSession = options.session.jwt
 
@@ -179,7 +179,25 @@ export default async (sessionToken, profile, providerAccount, options) => {
           // We end up here when we don't have an account with the same [provider].id *BUT*
           // we do already have an account with the same email address as the one in the
           // oAuth profile the user has just tried to sign in with.
-          //
+          if (linkOAuthWithExistingAccount) {
+            await linkAccount(
+              userByEmail.id,
+              providerAccount.provider,
+              providerAccount.type,
+              providerAccount.id,
+              providerAccount.refreshToken,
+              providerAccount.accessToken,
+              providerAccount.accessTokenExpires
+            )
+            await dispatchEvent(events.linkAccount, { user: userByEmail, providerAccount })
+            session = useJwtSession ? {} : await createSession(userByEmail)
+            return {
+              session,
+              user: userByEmail,
+              isNewUser
+            }
+          }
+
           // We don't want to have two accounts with the same email address, and we don't
           // want to link them in case it's not safe to do so, so instead we prompt the user
           // to sign in via email to verify their identity and then link the accounts.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Note before creating the Pull Request. Even though the CONTRIBUTONG.md tells otherwise, we ask you to use the `canary` branch as base for your PR. We are tranistioning to a new structure, and the CONTRIBUTONG.md file has not been updated yet. Thank you!

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Provide an option to allow OAuth to link with existing user found by email address. By default, this is disabled to preserve existing behavior.
<!-- Why are these changes necessary? -->

**Why**:

In some instances, accepting the risk of duplicate user accounts is a better user experience than having the user login with email and then link their account to their oauth provider.

<!-- How were these changes implemented? -->

**How**:

Added a boolean configuration option called `linkOAuthWithExistingUser`
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
