### PR TITLE
feat: make tokens available in profile callback

### DIFF
--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -108,7 +108,7 @@ async function getProfile ({ profileData, tokens, provider, user }) {
 
     logger.debug('PROFILE_DATA', profileData)
 
-    const profile = await provider.profile(profileData, tokens.access_token)
+    const profile = await provider.profile(profileData, tokens)
     // Return profile, raw profile and auth provider details
     return {
       profile: {

--- a/src/server/lib/oauth/callback.js
+++ b/src/server/lib/oauth/callback.js
@@ -108,7 +108,7 @@ async function getProfile ({ profileData, tokens, provider, user }) {
 
     logger.debug('PROFILE_DATA', profileData)
 
-    const profile = await provider.profile(profileData)
+    const profile = await provider.profile(profileData, tokens.access_token)
     // Return profile, raw profile and auth provider details
     return {
       profile: {

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -78,9 +78,10 @@ As an example of what this looks like, this is the the provider object returned 
   requestTokenUrl: "https://accounts.google.com/o/oauth2/auth",
   authorizationUrl: "https://accounts.google.com/o/oauth2/auth?response_type=code",
   profileUrl: "https://www.googleapis.com/oauth2/v1/userinfo?alt=json",
-  async profile(profile, accessToken) {
-    // You can use the `accessToken`, in case you want to fetch more profile information
+  async profile(profile, tokens) {
+    // You can use the tokens, in case you want to fetch more profile information
     // For example several OAuth provider does not return e-mail by default.
+    // Depending on your provider, will have tokens like `access_token`, `id_token` and or `refresh_token`
     return {
       id: profile.id,
       name: profile.name,

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -78,7 +78,9 @@ As an example of what this looks like, this is the the provider object returned 
   requestTokenUrl: "https://accounts.google.com/o/oauth2/auth",
   authorizationUrl: "https://accounts.google.com/o/oauth2/auth?response_type=code",
   profileUrl: "https://www.googleapis.com/oauth2/v1/userinfo?alt=json",
-  async profile(profile) {
+  async profile(profile, accessToken) {
+    // You can use the `accessToken`, in case you want to fetch more profile information
+    // For example several OAuth provider does not return e-mail by default.
     return {
       id: profile.id,
       name: profile.name,


### PR DESCRIPTION
**What**:

Adds a new parameter to the `profile()` callback in provider options.

**Why**:
Since there is a lot of inconsistencies in OAuth provider implementations, the `profile` callback often provider an inconsistent result in its first parameter. The `profile` callback is called asynchronously, so it is a good place to fetch more data, but usually, that request should be authenticated by the logged-in user. Without an access_token, it is in most cases probably impossible.

**How**:

Forward `tokens` to `profile`, so it will receive these params:
```js
async profile(profile, tokens) {
  const email = await getEmailForUser(tokens.access_token)
  return {
    id: profile.sub,
    name: profile.nickname,
    email,
    image: profile.picture
  }
}
```

We will forward all the tokens we have for a provider. Depending on which provider we talk about, you will have an `access_token`, `id_token`, and `refresh_token`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Discusses briefly: https://github.com/nextauthjs/next-auth/issues/1238#issuecomment-771796703

Multiple of our built-in providers also return `null` for email and image because of this. With an `access_token` available, it might be possible to fetch that info for those as well.