### PR TITLE
fix: twitter oauth authorize authorizationUrl

### DIFF
--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -7,7 +7,7 @@ export default (options) => {
     scope: '',
     accessTokenUrl: 'https://api.twitter.com/oauth/access_token',
     requestTokenUrl: 'https://api.twitter.com/oauth/request_token',
-    authorizationUrl: 'https://api.twitter.com/oauth/authenticate',
+    authorizationUrl: 'https://api.twitter.com/oauth/authorize',
     profileUrl:
       'https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true',
     profile: (profile) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Changed the twitter oauth authorizationURL.

**Why**:

As twitter updated the endpoint.

<img width="765" alt="Screenshot 2021-02-17 at 8 41 50 PM" src="https://user-images.githubusercontent.com/43822585/108224121-9117fe80-7160-11eb-9060-c3ab5406cb45.png">

Here is the [link](https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens) to the doc.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
