### PR TITLE
feat(provider): add vk.com provider

### DIFF
--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -6,8 +6,8 @@ import Basecamp from './basecamp'
 import BattleNet from './battlenet'
 import Box from './box'
 import Bungie from './bungie'
-import Credentials from './credentials'
 import Cognito from './cognito'
+import Credentials from './credentials'
 import Discord from './discord'
 import Email from './email'
 import Facebook from './facebook'
@@ -27,19 +27,20 @@ import Spotify from './spotify'
 import Strava from './strava'
 import Twitch from './twitch'
 import Twitter from './twitter'
+import VK from './vk'
 import Yandex from './yandex'
 
 export default {
+  Apple,
   Atlassian,
   Auth0,
-  Apple,
   AzureADB2C,
   Basecamp,
   BattleNet,
   Box,
   Bungie,
-  Credentials,
   Cognito,
+  Credentials,
   Discord,
   Email,
   Facebook,
@@ -57,7 +58,8 @@ export default {
   Slack,
   Spotify,
   Strava,
-  Twitter,
   Twitch,
+  Twitter,
+  VK,
   Yandex
 }

--- a/src/providers/vk.js
+++ b/src/providers/vk.js
@@ -1,0 +1,32 @@
+export default (options) => {
+  const apiVersion = options.apiVersion || '5.126' // https://vk.com/dev/versions
+
+  return {
+    id: 'vk',
+    name: 'vk.com',
+    type: 'oauth',
+    version: '2.0',
+    scope: 'email',
+    params: {
+      grant_type: 'authorization_code'
+    },
+    accessTokenUrl: `https://oauth.vk.com/access_token?v=${apiVersion}`,
+    requestTokenUrl: `https://oauth.vk.com/access_token?v=${apiVersion}`,
+    authorizationUrl:
+      `https://oauth.vk.com/authorize?response_type=code&v=${apiVersion}`,
+    profileUrl: `https://api.vk.com/method/users.get?fields=photo_100&v=${apiVersion}`,
+    profile: (result) => {
+      const profile = result.response?.[0]
+
+      if (!profile) return {}
+
+      return {
+        id: profile.id,
+        name: [profile.first_name, profile.last_name].filter(Boolean).join(' '),
+        email: profile.email,
+        image: profile.photo_100
+      }
+    },
+    ...options
+  }
+}

--- a/src/providers/vk.js
+++ b/src/providers/vk.js
@@ -1,5 +1,5 @@
 export default (options) => {
-  const apiVersion = options.apiVersion || '5.126' // https://vk.com/dev/versions
+  const apiVersion = '5.126' // https://vk.com/dev/versions
 
   return {
     id: 'vk',
@@ -16,9 +16,7 @@ export default (options) => {
       `https://oauth.vk.com/authorize?response_type=code&v=${apiVersion}`,
     profileUrl: `https://api.vk.com/method/users.get?fields=photo_100&v=${apiVersion}`,
     profile: (result) => {
-      const profile = result.response?.[0]
-
-      if (!profile) return {}
+      const profile = result.response?.[0] ?? {}
 
       return {
         id: profile.id,

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -184,8 +184,8 @@ async function getOAuth2 (provider, accessToken, results) {
   if (this._useAuthorizationHeaderForGET) {
     headers.Authorization = this.buildAuthHeader(accessToken)
 
-    // Mail.ru requires 'access_token' as URL request parameter
-    if (provider.id === 'mailru') {
+    // Mail.ru & vk.com require 'access_token' as URL request parameter
+    if (['mailru', 'vk'].includes(provider.id)) {
       const safeAccessTokenURL = new URL(url)
       safeAccessTokenURL.searchParams.append('access_token', accessToken)
       url = safeAccessTokenURL.href

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -38,6 +38,7 @@ NextAuth.js is designed to work with any OAuth service, it supports OAuth 1.0, 1
 * [Strava](/providers/strava)
 * [Twitch](/providers/Twitch)
 * [Twitter](/providers/twitter)
+* [VK](/providers/vk)
 * [Yandex](/providers/yandex)
 
 ### Using a built-in OAuth provider

--- a/www/docs/providers/vk.md
+++ b/www/docs/providers/vk.md
@@ -23,3 +23,27 @@ providers: [
   })
 ]
 ...
+```
+
+:::note
+By default the provider uses `5.126` version of the API. See https://vk.com/dev/versions for more info.
+:::
+
+If you want to use a different version, you can pass it to provider's options object:
+
+```js
+// pages/api/auth/[...nextauth].js
+
+const apiVersion = "5.126"
+...
+providers: [
+  Providers.VK({
+    accessTokenUrl: `https://oauth.vk.com/access_token?v=${apiVersion}`,
+    requestTokenUrl: `https://oauth.vk.com/access_token?v=${apiVersion}`,
+    authorizationUrl:
+      `https://oauth.vk.com/authorize?response_type=code&v=${apiVersion}`,
+    profileUrl: `https://api.vk.com/method/users.get?fields=photo_100&v=${apiVersion}`,
+  })
+]
+...
+```

--- a/www/docs/providers/vk.md
+++ b/www/docs/providers/vk.md
@@ -1,0 +1,25 @@
+---
+id: vk
+title: vk.com
+---
+
+## Documentation
+
+https://vk.com/dev/first_guide
+
+## Configuration
+
+https://vk.com/apps?act=manage
+
+## Example
+
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.VK({
+    clientId: process.env.VK_CLIENT_ID,
+    clientSecret: process.env.VK_CLIENT_SECRET
+  })
+]
+...

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -53,6 +53,7 @@ module.exports = {
       'providers/strava',
       'providers/twitch',
       'providers/twitter',
+      'providers/vk',
       'providers/yandex'
     ]
   }


### PR DESCRIPTION
Hi! 👋

**What**:

This PR adds [vk.com](https://en.wikipedia.org/wiki/VK_(service)) provider.
VK's api calls require explicit version so it is added to urls. Also, it is possible to change it via providers' options config.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged

Looks like everything works fine. Let me know if I missed anything!

Thanks!
