### PR TITLE
fix: update protection to accept array with multiples options

### DIFF
--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -167,9 +167,17 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
           raw = querystring.parse(data)
         }
 
-        const accessToken = provider.id === 'slack'
-          ? raw.authed_user.access_token
-          : raw.access_token
+        let accessToken
+        if (provider.id === 'slack') {
+          const { ok, error } = raw
+          if (!ok) {
+            return reject(error)
+          }
+
+          accessToken = raw.authed_user.access_token
+        } else {
+          accessToken = raw.access_token
+        }
 
         resolve({
           accessToken,

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -136,7 +136,7 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
     headers.Authorization = `Bearer ${code}`
   }
 
-  if (['pkce', 'both'].includes(provider.protection)) {
+  if ([provider.protection].flat().includes('pkce')) {
     params.code_verifier = codeVerifier
   }
 

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -136,7 +136,7 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
     headers.Authorization = `Bearer ${code}`
   }
 
-  if (provider.protection === 'pkce') {
+  if (["pkce", "both"].includes(provider.protection)) {
     params.code_verifier = codeVerifier
   }
 
@@ -167,17 +167,9 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
           raw = querystring.parse(data)
         }
 
-        let accessToken
-        if (provider.id === 'slack') {
-          const { ok, error } = raw
-          if (!ok) {
-            return reject(error)
-          }
-
-          accessToken = raw.authed_user.access_token
-        } else {
-          accessToken = raw.access_token
-        }
+        const accessToken = provider.id === 'slack'
+          ? raw.authed_user.access_token
+          : raw.access_token
 
         resolve({
           accessToken,

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -136,7 +136,7 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
     headers.Authorization = `Bearer ${code}`
   }
 
-  if (["pkce", "both"].includes(provider.protection)) {
+  if (['pkce', 'both'].includes(provider.protection)) {
     params.code_verifier = codeVerifier
   }
 

--- a/src/server/lib/oauth/pkce-handler.js
+++ b/src/server/lib/oauth/pkce-handler.js
@@ -16,7 +16,7 @@ const PKCE_MAX_AGE = 60 * 15 // 15 minutes in seconds
 export async function handleCallback (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (!['pkce', 'both'].includes(provider.protection)) {// Provider does not support PKCE, nothing to do.
+    if (![provider.protection].flat().includes('pkce')) {// Provider does not support PKCE, nothing to do.
       return
     }
 
@@ -50,7 +50,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (!['pkce', 'both'].includes(provider.protection)) { // Provider does not support PKCE, nothing to do.
+    if (![provider.protection].flat().includes('pkce')) { // Provider does not support PKCE, nothing to do.
       return
     }
     // Started login flow, add generated pkce to req.options and (encrypted) code_verifier to a cookie

--- a/src/server/lib/oauth/pkce-handler.js
+++ b/src/server/lib/oauth/pkce-handler.js
@@ -16,7 +16,7 @@ const PKCE_MAX_AGE = 60 * 15 // 15 minutes in seconds
 export async function handleCallback (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (!["pkce", "both"].includes(provider.protection)) {// Provider does not support PKCE, nothing to do.
+    if (!['pkce', 'both'].includes(provider.protection)) {// Provider does not support PKCE, nothing to do.
       return
     }
 
@@ -50,7 +50,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (!["pkce", "both"].includes(provider.protection)) { // Provider does not support PKCE, nothing to do.
+    if (!['pkce', 'both'].includes(provider.protection)) { // Provider does not support PKCE, nothing to do.
       return
     }
     // Started login flow, add generated pkce to req.options and (encrypted) code_verifier to a cookie

--- a/src/server/lib/oauth/pkce-handler.js
+++ b/src/server/lib/oauth/pkce-handler.js
@@ -16,7 +16,7 @@ const PKCE_MAX_AGE = 60 * 15 // 15 minutes in seconds
 export async function handleCallback (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (![provider.protection].flat().includes('pkce')) {// Provider does not support PKCE, nothing to do.
+    if (![provider.protection].flat().includes('pkce')) { // Provider does not support PKCE, nothing to do.
       return
     }
 

--- a/src/server/lib/oauth/pkce-handler.js
+++ b/src/server/lib/oauth/pkce-handler.js
@@ -16,7 +16,7 @@ const PKCE_MAX_AGE = 60 * 15 // 15 minutes in seconds
 export async function handleCallback (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (provider.protection !== 'pkce') { // Provider does not support PKCE, nothing to do.
+    if (!["pkce", "both"].includes(provider.protection)) {// Provider does not support PKCE, nothing to do.
       return
     }
 
@@ -50,7 +50,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (provider.protection !== 'pkce') { // Provider does not support PKCE, nothing to do.
+    if (!["pkce", "both"].includes(provider.protection)) { // Provider does not support PKCE, nothing to do.
       return
     }
     // Started login flow, add generated pkce to req.options and (encrypted) code_verifier to a cookie

--- a/src/server/lib/oauth/state-handler.js
+++ b/src/server/lib/oauth/state-handler.js
@@ -12,7 +12,7 @@ import { OAuthCallbackError } from '../../../lib/errors'
 export async function handleCallback (req, res) {
   const { csrfToken, provider, baseUrl, basePath } = req.options
   try {
-    if (!['state', 'both'].includes(provider.protection)) { // Provider does not support state, nothing to do.
+    if (![provider.protection].flat().includes('state')) { // Provider does not support state, nothing to do.
       return
     }
 
@@ -41,7 +41,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { provider, baseUrl, basePath, csrfToken } = req.options
   try {
-    if (!['state', 'both'].includes(provider.protection)) { // Provider does not support state, nothing to do.
+    if (![provider.protection].flat().includes('state')) { // Provider does not support state, nothing to do.
       return
     }
 

--- a/src/server/lib/oauth/state-handler.js
+++ b/src/server/lib/oauth/state-handler.js
@@ -12,7 +12,7 @@ import { OAuthCallbackError } from '../../../lib/errors'
 export async function handleCallback (req, res) {
   const { csrfToken, provider, baseUrl, basePath } = req.options
   try {
-    if (!["state", "both"].includes(provider.protection)) { // Provider does not support state, nothing to do.
+    if (!['state', 'both'].includes(provider.protection)) { // Provider does not support state, nothing to do.
       return
     }
 
@@ -41,7 +41,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { provider, baseUrl, basePath, csrfToken } = req.options
   try {
-    if (!["state", "both"].includes(provider.protection)) { // Provider does not support state, nothing to do.
+    if (!['state', 'both'].includes(provider.protection)) { // Provider does not support state, nothing to do.
       return
     }
 

--- a/src/server/lib/oauth/state-handler.js
+++ b/src/server/lib/oauth/state-handler.js
@@ -12,7 +12,7 @@ import { OAuthCallbackError } from '../../../lib/errors'
 export async function handleCallback (req, res) {
   const { csrfToken, provider, baseUrl, basePath } = req.options
   try {
-    if (provider.protection !== 'state') { // Provider does not support state, nothing to do.
+    if (!["state", "both"].includes(provider.protection)) { // Provider does not support state, nothing to do.
       return
     }
 
@@ -41,7 +41,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { provider, baseUrl, basePath, csrfToken } = req.options
   try {
-    if (provider.protection !== 'state') { // Provider does not support state, nothing to do.
+    if (!["state", "both"].includes(provider.protection)) { // Provider does not support state, nothing to do.
       return
     }
 

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -145,7 +145,7 @@ You can look at the existing built-in providers for inspiration.
 |       profile       |       An callback returning an object with the user's info       |            `object`             |    No    |
 |       idToken       |   Set to `true` for services that use ID Tokens (e.g. OpenID)    |            `boolean`            |    No    |
 |       headers       |      Any headers that should be sent to the OAuth provider       |            `object`             |    No    |
-|     protection      | Additional security for OAuth login flows (defaults to `state`)  | `pkce`, `state`, `none`, 'both' |    No    |
+|     protection      | Additional security for OAuth login flows (defaults to `state`)  |`[pkce]`,`[state]`,`[pkce,state]`|    No    |
 |        state        | Same as `protection: "state"`. Being deprecated, use protection. |            `boolean`            |    No    |
 
 ## Sign in with Email

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -145,7 +145,7 @@ You can look at the existing built-in providers for inspiration.
 |       profile       |       An callback returning an object with the user's info       |            `object`             |    No    |
 |       idToken       |   Set to `true` for services that use ID Tokens (e.g. OpenID)    |            `boolean`            |    No    |
 |       headers       |      Any headers that should be sent to the OAuth provider       |            `object`             |    No    |
-|     protection      | Additional security for OAuth login flows (defaults to `state`)  |     `pkce`, `state`, `none`     |    No    |
+|     protection      | Additional security for OAuth login flows (defaults to `state`)  | `pkce`, `state`, `none`, 'both' |    No    |
 |        state        | Same as `protection: "state"`. Being deprecated, use protection. |            `boolean`            |    No    |
 
 ## Sign in with Email


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add new protection value: "both", to use both handlers (state and pkce).
<!-- Why are these changes necessary? -->

**Why**:
Some provider require the state param when using the pkce protection as reported on this issues:
https://github.com/nextauthjs/next-auth/issues/1530
https://github.com/nextauthjs/next-auth/issues/1367
<!-- How were these changes implemented? -->

**How**:
Just editing the handlers validations to handle in case of "both" is set on protection.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
It's note ready, actually its more a suggestion than a PR.
<!-- feel free to add additional comments -->
Note: I called it both, but it could have other names, such as: pkce-state or pkce-with-state