### PR TITLE
feat: use browser visibility API to synchronise session across tabs

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -67,9 +67,20 @@ if (typeof window !== 'undefined') {
       }
     })
 
-    // Listen for window focus/blur events
-    window.addEventListener('focus', async (event) => __NEXTAUTH._getSession({ event: 'focus' }))
-    window.addEventListener('blur', async (event) => __NEXTAUTH._getSession({ event: 'blur' }))
+    // Listen for document visibilitychange events
+    let hidden, visibilityChange
+    if (typeof document.hidden !== 'undefined') { // Opera 12.10 and Firefox 18 and later support
+      hidden = 'hidden'
+      visibilityChange = 'visibilitychange'
+    } else if (typeof document.msHidden !== 'undefined') {
+      hidden = 'msHidden'
+      visibilityChange = 'msvisibilitychange'
+    } else if (typeof document.webkitHidden !== 'undefined') {
+      hidden = 'webkitHidden'
+      visibilityChange = 'webkitvisibilitychange'
+    }
+    const handleVisibilityChange = () => !document[hidden] && __NEXTAUTH._getSession({ event: visibilityChange })
+    document.addEventListener('visibilitychange', handleVisibilityChange, false)
   }
 }
 


### PR DESCRIPTION
**What**:

Changes represent the feature request #1080

**Why**:

This PR replaces blur/focus event for triggering getSession to better visibility API that is widely supported. It will prevent extra calls and improve dev experience while you use Chrome Inspector since there won't be extra sessions calls that spam Network tab.

**How**:
I replace blur/focus event listeners to document visibilitychange.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

**Before**

https://user-images.githubusercontent.com/2697570/104128614-fcec9780-5368-11eb-8f9b-d142d45bfe21.mov

**After**

https://user-images.githubusercontent.com/2697570/104135726-2b329d00-5392-11eb-9177-40dbb5cf161a.mov

I have tested solution in latest Opera, IE, Chrome, Safari. In Firefox I was not able to test it because dev version just does not work at all due to React errors.

- [ ] Documentation n/a
- [ ] Tests n/a
- [ ] Ready to be merged


Fixes #1080