### PR TITLE
feat: add profile callback to options

### DIFF
--- a/src/providers/auth0.js
+++ b/src/providers/auth0.js
@@ -9,7 +9,7 @@ export default (options) => {
     accessTokenUrl: `https://${options.domain}/oauth/token`,
     authorizationUrl: `https://${options.domain}/authorize?response_type=code`,
     profileUrl: `https://${options.domain}/userinfo`,
-    profile: (profile) => {
+    profile: options.profile ?? (profile) => {
       return {
         id: profile.sub,
         name: profile.nickname,


### PR DESCRIPTION
**What**:

Add ability to overwrite the profile option, which allows adding additional attributes to the profile.

NOTE: A custom adapter will need to be used to take advantage of this. 

**Why**:

Fixes #597

**How**:

Specify `profile` function in the provider options

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

PS. This will obviously need to be done for all providers. I am simply showing here with a single provider what can be done. 