### PR TITLE
docs(pages): correct getCsrfToken and input types

### DIFF
--- a/www/docs/configuration/pages.md
+++ b/www/docs/configuration/pages.md
@@ -65,7 +65,7 @@ SignIn.getInitialProps = async () => {
 If you create a custom sign in form for email sign in, you will need to submit both fields for the **email** address and **csrfToken** from **/api/auth/csrf** in a POST request to **/api/auth/signin/email**.
 
 ```jsx title="pages/auth/email-signin.js"
-import { csrfToken } from 'next-auth/client'
+import { getCsrfToken } from 'next-auth/client'
 
 export default function SignIn({ csrfToken }) {
   return (
@@ -73,7 +73,7 @@ export default function SignIn({ csrfToken }) {
       <input name='csrfToken' type='hidden' defaultValue={csrfToken}/>
       <label>
         Email address
-        <input type='text' id='email' name='email'/>
+        <input type='email' id='email' name='email'/>
       </label>
       <button type='submit'>Sign in with Email</button>
     </form>
@@ -92,7 +92,7 @@ export async function getServerSideProps(context){
 // If older than Next.js 9.3
 SignIn.getInitialProps = async (context) => {
   return {
-    csrfToken: await csrfToken(context)
+    csrfToken: await getCsrfToken(context)
   }
 }
 */
@@ -109,7 +109,7 @@ signIn('email', { email: 'jsmith@example.com' })
 If you create a sign in form for credentials based authentication, you will need to pass a **csrfToken** from **/api/auth/csrf** in a POST request to **/api/auth/callback/credentials**.
 
 ```jsx title="pages/auth/credentials-signin.js"
-import { csrfToken } from 'next-auth/client'
+import { getCsrfToken } from 'next-auth/client'
 
 export default function SignIn({ csrfToken }) {
   return (
@@ -121,7 +121,7 @@ export default function SignIn({ csrfToken }) {
       </label>
       <label>
         Password
-        <input name='password' type='text'/>
+        <input name='password' type='password'/>
       </label>
       <button type='submit'>Sign in</button>
     </form>
@@ -141,7 +141,7 @@ export async function getServerSideProps(context) {
 // If older than Next.js 9.3
 SignIn.getInitialProps = async (context) => {
   return {
-    csrfToken: await csrfToken(context)
+    csrfToken: await getCsrfToken(context)
   }
 }
 */


### PR DESCRIPTION
**What, Why and How**:

- This fixes the a mismatch between the import (`csrfToken`) and the method (`getCsrfToken`) used in `getInitialProps`/`getServerSideProps`.
- In addition the form input fields now have their correct type: `email` for email input (for better autocomplete, virtual keyboard support and native validation) and `password` for the password input (to hide password while typing).

**Checklist**:

- [x] Documentation
- [x] Tests N/A
- [x] Ready to be merged

ps: amazing work on this project! it has saved me so much time and works extremely well. ⭐ 
