### PR TITLE
feat: send all params to logger function

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,23 +1,23 @@
 const logger = {
-  error (code, ...text) {
+  error (code, ...message) {
     console.error(
       `[next-auth][error][${code.toLowerCase()}]`,
-      JSON.stringify(text),
-      `\nhttps://next-auth.js.org/errors#${code.toLowerCase()}`
+      `\nhttps://next-auth.js.org/errors#${code.toLowerCase()}`,
+      ...message
     )
   },
-  warn (code, ...text) {
+  warn (code, ...message) {
     console.warn(
       `[next-auth][warn][${code.toLowerCase()}]`,
-      JSON.stringify(text),
-      `\nhttps://next-auth.js.org/warnings#${code.toLowerCase()}`
+      `\nhttps://next-auth.js.org/warnings#${code.toLowerCase()}`,
+      ...message
     )
   },
-  debug (code, ...text) {
+  debug (code, ...message) {
     if (!process?.env?._NEXTAUTH_DEBUG) return
     console.log(
       `[next-auth][debug][${code.toLowerCase()}]`,
-      JSON.stringify(text)
+      ...message
     )
   }
 }


### PR DESCRIPTION
**What**:

A previous change in `canary` made the logs hard (or sometimes impossible) to read! This fixes it hopefully.

**Why**:

`JSON.stringify(new Error())` will result in `"{}"` which is useless. There might be other issues with stringifing.

**How**:

Instead of using JSON.stringify, we just spread the log params to the `console#{log,error,warn}` methods.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


Hopefully will help with debugging current `canary` related issues like #1202 