### PR TITLE
docs: clarify .env usage in CONTRIBUTING.md [skip release]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Rename file to .env and populate values
+# to be able to run tests
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_TWITTER_ID=
 NEXTAUTH_TWITTER_SECRET=

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,6 @@
+# Rename file to .env.local and populate values
+# to be able to run the dev app
+NEXTAUTH_URL=http://localhost:3000
+SECRET=
+GITHUB_ID=
+GITHUB_SECRET=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,12 @@ npm i
 
 3. Populate `.env.local`:
    
-    Copy `.env.example` to `.env.local`, and add your env variables for each provider you want to test.
+    Copy `.env.local.example` to `.env.local`, and add your env variables for each provider you want to test.
 
->NOTE: You can configure providers of the dev app in `pages/api/auth/[...nextauth].js`
+> NOTE: You can add any environment variables to .env.local that you would like to use in your dev app.
+> You can find the next-auth config under`pages/api/auth/[...nextauth].js`.
 
-4. Start the dev application/server and CSS watching:
+1. Start the dev application/server and CSS watching:
 ```sh
 npm run dev
 ```


### PR DESCRIPTION

**What**:

The contributing instructions were not clear enough on how to use environment variables.

**Why**:

We (can) use different environment variables for running tests with `npm run test`, and running the dev app with `npm run dev`. 

The contribution instruction did not make a difference between these environments, and caused misunderstanding on how to add environment variables.

**How**:

Split the .env examples into `.env.example` and `.env.local.example`, where
`.env.example`->`.env` will populate variables for the tests and
`.env.local.example`->`.env.local` will add them for the dev app

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


Fixes #1083