### PR TITLE
Convert sub to int for getUser()

### DIFF
--- a/src/server/lib/callback-handler.js
+++ b/src/server/lib/callback-handler.js
@@ -60,7 +60,7 @@ export default async function callbackHandler (sessionToken, profile, providerAc
       try {
         session = await jwt.decode({ ...jwt, token: sessionToken })
         if (session?.sub) {
-          user = await getUser(session.sub)
+          user = await getUser(parseInt(session.sub))
           isSignedIn = !!user
         }
       } catch {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Make sure an int is passed to `getUser()` when checking if the user is logged in the server callback handler.

<!-- Why are these changes necessary? -->

**Why**: I cannot link accounts to a single user without this code change... The adapters' `getUser()` requires a number as the sole param. Per the [JWT spec (sub section)](https://tools.ietf.org/html/rfc7519#section-4.1.2), `sub` is be a string. Thus, if you're calling `getUser(sub)`, you're passing a string to `getUser()`, which will throw an error in the adapter (e.g. prisma adapter).

Notably, [the `catch` block for this code](https://github.com/nextauthjs/next-auth/blob/main/src/server/lib/callback-handler.js#L67) does not throw an error, which made this issue hard to track down.

<!-- How were these changes implemented? -->

**How**: Calling `getUser(parseInt(sub))` instead of `getUser(sub)`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I am submitting this PR with the following questions, which will help us improve the PR before its merged (or an alternative fix is approved):

- Do all adapters require the param passed to `getUser()` to be an int? I have only used the Prisma adapter though, upon reading the source for other adapters, believe all adapters `getUser()` methods require a param passed as an int, not string, to function properly.
- Why is an error not thrown in [the catch block](https://github.com/nextauthjs/next-auth/blob/main/src/server/lib/callback-handler.js#L67)?
- I presume a test for linking OAuth accounts to a single user would help catch this issue. However, I do not see any tests for linking multiple OAuth accounts to a single user. Is this correct? If so, adding those tests seems valuable but outside the scope of this PR. Do you agree?