### PR TITLE
fix(prisma): replace findOne with findUnique

### DIFF
--- a/src/adapters/prisma/index.js
+++ b/src/adapters/prisma/index.js
@@ -57,7 +57,7 @@ const Adapter = (config) => {
     async function getUser (id) {
       debug('GET_USER', id)
       try {
-        return prisma[User].findOne({ where: { id } })
+        return prisma[User].findUnique({ where: { id } })
       } catch (error) {
         logger.error('GET_USER_BY_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_ID_ERROR', error))
@@ -68,7 +68,7 @@ const Adapter = (config) => {
       debug('GET_USER_BY_EMAIL', email)
       try {
         if (!email) { return Promise.resolve(null) }
-        return prisma[User].findOne({ where: { email } })
+        return prisma[User].findUnique({ where: { email } })
       } catch (error) {
         logger.error('GET_USER_BY_EMAIL_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_EMAIL_ERROR', error))
@@ -78,9 +78,9 @@ const Adapter = (config) => {
     async function getUserByProviderAccountId (providerId, providerAccountId) {
       debug('GET_USER_BY_PROVIDER_ACCOUNT_ID', providerId, providerAccountId)
       try {
-        const account = await prisma[Account].findOne({ where: { compoundId: getCompoundId(providerId, providerAccountId) } })
+        const account = await prisma[Account].findUnique({ where: { compoundId: getCompoundId(providerId, providerAccountId) } })
         if (!account) { return null }
-        return prisma[User].findOne({ where: { id: account.userId } })
+        return prisma[User].findUnique({ where: { id: account.userId } })
       } catch (error) {
         logger.error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
         return Promise.reject(new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error))
@@ -174,7 +174,7 @@ const Adapter = (config) => {
     async function getSession (sessionToken) {
       debug('GET_SESSION', sessionToken)
       try {
-        const session = await prisma[Session].findOne({ where: { sessionToken } })
+        const session = await prisma[Session].findUnique({ where: { sessionToken } })
 
         // Check session has not expired (do not return it if it has)
         if (session && session.expires && new Date() > session.expires) {
@@ -280,7 +280,7 @@ const Adapter = (config) => {
         // Hash token provided with secret before trying to match it with database
         // @TODO Use bcrypt instead of salted SHA-256 hash for token
         const hashedToken = createHash('sha256').update(`${token}${secret}`).digest('hex')
-        const verificationRequest = await prisma[VerificationRequest].findOne({ where: { token: hashedToken } })
+        const verificationRequest = await prisma[VerificationRequest].findUnique({ where: { token: hashedToken } })
 
         if (verificationRequest && verificationRequest.expires && new Date() > verificationRequest.expires) {
           // Delete verification entry so it cannot be used again


### PR DESCRIPTION
Fixes the breaking change in Prisma **2.15** which removes the deprecated method `findOne` which was replaced with `findUnique` in **2.12**