### PR TITLE
fix: make OAuth 1 flow work again after refactoring

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,15 @@
 # Rename file to .env.local and populate values
 # to be able to run the dev app
+
 NEXTAUTH_URL=http://localhost:3000
-SECRET=
+SECRET= Linux: `openssl rand -hex 32` or https://generate-secret.now.sh/32
+
+AUTH0_ID=
+AUTH0_DOMAIN=
+AUTH0_SECRET=
+
 GITHUB_ID=
 GITHUB_SECRET=
+
+TWITTER_ID=
+TWITTER_SECRET=

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -13,7 +13,11 @@ export default NextAuth({
       clientSecret: process.env.AUTH0_SECRET,
       domain: process.env.AUTH0_DOMAIN,
       protection: "pkce"
-    })
+    }),
+    Providers.Twitter({
+      clientId: process.env.TWITTER_ID,
+      clientSecret: process.env.TWITTER_SECRET,
+    }),
   ],
   // Database optional. MySQL, Maria DB, Postgres and MongoDB are supported.
   // https://next-auth.js.org/configuration/databases

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -39,7 +39,7 @@ export default function oAuthClient (provider) {
   )
 
   // Promisify get() and getOAuth2AccessToken() for OAuth1
-  const originalGet = oauth1Client.get
+  const originalGet = oauth1Client.get.bind(oauth1Client)
   oauth1Client.get = (...args) => {
     return new Promise((resolve, reject) => {
       originalGet(...args, (error, result) => {
@@ -50,7 +50,7 @@ export default function oAuthClient (provider) {
       })
     })
   }
-  const originalGetOAuth1AccessToken = oauth1Client.getOAuthAccessToken
+  const originalGetOAuth1AccessToken = oauth1Client.getOAuthAccessToken.bind(oauth1Client)
   oauth1Client.getOAuthAccessToken = (...args) => {
     return new Promise((resolve, reject) => {
       originalGetOAuth1AccessToken(...args, (error, accessToken, refreshToken, results) => {
@@ -62,7 +62,7 @@ export default function oAuthClient (provider) {
     })
   }
 
-  const originalGetOAuthRequestToken = oauth1Client.getOAuthRequestToken
+  const originalGetOAuthRequestToken = oauth1Client.getOAuthRequestToken.bind(oauth1Client)
   oauth1Client.getOAuthRequestToken = (...args) => {
     return new Promise((resolve, reject) => {
       originalGetOAuthRequestToken(...args, (error, oauthToken) => {

--- a/src/server/lib/signin/oauth.js
+++ b/src/server/lib/signin/oauth.js
@@ -33,7 +33,7 @@ export default async function getAuthorizationUrl (req) {
   }
 
   try {
-    const oAuthToken = await client.getOAuthRequestToken(provider.callbackUrl)
+    const oAuthToken = await client.getOAuthRequestToken()
     const url = `${provider.authorizationUrl}?oauth_token=${oAuthToken}`
     logger.debug('GET_AUTHORIZATION_URL', url)
     return url


### PR DESCRIPTION
**What**:

Make the OAuth 1 signin flow work again.

**Why**:

Somewhere along the refactorings, `node-oauth` callbacks were rewritten to Promises to simplify the core code. I managed to slip in a fail for `client.getOAuthRequestToken`, which - apart from the callback - had no arguments, but I accidentally provided a `provider.callbackUrl` to it.

Re-writing to proimses also required to bind the rewritten methods to the new client instance, as they were dependent on `this`.

**How**:

The rewritten methods are bound to the client instance correctly now, and `client.getOAuthRequestToken()` now takes no params anymore.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests // Tested it locally with the Twitter provider, and everything worked fine
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
