### PR TITLE
Add a null check to the window 'storage' event listener

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -48,7 +48,7 @@ if (typeof window !== 'undefined') {
     window.addEventListener('storage', async (event) => {
       if (event.key === 'nextauth.message') {
         const message = JSON.parse(event.newValue)
-        if (message && message.event && message.event === 'session' && message.data) {
+        if (message?.event=== 'session' && message.data) {
           // Ignore storage events fired from the same window that created them
           if (__NEXTAUTH._clientId === message.clientId) {
             return

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -48,7 +48,7 @@ if (typeof window !== 'undefined') {
     window.addEventListener('storage', async (event) => {
       if (event.key === 'nextauth.message') {
         const message = JSON.parse(event.newValue)
-        if (message.event && message.event === 'session' && message.data) {
+        if (messsage && message.event && message.event === 'session' && message.data) {
           // Ignore storage events fired from the same window that created them
           if (__NEXTAUTH._clientId === message.clientId) {
             return

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -48,7 +48,7 @@ if (typeof window !== 'undefined') {
     window.addEventListener('storage', async (event) => {
       if (event.key === 'nextauth.message') {
         const message = JSON.parse(event.newValue)
-        if (messsage && message.event && message.event === 'session' && message.data) {
+        if (message && message.event && message.event === 'session' && message.data) {
           // Ignore storage events fired from the same window that created them
           if (__NEXTAUTH._clientId === message.clientId) {
             return

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -48,7 +48,7 @@ if (typeof window !== 'undefined') {
     window.addEventListener('storage', async (event) => {
       if (event.key === 'nextauth.message') {
         const message = JSON.parse(event.newValue)
-        if (message?.event=== 'session' && message.data) {
+        if (message?.event === 'session' && message.data) {
           // Ignore storage events fired from the same window that created them
           if (__NEXTAUTH._clientId === message.clientId) {
             return


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adding a null check to `message` (which is the `newValue` off of a [StorageEvent](https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent)) to prevent `Runtime error "Cannot read property 'event' of null"` when testing with Cypress. This could likely also occur in other iframe applications that use the storage API. 
Fixes #1125 

<!-- Why are these changes necessary? -->

**Why**:

It's currently throwing errors in Cypress and the additional null check on a field that _can_ be null adds extra resilience 
<!-- How were these changes implemented? -->

**How**:
Adding a null check on the value of `message`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
