### PR TITLE
refactor: provide raw idToken through account object

### DIFF
--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -151,27 +151,28 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
           return reject(error)
         }
 
-        let results
+        let raw
         try {
           // As of http://tools.ietf.org/html/draft-ietf-oauth-v2-07
           // responses should be in JSON
-          results = JSON.parse(data)
+          raw = JSON.parse(data)
         } catch {
           // However both Facebook + Github currently use rev05 of the spec  and neither
           // seem to specify a content-type correctly in their response headers. :(
           // Clients of these services suffer a minor performance cost.
-          results = querystring.parse(data)
+          raw = querystring.parse(data)
         }
 
         const accessToken = provider.id === 'slack'
-          ? results.authed_user.access_token
-          : results.access_token
+          ? raw.authed_user.access_token
+          : raw.access_token
 
         resolve({
           accessToken,
-          refreshToken: results.refresh_token,
-          idToken: results.id_token,
-          results
+          accessTokenExpires: raw.expires_in ?? null,
+          refreshToken: raw.refresh_token,
+          idToken: raw.id_token,
+          ...raw
         })
       }
     )

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -156,18 +156,23 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
           // As of http://tools.ietf.org/html/draft-ietf-oauth-v2-07
           // responses should be in JSON
           results = JSON.parse(data)
-        } catch (e) {
+        } catch {
           // However both Facebook + Github currently use rev05 of the spec  and neither
           // seem to specify a content-type correctly in their response headers. :(
           // Clients of these services suffer a minor performance cost.
           results = querystring.parse(data)
         }
-        let accessToken = results.access_token
-        if (provider.id === 'slack') {
-          accessToken = results.authed_user.access_token
-        }
-        const refreshToken = results.refresh_token
-        resolve({ accessToken, refreshToken, results })
+
+        const accessToken = provider.id === 'slack'
+          ? results.authed_user.access_token
+          : results.access_token
+
+        resolve({
+          accessToken,
+          refreshToken: results.refresh_token,
+          idToken: results.id_token,
+          results
+        })
       }
     )
   })

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -35,8 +35,8 @@ export default async function callback (req, res) {
         logger.debug('OAUTH_CALLBACK_RESPONSE', { profile, account, OAuthProfile })
 
         // If we don't have a profile object then either something went wrong
-        // or the user cancelled signin in. We don't know which, so we just
-        // direct the user to the signup page for now. We could do something
+        // or the user cancelled signing in. We don't know which, so we just
+        // direct the user to the signin page for now. We could do something
         // else in future.
         //
         // Note: In oAuthCallback an error is logged with debug info, so it

--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -131,9 +131,9 @@ callbacks: {
    * @return {object}              Session that will be returned to the client 
    */
   async session(session, token) {
-    if(token?.access_token) {
+    if(token?.accessToken) {
       // Add property to session, like an access_token from a provider
-      session.access_token = token.access_token
+      session.accessToken = token.accessToken
     }
     return session
   }
@@ -183,8 +183,8 @@ callbacks: {
    */
   async jwt(token, user, account, profile, isNewUser) {
     // Add access_token to the token right after signin
-    if (account?.access_token) {
-      token.access_token = account.access_token
+    if (account?.accessToken) {
+      token.accessToken = account.accessToken
     }
     return token
   }


### PR DESCRIPTION
**What**:

Move `idToken` from `profile` to `account` object in callbacks.

This PR also forwards the `expires_in` value for `accessTokenExpires`, if available. This has long been simply defined as `null`.

**Why**:
The `idToken` has been provided "as is" to the `signIn` and `jwt` callbacks since #1024 through the `profile` object. Although, both `accessToken` and `refreshToken` have been on the `account` object.
To better group the tokens, this PR simply moves `profile.idToken` to `account.idToken`.
