### PR TITLE
chore: add auto labeling to PRs [skip release]

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,5 +1,5 @@
 test:
-  - test/**/*.js
+  - test/**/*
 
 documentation:
   - www/**/*

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,21 @@
+test:
+  - test/**/*.js
+
+documentation:
+  - www/**/*
+  - ./**/*.md
+
+providers:
+  - src/providers/**/*
+  - www/docs/configuration/providers.md
+  - test/integration/**/*
+
+adapters:
+  - src/adapters/**/*
+  - www/docs/schemas/adapters.md
+
+databases:
+  - www/docs/schemas/*.md
+  - test/docker/databases/**/*
+  - www/docs/configuration/databases.md
+  - test/fixtures/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
**What**:
Using a GitHub Action to label PRs automatically.
<!-- Why are these changes necessary? -->

**Why**:
To easily sort/filter PRs that should be reviewed. It is also easier for maintainers to identify PRs they can review.
<!-- How were these changes implemented? -->

**How**:

https://github.com/actions/labeler

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
