### PR TITLE
fix: reject access token if slack login flow was canceled

### DIFF
--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -167,9 +167,18 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
           raw = querystring.parse(data)
         }
 
-        const accessToken = provider.id === 'slack'
-          ? raw.authed_user.access_token
-          : raw.access_token
+        let accessToken;
+        if (provider.id === 'slack') {
+          const { ok, error } = raw;
+          if (!ok) {
+            return reject(error);
+          }
+
+          accessToken = raw.authed_user.access_token;
+        }
+        else {
+          accessToken = raw.access_token;
+        }
 
         resolve({
           accessToken,

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -167,17 +167,16 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
           raw = querystring.parse(data)
         }
 
-        let accessToken;
+        let accessToken
         if (provider.id === 'slack') {
-          const { ok, error } = raw;
+          const { ok, error } = raw
           if (!ok) {
-            return reject(error);
+            return reject(error)
           }
 
-          accessToken = raw.authed_user.access_token;
-        }
-        else {
-          accessToken = raw.access_token;
+          accessToken = raw.authed_user.access_token
+        } else {
+          accessToken = raw.access_token
         }
 
         resolve({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Access token parsing when the provider is Slack.

<!-- Why are these changes necessary? -->

**Why**:
If the user canceled the login flow when on Slack's consent page the application would crash when trying to read access token from response body.  
Closes #1513.

<!-- How were these changes implemented? -->

**How**:
Slack responds with an `ok: boolean` property in the body object. If it's false we reject the auth flow. Else continue as before.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [ ] Tests
- [x] Ready to be merged
<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
