### PR TITLE
fix(provider): use authed_user on slack instead of spotify

### DIFF
--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -163,7 +163,7 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
           results = querystring.parse(data)
         }
         let accessToken = results.access_token
-        if (provider.id === 'spotify') {
+        if (provider.id === 'slack') {
           accessToken = results.authed_user.access_token
         }
         const refreshToken = results.refresh_token


### PR DESCRIPTION
This fixes what looks like a typo from 3fcdd2265637e8c66adcbeaedf7d2a3335e8b661
Spotify doesn't nest the user inside an `authed_user` field

