### PR TITLE
fix(provider): okta client authentication

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -17,11 +17,6 @@ export default NextAuth({
       clientId: process.env.TWITTER_ID,
       clientSecret: process.env.TWITTER_SECRET
     }),
-    Providers.Okta({
-      clientId: process.env.OKTA_ID,
-      clientSecret: process.env.OKTA_SECRET,
-      domain: process.env.OKTA_DOMAIN
-    }),
     Providers.Credentials({
       name: 'Credentials',
       credentials: {

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -20,7 +20,7 @@ export default NextAuth({
     Providers.Okta({
       clientId: process.env.OKTA_ID,
       clientSecret: process.env.OKTA_SECRET,
-      domain: process.env.OKTA_DOMAIN,
+      domain: process.env.OKTA_DOMAIN
     }),
     Providers.Credentials({
       name: 'Credentials',

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -17,6 +17,11 @@ export default NextAuth({
       clientId: process.env.TWITTER_ID,
       clientSecret: process.env.TWITTER_SECRET
     }),
+    Providers.Okta({
+      clientId: process.env.OKTA_ID,
+      clientSecret: process.env.OKTA_SECRET,
+      domain: process.env.OKTA_DOMAIN,
+    }),
     Providers.Credentials({
       name: 'Credentials',
       credentials: {

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -132,7 +132,7 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
     headers.Authorization = 'Basic ' + Buffer.from((provider.clientId + ':' + provider.clientSecret)).toString('base64')
   }
 
-  if ((provider.id === 'okta' || provider.id === 'identity-server4') && !headers.Authorization) {
+  if (provider.id === 'identity-server4' && !headers.Authorization) {
     headers.Authorization = `Bearer ${code}`
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adding the bearer Authorization header here breaks the Okta provider flow.

<!-- Why are these changes necessary? -->

**Why**: See [okta:client-authentication-methods](https://developer.okta.com/docs/reference/api/oidc/#client-authentication-methods). While the bearer token is not a supported client authentication method, posting the client secret is supported. So nothing need be added here.

<!-- How were these changes implemented? -->

**How**: Remove the Authorization header for `provider === 'okta'`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
