### PR TITLE
Fix useSession loading state

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -130,9 +130,9 @@ function _useSessionHook (session) {
         __NEXTAUTH._clientSession = newClientSessionData
 
         setData(newClientSessionData)
+        setLoading(false)
       } catch (error) {
         logger.error('CLIENT_USE_SESSION_ERROR', error)
-      } finally {
         setLoading(false)
       }
     }


### PR DESCRIPTION
Fixes #1467

The issue was due to doing the `setLoading(false)` in the finally:  as we can do an early return [here](https://github.com/nextauthjs/next-auth/blob/a7e08e2a3266efa9c82eb859e7141c798fcf07ae/src/client/index.js#L100-L100), we would still go to the finally and mark the session as being loaded.

I simply removed the `finally` block to only set the `loading` state to false when:
- the data is ready
- an error occurs
