### PR TITLE
fix: Use `findOne` for typeorm

### DIFF
--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -144,7 +144,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
       }
 
       try {
-        return manager.findUnique(User, { [idKey]: id })
+        return manager.findOne(User, { [idKey]: id })
       } catch (error) {
         logger.error('GET_USER_BY_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_ID_ERROR', error))
@@ -155,7 +155,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
       debug('GET_USER_BY_EMAIL', email)
       try {
         if (!email) { return Promise.resolve(null) }
-        return manager.findUnique(User, { email })
+        return manager.findOne(User, { email })
       } catch (error) {
         logger.error('GET_USER_BY_EMAIL_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_EMAIL_ERROR', error))
@@ -165,9 +165,9 @@ const Adapter = (typeOrmConfig, options = {}) => {
     async function getUserByProviderAccountId (providerId, providerAccountId) {
       debug('GET_USER_BY_PROVIDER_ACCOUNT_ID', providerId, providerAccountId)
       try {
-        const account = await manager.findUnique(Account, { providerId, providerAccountId })
+        const account = await manager.findOne(Account, { providerId, providerAccountId })
         if (!account) { return null }
-        return manager.findUnique(User, { [idKey]: account.userId })
+        return manager.findOne(User, { [idKey]: account.userId })
       } catch (error) {
         logger.error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error))
@@ -227,7 +227,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
     async function getSession (sessionToken) {
       debug('GET_SESSION', sessionToken)
       try {
-        const session = await manager.findUnique(Session, { sessionToken })
+        const session = await manager.findOne(Session, { sessionToken })
 
         // Check session has not expired (do not return it if it has)
         if (session && session.expires && new Date() > new Date(session.expires)) {
@@ -327,7 +327,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         // Hash token provided with secret before trying to match it with database
         // @TODO Use bcrypt instead of salted SHA-256 hash for token
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')
-        const verificationRequest = await manager.findUnique(VerificationRequest, { identifier, token: hashedToken })
+        const verificationRequest = await manager.findOne(VerificationRequest, { identifier, token: hashedToken })
 
         if (verificationRequest && verificationRequest.expires && new Date() > new Date(verificationRequest.expires)) {
           // Delete verification entry so it cannot be used again


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Note before creating the Pull Request. Even though the CONTRIBUTONG.md tells otherwise, we ask you to use the `canary` branch as base for your PR. We are tranistioning to a new structure, and the CONTRIBUTONG.md file has not been updated yet. Thank you!

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

`next-auth` causes an error when app tries to sign-in by email using MySQL and typeorm adapter.

```
app_1    |
app_1    | > next-auth-test@0.0.1 start /
app_1    | > next start
app_1    |
app_1    | ready - started server on http://localhost:3000
app_1    | mysql://nextauth:password@mysql:3306/nextauth
app_1    | [next-auth][debug][typeorm_get_user_by_email] aaaaa@gmail.com
app_1    | [next-auth][error][get_user_by_email_error] TypeError: manager.findUnique is not a function
app_1    |     at /node_modules/next-auth/dist/adapters/typeorm/index.js:188:28
app_1    |     at Generator.next (<anonymous>)
app_1    |     at asyncGeneratorStep (/node_modules/next-auth/dist/adapters/typeorm/index.js:28:103)
app_1    |     at _next (/node_modules/next-auth/dist/adapters/typeorm/index.js:30:194)
app_1    |     at /node_modules/next-auth/dist/adapters/typeorm/index.js:30:364
app_1    |     at new Promise (<anonymous>)
app_1    |     at /node_modules/next-auth/dist/adapters/typeorm/index.js:30:97
app_1    |     at _getUserByEmail (/node_modules/next-auth/dist/adapters/typeorm/index.js:197:32)
app_1    |     at getUserByEmail (/node_modules/next-auth/dist/adapters/typeorm/index.js:176:32)
app_1    |     at /node_modules/next-auth/dist/server/routes/signin.js:72:28
app_1    | https://next-auth.js.org/errors#get_user_by_email_error
app_1    | (node:19) UnhandledPromiseRejectionWarning: Error: GET_USER_BY_EMAIL_ERROR
app_1    |     at /node_modules/next-auth/dist/adapters/typeorm/index.js:194:35
app_1    |     at Generator.next (<anonymous>)
app_1    |     at asyncGeneratorStep (/node_modules/next-auth/dist/adapters/typeorm/index.js:28:103)
app_1    |     at _next (/node_modules/next-auth/dist/adapters/typeorm/index.js:30:194)
app_1    |     at /node_modules/next-auth/dist/adapters/typeorm/index.js:30:364
app_1    |     at new Promise (<anonymous>)
app_1    |     at /node_modules/next-auth/dist/adapters/typeorm/index.js:30:97
app_1    |     at _getUserByEmail (/node_modules/next-auth/dist/adapters/typeorm/index.js:197:32)
app_1    |     at getUserByEmail (/node_modules/next-auth/dist/adapters/typeorm/index.js:176:32)
app_1    |     at /node_modules/next-auth/dist/server/routes/signin.js:72:28
app_1    | (node:19) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 6)
app_1    | (node:19) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**Why**:

<!-- How were these changes implemented? -->

> `app_1    | [next-auth][error][get_user_by_email_error] TypeError: manager.findUnique is not a function`

https://github.com/nextauthjs/next-auth/blob/canary/src/adapters/typeorm/index.js#L158

Because manager (`EntityManager` class) does not have `findUnique` method.
https://github.com/typeorm/typeorm/blob/0.2.24/src/entity-manager/EntityManager.ts

These lines were changed in https://github.com/nextauthjs/next-auth/pull/881 due to Prisma updates, but typeorm adapter didn't have to be modified.

**How**:

<!-- Have you done all of these things?  -->
Use `findUnique` instead of `findOne` for typeorm adapter.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
