### PR TITLE
feat: allow to return string in signIn callback

### DIFF
--- a/src/server/lib/callbacks.js
+++ b/src/server/lib/callbacks.js
@@ -12,8 +12,9 @@
  * @param  {object} profile  User profile (e.g. user id, name, email)
  * @param  {object} account  Account used to sign in (e.g. OAuth account)
  * @param  {object} metadata Provider specific metadata (e.g. OAuth Profile)
- * @return {boolean|object}  Return `true` (or a modified JWT) to allow sign in
+ * @return {boolean|string}  Return `true` to allow sign in
  *                           Return `false` to deny access
+ *                           Return `string` to redirect to (eg.: "/unauthorized")
  */
 const signIn = async (profile, account, metadata) => {
   const isAllowedToSignIn = true

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -71,13 +71,16 @@ export default async (req, res, options, done) => {
             const signInCallbackResponse = await callbacks.signIn(userOrProfile, account, OAuthProfile)
             if (signInCallbackResponse === false) {
               return redirect(`${baseUrl}${basePath}/error?error=AccessDenied`)
+            } else if (typeof signInCallbackResponse === 'string') {
+              return redirect(signInCallbackResponse)
             }
           } catch (error) {
             if (error instanceof Error) {
               return redirect(`${baseUrl}${basePath}/error?error=${encodeURIComponent(error)}`)
-            } else {
-              return redirect(error)
             }
+            // TODO: Remove in a future major release
+            logger.warn('SIGNIN_CALLBACK_REJECT_REDIRECT')
+            return redirect(error)
           }
 
           // Sign user in
@@ -162,13 +165,16 @@ export default async (req, res, options, done) => {
         const signInCallbackResponse = await callbacks.signIn(profile, account, { email })
         if (signInCallbackResponse === false) {
           return redirect(`${baseUrl}${basePath}/error?error=AccessDenied`)
+        } else if (typeof signInCallbackResponse === 'string') {
+          return redirect(signInCallbackResponse)
         }
       } catch (error) {
         if (error instanceof Error) {
           return redirect(`${baseUrl}${basePath}/error?error=${encodeURIComponent(error)}`)
-        } else {
-          return redirect(error)
         }
+        // TODO: Remove in a future major release
+        logger.warn('SIGNIN_CALLBACK_REJECT_REDIRECT')
+        return redirect(error)
       }
 
       // Sign user in

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -44,8 +44,9 @@ callbacks: {
    * @param  {object} user     User object
    * @param  {object} account  Provider account
    * @param  {object} profile  Provider profile 
-   * @return {boolean}         Return `true` (or a modified JWT) to allow sign in
+   * @return {boolean|string}  Return `true` to allow sign in
    *                           Return `false` to deny access
+   *                           Return `string` to redirect to (eg.: "/unauthorized")
    */
   signIn: async (user, account, profile) => {
     const isAllowedToSignIn = true
@@ -54,9 +55,8 @@ callbacks: {
     } else {
       // Return false to display a default error message
       return false
-      // You can also Reject this callback with an Error or with a URL:
-      // throw new Error('error message') // Redirect to error page
-      // return '/path/to/redirect'        // Redirect to a URL
+      // Or you can return a URL to redirect to:
+      // return '/unauthorized'
     }
   }
 }

--- a/www/docs/warnings.md
+++ b/www/docs/warnings.md
@@ -48,3 +48,23 @@ You can use [node-jose-tools](https://www.npmjs.com/package/node-jose-tools) to 
 
 #### JWT_AUTO_GENERATED_ENCRYPTION_KEY
 
+#### SIGNIN_CALLBACK_REJECT_REDIRECT
+
+You returned something in the `signIn` callback, that is being deprecated.
+
+You probably had something similar in the callback:
+```js
+  return Promise.reject("/some/url")
+```
+
+or
+
+```js
+  throw "/some/url"
+```
+
+To remedy this, simply return the url instead:
+
+```js
+  return "/some/url"
+```


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Note before creating the Pull Request. Even though the CONTRIBUTONG.md tells otherwise, we ask you to use the `canary` branch as base for your PR. We are tranistioning to a new structure, and the CONTRIBUTONG.md file has not been updated yet. Thank you!

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
The `signIn` callback should allow to simply return a `string` url.

**Why**:

Right now, the string must be thrown, or be wrapped in `Promise.reject()`
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Related issues: #751
