### PR TITLE
Added tutorial on testing pages with authentication by setting next-a…

### DIFF
--- a/www/docs/tutorials/testing-pages-with-authentication.md
+++ b/www/docs/tutorials/testing-pages-with-authentication.md
@@ -1,0 +1,39 @@
+---
+id: testing-pages-with-authentication
+title: Testing pages with authentication
+---
+
+NOTE: This approach requires that you are using [a database](/configuration/databases.md) and are not using JWT.
+
+You may want to functionally test pages of your application that require authentication. In order to circumvent a login with a real authentication provider, you can create a session in the database and set a cookie inside your browser to use that session.
+
+## Create a session 
+Add a record to the `Sessions`-table, and make sure that the userId exists. A good place to do this is in your [database seed script](https://www.prisma.io/docs/guides/application-lifecycle/seed-database).
+
+Example with [prisma](schemas/adapters#prisma-adapter):
+```js
+  const session = await prisma.session.create({
+    data: {
+      userId: 1,
+      expires: "2099-04-20T02:04:17.216Z",
+      sessionToken: "testSessionToken",
+      accessToken: "testAccessToken",
+    },
+  });
+```
+## Set a cookie
+Use the sessionToken from the previous step to set a cookie called `next-auth.session-token`. Make sure to adjust the values to fit your use case.
+
+Example in [Cypress](https://cypress.io)
+```js
+cy.setCookie("next-auth.session-token","testSessionToken", {
+    domain: "localhost",
+    expiry: 999999999999,
+    path: "/",
+  });
+cy.visit("http://localhost:3000")
+```
+
+### Cookies & Test tools
+- [Selenium](https://www.selenium.dev/documentation/en/support_packages/working_with_cookies/)
+- [Cypress](https://docs.cypress.io/api/commands/setcookie.html#Syntax)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR adds a tutorial page about testing pages with authentication by setting a session-token cookie.
<!-- Why are these changes necessary? -->

**Why**:
The current docs/tutorials only mention testing with https://www.npmjs.com/package/cypress-social-logins, which doesn't support all authentication providers supported by NextAuth.js yet, and, in my experience, makes test scenario's unnecessarily slow/long. I'm not sure if this is the best way to go about it, but in my workflow the approach of seeding a session-token to the DB and setting that in Cypress before visiting any page worked faster and circumvented setting up credentials with an authentication provider. For tests that are not focused on the authentication flow itself, this allows for writing focused functional tests.

If this doesn't belong here, or is not in-line with the vision of the project, feel free to close the PR, just figured I'd share my approach.

<!-- How were these changes implemented? -->

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
