### PR TITLE
fix: treat user.id as optional param

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -88,7 +88,7 @@ export default async (req, res, options, done) => {
               name: user.name,
               email: user.email,
               picture: user.image,
-              sub: user.id.toString()
+              sub: user.id?.toString()
             }
             const jwtPayload = await callbacks.jwt(defaultJwtPayload, user, account, OAuthProfile, isNewUser)
 
@@ -179,7 +179,7 @@ export default async (req, res, options, done) => {
           name: user.name,
           email: user.email,
           picture: user.image,
-          sub: user.id.toString()
+          sub: user.id?.toString()
         }
         const jwtPayload = await callbacks.jwt(defaultJwtPayload, user, account, profile, isNewUser)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Note before creating the Pull Request. Even though the CONTRIBUTONG.md tells otherwise, we ask you to use the `canary` branch as base for your PR. We are tranistioning to a new structure, and the CONTRIBUTONG.md file has not been updated yet. Thank you!

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Treat `user.id` as an optional parameter

<!-- Why are these changes necessary? -->

**Why**:

#784 added user id (`sub`) as a parameter to the default JWT object. Although in some cases it won't be defined, so we should treat as such.
<!-- How were these changes implemented? -->

**How**:

We called `.toString()` on `user.id`, which in case of an `undefined` value threw an error.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

closes #1007
