### PR TITLE
fix(ui): use color-text var for input color

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -80,6 +80,7 @@ input[type] {
   font-size: 1rem;
   border-radius: var(--border-radius);
   box-shadow: inset 0 .1rem .2rem rgba(0, 0, 0, .2);
+  color: var(--color-text);
 
   &:focus {
     box-shadow: none;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Updated the stylesheet to use the `color-text` variable in the `input` element.

<!-- Why are these changes necessary? -->

**Why**:

As reported in issue #1256 , the `input` element was defaulting to black even on dark mode.

<!-- How were these changes implemented? -->

**How**:

By updating the stylesheet in `src/css/index.css`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<img width="599" alt="Screen Shot 2021-02-04 at 9 02 16 PM" src="https://user-images.githubusercontent.com/2882440/106992079-7ab77f00-672c-11eb-862a-0faef0f9e05a.png">
<img width="616" alt="Screen Shot 2021-02-04 at 9 02 11 PM" src="https://user-images.githubusercontent.com/2882440/106992086-7e4b0600-672c-11eb-84e1-bc5f30316fb6.png">

Fixes #1256