### PR TITLE
fix: make sure useSession populates session correctly

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -71,7 +71,12 @@ const SessionContext = createContext()
  */
 export function useSession (session) {
   const context = useContext(SessionContext)
-  const [data, setData] = useState(context?.[0] ?? session)
+  if (context) return context
+  return _useSessionHook(session)
+}
+
+function _useSessionHook (session) {
+  const [data, setData] = useState(session)
   const [loading, setLoading] = useState(!data)
 
   useEffect(() => {


### PR DESCRIPTION
**What**:

A bug has been introduced while trying to optimize the calls to the session endpoint. (#1084) Unfortunately, my fix has not worked. I think to make this correct, a major version bump might be needed because we should move event listeners into the Provider context. This would require `Provider` in ALL cases for the session to work correctly.

**Why**:

#1461 reported incorrect behaviour when using `useSession()` multiple times.

**How**:

Partially reverts https://github.com/nextauthjs/next-auth/commit/3aee24b5dc07092b8e2e06f46fb34078b911d79c.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


closes #1461 