### PR TITLE
chore(ts): build types pipeline

### DIFF
--- a/config/build-types.js
+++ b/config/build-types.js
@@ -1,0 +1,23 @@
+const fs = require("fs")
+const path = require("path")
+
+const BUILD_TARGETS = [
+  "index.d.ts",
+  "client.d.ts",
+  "adapters.d.ts",
+  "providers.d.ts",
+  "jwt.d.ts",
+  "_next.d.ts",
+  "_utils.d.ts",
+]
+
+BUILD_TARGETS.forEach((target) => {
+  fs.copyFile(
+    path.resolve("types", target),
+    path.join(process.cwd(), target),
+    (err) => {
+      if (err) throw err
+      console.log(`[build-types] copying "${target}" to root folder`)
+    }
+  )
+})

--- a/config/build-types.js
+++ b/config/build-types.js
@@ -1,19 +1,19 @@
-const fs = require("fs")
-const path = require("path")
+const fs = require('fs')
+const path = require('path')
 
 const BUILD_TARGETS = [
-  "index.d.ts",
-  "client.d.ts",
-  "adapters.d.ts",
-  "providers.d.ts",
-  "jwt.d.ts",
-  "_next.d.ts",
-  "_utils.d.ts",
+  'index.d.ts',
+  'client.d.ts',
+  'adapters.d.ts',
+  'providers.d.ts',
+  'jwt.d.ts',
+  '_next.d.ts',
+  '_utils.d.ts'
 ]
 
 BUILD_TARGETS.forEach((target) => {
   fs.copyFile(
-    path.resolve("types", target),
+    path.resolve('types', target),
     path.join(process.cwd(), target),
     (err) => {
       if (err) throw err

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "author": "Iain Collins <me@iaincollins.com>",
   "main": "index.js",
   "scripts": {
-    "build": "npm run build:js && npm run build:css",
+    "build": "npm run build:js && npm run build:css && npm run build:types",
     "build:js": "babel --config-file ./config/babel.config.json src --out-dir dist",
     "build:css": "postcss --config config/postcss.config.js src/**/*.css --base src --dir dist && node config/wrap-css.js",
+    "build:types": "node ./config/build-types.js",
     "dev": "next | npm run watch:css",
     "watch": "npm run watch:js | npm run watch:css",
     "watch:js": "babel --config-file ./config/babel.config.json --watch src --out-dir dist",


### PR DESCRIPTION
## What 🏕

As part of #1649, adds a script that moves the declaration files we have in `./types` to `./` relative to the files they intend to type.

## Why 💭

In this way, all the sub-modules exposed by`next-auth`: 
```
• next-auth/providers
• next-auth/adapters
• next-auth/client
• next-auth/jwt
```
can be typed through declaration files, and **Typescript** can pick up the types properly when importing them.

Refer to this issue: https://github.com/microsoft/TypeScript/issues/8305 to understand why we need a **1:1** file mapping when typing package sub-modules.

## How 🪂

Adding a simple **Node** script that copies the declaration files we have in `./types` to `./`, creating a **1:1 mapping** with the source files. In this way, we can keep the declaration files within `./types` rather than having them scattered through the `./src` directory and keep the tests working through [`dtslint`](https://github.com/microsoft/dtslint/).

The mapping information is stored in a constant within a file `./config/build-types` that we'll need to keep updating whenever new sub-modules are added to the package.

## Checklist 🙇🏽‍♂️

- [x] Add build scripts
  - [x] verify they work as intended
- [x] Manage to type `next-auth/jwt` properly
- [x] Update  `package.json`
- [x] Add it to the **CI pipeline**

