### PR TITLE
fix(client): reload after login/logout when url contains hash

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -54,7 +54,7 @@ export default function Header () {
                 className={styles.button}
                 onClick={(e) => {
                   e.preventDefault()
-                  signOut({ redirect: false })
+                  signOut()
                 }}
               >
                 Sign out

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -278,7 +278,11 @@ export async function signIn (provider, options = {}, authorizationParams = {}) 
   const res = await fetch(_signInUrl, fetchOptions)
   const data = await res.json()
   if (redirect || !isCredentials) {
-    window.location = data.url ?? callbackUrl
+    const url = data.url ?? callbackUrl
+    window.location = url
+    // If url contains a hash, the browser does not reload the page. We reload manually
+    if (url.includes('#')) window.location.reload()
+
     return
   }
 
@@ -324,7 +328,10 @@ export async function signOut (options = {}) {
   const data = await res.json()
   _sendMessage({ event: 'session', data: { trigger: 'signout' } })
   if (redirect) {
-    window.location = data.url ?? callbackUrl
+    const url = data.url ?? callbackUrl
+    window.location = url
+    // If url contains a hash, the browser does not reload the page. We reload manually
+    if (url.includes('#')) window.location.reload()
     return
   }
 


### PR DESCRIPTION
**What**:

Reload the page after `signIn` or `signOut` is called, even if the URL contains a hash.

**Why**:

A small experiment:

1. go to https://google.com#top
2. open the inspector
3. write `window.location = "https://google.com#top"`

Observe that "nothing" happens.

We use `window.location =` to reload the page after a successful login/logout, but it does not work in the above mentioned case.

**How**:

After `window.location` is set, check if the url contains a `#`, if it does, reload the page with `window.location.reload()` 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

~- [ ] Documentation~
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

This has been discovered in #1107 by @thewbear, so the credit goes to them!

I re-created the PR, because we did some changes in our release process and unfortunately all open PRs are getting massive merge conflicts now. Since it was a small update, I did not wish to ask the original creator to fix all those issues. (Very sorry for the inconvenience! 🙏)

Fixes #532