### PR TITLE
add verificationRequest flag to email signIn callback fixes #1251

### DIFF
--- a/src/server/routes/signin.js
+++ b/src/server/routes/signin.js
@@ -44,7 +44,7 @@ export default async function signin (req, res) {
 
     // Check if user is allowed to sign in
     try {
-      const signInCallbackResponse = await callbacks.signIn(profile, account, { email })
+      const signInCallbackResponse = await callbacks.signIn(profile, account, { email, verificationRequest: true })
       if (signInCallbackResponse === false) {
         return res.redirect(`${baseUrl}${basePath}/error?error=AccessDenied`)
       } else if (typeof signInCallbackResponse === 'string') {


### PR DESCRIPTION
**What**:

Add `verificationRequest: true` back to the the email `signIn` callback during the first call prior to sending the email, fixes #1251

**Why**:
 
Appears to have ben accidentally removed in a refactor #959
