### PR TITLE
feat(provider): call generateVerificationToken async

### DIFF
--- a/src/server/lib/signin/email.js
+++ b/src/server/lib/signin/email.js
@@ -10,7 +10,7 @@ export default async function email (email, provider, options) {
     const secret = provider.secret || options.secret
 
     // Generate token
-    const token = provider.generateVerificationToken?.() ?? randomBytes(32).toString('hex')
+    const token = await provider.generateVerificationToken?.() ?? randomBytes(32).toString('hex')
 
     // Send email with link containing token (the unhashed version)
     const url = `${baseUrl}${basePath}/callback/${encodeURIComponent(provider.id)}?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`

--- a/www/docs/providers/email.md
+++ b/www/docs/providers/email.md
@@ -184,3 +184,17 @@ const text = ({ url, site }) => `Sign in to ${site}\n${url}\n\n`
 :::tip
 If you want to generate great looking email client compatible HTML with React, check out https://mjml.io
 :::
+
+
+## Customising the Verification Token
+
+By default, we are generating a random verification token. You can define a `generateVerificationToken` method in your provider options if you want to override it:
+
+```js title="pages/api/auth/[...nextauth].js"
+providers: [
+  Providers.Email({
+    async generateVerificationToken() {
+      return "ABC123"
+    }
+  })
+],


### PR DESCRIPTION
**What**:

When using the "email" provider, you can supply your own `generateVerificationToken` function to create a token of your liking.

**Why**:

Until now, it was not possible to do async operations inside this function.

**How**:

When `generateVerificationToken` is called, we simply put an `await` in front of it, so you can do any async task inside it.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

As mentioned by @iaincollins  in https://github.com/nextauthjs/next-auth/issues/709#issuecomment-784077142, this is something we are supposed to support. So here you go :slightly_smiling_face: 