### PR TITLE
feat: add jsonwebtoken support to jwt options

### DIFF
--- a/test/docker/app/pages/api/auth/[...nextauth].js
+++ b/test/docker/app/pages/api/auth/[...nextauth].js
@@ -75,6 +75,8 @@ const options = {
   jwt: {
     // A secret to use for key generation (you should set this explicitly)
     // secret: 'INp8IvdIyeMcoGAgFGoA61DdBglwwSqnXJZkgz8PSnw',
+    // Set to true when using jsonwebtoken library
+    // jsonwebtoken: true,
 
     // Set to true to use encryption (default: false)
     // encryption: true,


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
 `jwt.getToken()` doesn't seem to work when using custom encode/decode functions. And considering how much more popular [jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken) is compared to jose I thought it'd be nice if there was an easier way to use jsonwebtokens. 
I add an extra config option in [...nextauth]/jwt so that when` jsonwebtoken = true` next-auth will use the library jsonwebtoken instead of jose for encoding and decoding. 

<!-- Why are these changes necessary? -->

**Why**:

So I personally have preferred using jsonwebtokens over jose for JWT related code, and I noticed a small bug(or maybe it was inteded) where if we set custom encode/decode functions jwt.getToken would no longer work. I think the issue was that in getToken, it calls the default decode() instead of the new custom decode to be called which causes an invalid signature to occur when checking if the token is valid on jwt.io.

I also found that it's not well explained that by default that jose is used, issue  #615 helped me figure out how to use jsonwebtoken with next-auth and I just thought it'd be nice to use the more popular jsonwebtoken library without having to set custom encode/decode functions. 


<!-- How were these changes implemented? -->

**How**:

So in the config file I'm introducing a new variable `jsonwebtoken` in lib/jwt.js  which by default is set to false using `DEFAULT_JSONWEBTOKEN`. And fortunately the only real changes is that an extra if statement is added to both the decode and encode functions:



    if (jsonwebtoken) {

    // signing key using jsonwebtoken instead of jose

    const signedToken = jwt.sign(token, secret, { algorithm: DEFAULT_SIGNATURE_ALGORITHM })

    // no support for encrypting tokens yet

    // return signed token

    return signedToken
  
    } 

    if (jsonwebtoken) {
    return jwt.verify(token, secret)
    } 









Everything else should have been left the same. In order to use these changes only one small change is needed in [...nextauth].js

    
    secret: process.env.JWT_SECRET,

    jsonwebtoken:true,
    
 

Additionally when calling getToken, it might be required to send one extra option however I don't remember testing for it.

` const token = await jwt.getToken({ req, secret,jsonwebtoken:true})`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
   
   I didn't write any tests so no even though the changes are somewhat minor , however it did seem to be working fine in my local development. 


<!-- feel free to add additional comments -->

I don't know how to write tests(like I've written both bdd/tdd tests before but I have no idea where to write the tests in the project structure). 
Also sorry if I messed up anything from the pull request to even this explanation. It's my first time contributing to an open source project and I'm not 100% sure if I'm doing things right. 
