### PR TITLE
fix(provider): use correct file type for Discord profile img

### DIFF
--- a/src/providers/discord.js
+++ b/src/providers/discord.js
@@ -14,7 +14,7 @@ export default (options) => {
         const defaultAvatarNumber = parseInt(profile.discriminator) % 5
         profile.image_url = `https://cdn.discordapp.com/embed/avatars/${defaultAvatarNumber}.png`
       } else {
-        const format = profile.premium_type === 1 || profile.premium_type === 2 ? 'gif' : 'png'
+        const format = profile.avatar.startsWith('a_') ? 'gif' : 'png'
         profile.image_url = `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.${format}`
       }
       return {


### PR DESCRIPTION
Fixing discord avatar URL bug.

**What and Why and How**:

Refer to my Bug Report: https://github.com/nextauthjs/next-auth/issues/1364#issue-814807217

**Checklist**:
- [✅] Documentation
- [✅] Tests
- [✅] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


fixes #1364