### PR TITLE
feat(provider): allow disabling redirection on sign in with email

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -100,6 +100,11 @@ export default function Header () {
               <a>Credentials</a>
             </Link>
           </li>
+          <li className={styles.navItem}>
+            <Link href='/email'>
+              <a>Email</a>
+            </Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/pages/email.js
+++ b/pages/email.js
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import { signIn, signOut, useSession } from 'next-auth/client'
+import Layout from 'components/layout'
+
+export default function Page () {
+  const [response, setResponse] = React.useState(null)
+  const [email, setEmail] = React.useState('')
+
+  const handleChange = (event) => {
+    setEmail(event.target.value)
+  }
+
+  const handleLogin = (options) => async (event) => {
+    event.preventDefault()
+
+    if (options.redirect) {
+      return signIn('email', options)
+    }
+    const response = await signIn('email', options)
+    setResponse(response)
+  }
+
+  const handleLogout = (options) => async (event) => {
+    if (options.redirect) {
+      return signOut(options)
+    }
+    const response = await signOut(options)
+    setResponse(response)
+  }
+
+  const [session] = useSession()
+
+  if (session) {
+    return (
+      <Layout>
+        <h1>Test different flows for Email logout</h1>
+        <span className='spacing'>Default:</span>
+        <button onClick={handleLogout({ redirect: true })}>Logout</button><br />
+        <span className='spacing'>No redirect:</span>
+        <button onClick={handleLogout({ redirect: false })}>Logout</button><br />
+        <p>Response:</p>
+        <pre style={{ background: '#eee', padding: 16 }}>{JSON.stringify(response, null, 2)}</pre>
+      </Layout>
+    )
+  }
+
+  return (
+    <Layout>
+      <h1>Test different flows for Email login</h1>
+      <span className='spacing'>Default:</span>
+      <form onSubmit={handleLogin({ redirect: true, email })}>
+        <label>
+          Email address
+          <input type='text' id='email' name='email' value={email} onChange={handleChange} />
+        </label>
+        <button type='submit'>Sign in with Email</button>
+      </form>
+      <span className='spacing'>No redirect:</span>
+      <form onSubmit={handleLogin({ redirect: false, email })}>
+        <label>
+          Email address
+          <input type='text' id='email' name='email' value={email} onChange={handleChange} />
+        </label>
+        <button type='submit'>Sign in with Email</button>
+      </form>
+      <p>Response:</p>
+      <pre style={{ background: '#eee', padding: 16 }}>{JSON.stringify(response, null, 2)}</pre>
+    </Layout>
+  )
+}

--- a/pages/email.js
+++ b/pages/email.js
@@ -47,20 +47,16 @@ export default function Page () {
   return (
     <Layout>
       <h1>Test different flows for Email login</h1>
-      <span className='spacing'>Default:</span>
+      <label className='spacing'>
+        Email address:{' '}
+        <input type='text' id='email' name='email' value={email} onChange={handleChange} />
+      </label><br />
       <form onSubmit={handleLogin({ redirect: true, email })}>
-        <label>
-          Email address
-          <input type='text' id='email' name='email' value={email} onChange={handleChange} />
-        </label>
+        <span className='spacing'>Default:</span>
         <button type='submit'>Sign in with Email</button>
       </form>
-      <span className='spacing'>No redirect:</span>
       <form onSubmit={handleLogin({ redirect: false, email })}>
-        <label>
-          Email address
-          <input type='text' id='email' name='email' value={email} onChange={handleChange} />
-        </label>
+        <span className='spacing'>No redirect:</span>
         <button type='submit'>Sign in with Email</button>
       </form>
       <p>Response:</p>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -258,6 +258,9 @@ export async function signIn (provider, options = {}, authorizationParams = {}) 
     return
   }
   const isCredentials = providers[provider].type === 'credentials'
+  const isEmail = providers[provider].type === 'email'
+  const canRedirectBeDisabled = isCredentials || isEmail
+
   const signInUrl = isCredentials
     ? `${baseUrl}/callback/${provider}`
     : `${baseUrl}/signin/${provider}`
@@ -279,7 +282,7 @@ export async function signIn (provider, options = {}, authorizationParams = {}) 
   const _signInUrl = `${signInUrl}?${new URLSearchParams(authorizationParams)}`
   const res = await fetch(_signInUrl, fetchOptions)
   const data = await res.json()
-  if (redirect || !isCredentials) {
+  if (redirect || !canRedirectBeDisabled) {
     const url = data.url ?? callbackUrl
     window.location = url
     // If url contains a hash, the browser does not reload the page. We reload manually

--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -212,7 +212,18 @@ The URL must be considered valid by the [redirect callback handler](/configurati
 
 #### Using the redirect: false option
 
-When you use the `credentials` provider, you might not want the user to redirect to an error page if an error occurs, so you can handle any errors (like wrong credentials given by the user) on the same page. For that, you can pass `redirect: false` in the second parameter object. `signIn` then will return a Promise, that resolves to the following:
+:::note
+The redirect option is only available for `credentials` and `email` providers.
+:::
+
+In some cases, you might want to deal with the sign in response on the same page and disable the default redirection. For example, if an error occurs (like wrong credentials given by the user), you might want to handle the error on the same page. For that, you can pass `redirect: false` in the second parameter object.
+
+e.g.
+
+- `signIn('credentials', { redirect: false, password: 'password' })`
+- `signIn('email', { redirect: false, email: 'bill@fillmurray.com' })`
+
+`signIn` will then return a Promise, that resolves to the following:
 
 ```ts
 {


### PR DESCRIPTION
**What**:

In case the user is using the Email provider, make it possible to disable the redirection after the response from the server.



**Why**:

Example: To make a user signin or signup flow more fluid, it may be desirable to handle email signin without a page reload.

**How**:

The Email Provider has been added to the list of the providers that allow disabled redirection
`canRedirectBeDisabled = isCredentials || isEmail`


**Checklist**:


- [x] Documentation
- [x] Tests (Tested it locally so far, through the developer application, looking good there)
- [ ] Ready to be merged


Also related:

- Issues/PRs: #1192 #989 #1219, #709, #414
- Discussions: https://github.com/nextauthjs/next-auth/discussions/754

closes #922