### PR TITLE
feat: use IE11 as client code bundle target

### DIFF
--- a/config/babel.config.json
+++ b/config/babel.config.json
@@ -1,9 +1,16 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "esmodules": true } }]
+    ["@babel/preset-env", { "targets": { "node": "10" } }]
   ],
   "comments": false,
   "overrides": [
+    {
+      "test": ["../src/client/**"],
+      "comments": true,
+      "presets": [
+        ["@babel/preset-env", { "targets": { "ie": "11" } }]
+      ]
+    },
     {
       "test": ["../src/server/pages/**"],
       "presets": ["preact"]


### PR DESCRIPTION
> NOTE: This is WIP. I have to check that some of my statements below are actually correct.

**What**:

Explicitly bundle client-side JS code to support IE11.

**Why**:

IE11 is still a (...painful 😢) browser many companies have to support for legacy reasons. By bundling the client-side code with IE11 as a target, we ensure that `next-auth` is available for a wider range of apps. This is a good choice anyway because as of this writing, Next.js itself supports IE11.
> Next.js supports IE11 and all modern browsers (Edge, Firefox, Chrome, Safari, Opera, et al) with no required configuration.
Ref: https://nextjs.org/docs/basic-features/supported-browsers-features 

Until now, we used https://github.com/martpie/next-transpile-modules as an alternative, but `next-transpile-module` explicitly state the following:
> What this plugin does not aim to solve:
>  - any-package IE11-compatible maker

**How**:

Leverage `@babel/preset-env` and `overrides` to set a different target for client code.

This PR also sets Node 10 as the minimum target for the rest of the app, which seems to be logical as this is the last maintained Node version. (Going away in April 2021).

This changes the bundle sizes the following way:

| Bundle        | Before           | After  | Change
| -------------- |:-------------:|:-----:|:-----------:|
| everything           | 345.6kB| 263.4kB |-24%|
| client  | 14.8kB      |   31.5kB| +53%|
| server  | 330.8kB      |   232kB |-30%|

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

There is a discussion around this at https://github.com/nextauthjs/next-auth/discussions/492

There was a comment that people started complaining about the increased client bundle size, which is understandable because it is pretty significant https://github.com/nextauthjs/next-auth/discussions/492#discussioncomment-154249, but I think for the remaining time IE11 is around, we could support it, then drop support the same day it reaches end-of-life. If Next.js itself does that, it is logical that we do the same.

This PR is open for discussion, please tell me what you think!