### PR TITLE
feat: forward id_token to jwt and signIn callbacks

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -31,7 +31,7 @@ export default async function callback (req, res) {
 
   if (type === 'oauth') {
     try {
-      const { profile, account, OAuthProfile } = await oAuthCallback(req, provider, csrfToken)
+      const { profile, account, OAuthProfile } = await oAuthCallback(req, csrfToken)
       try {
         // Make it easier to debug when adding a new provider
         logger.debug('OAUTH_CALLBACK_RESPONSE', { profile, account, OAuthProfile })


### PR DESCRIPTION
This is the continuation of #837

This is a bare minimum change required so an OpenID Connect compliant Identity Provider, (like IdentityServer4) can initiate a logout process from the IdP from within an app using `next-auth`, and return to the application afterward.

According to the [spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout), an `id_token` must be present as either a query param (in case of `GET`) or as a body in case of `POST` to `https://IdP.com/connect/endsession` to be able to redirect back to the application (or anywhere else explicitly allowed so in the IdP client by `post_logout_redirect_uri`) after successful logout.

This change forwards the `id_token` as-is to `callbacks.signIn` and `callbacks.jwt` initially, and leaves it up to the user to store that as they want to (probably either in a session database or in the JWT token).

There may be other situations where access to the `id_token` in that manner might be useful.

Related issues: #836, closes #393, closes #378, closes #837


The `idToken` can be found on the `profile` object in the `jwt` and `signIn` callbacks when calling the first time.

Example:
```js
// /api/auth/[...nextauth].js
import NextAuth from "next-auth"

export default NextAuth({
  //...
  callbacks: {
    async signIn(token, account, profile) {
      console.log(profile.idToken) // Raw id_token
      return true
    },
    async jwt(token, account, profile) {
      console.log(profile.idToken) // Raw id_token
      return token
    },
  }
//...
})
```