### PR TITLE
fix .flat is not a function when running node version lower than 11

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -79,6 +79,10 @@ async function NextAuthHandler (req, res, userOptions) {
       provider.protection = 'state' // Default to state, as we did in 3.1 REVIEW: should we use "pkce" or "none" as default?
     }
 
+    if (typeof provider.protection === 'string') {
+      provider.protection = [provider.protection]
+    }
+
     const maxAge = 30 * 24 * 60 * 60 // Sessions expire after 30 days of being idle
 
     // Parse database / adapter

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -136,7 +136,7 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
     headers.Authorization = `Bearer ${code}`
   }
 
-  if ([provider.protection].flat().includes('pkce')) {
+  if (provider.protection.includes('pkce')) {
     params.code_verifier = codeVerifier
   }
 

--- a/src/server/lib/oauth/pkce-handler.js
+++ b/src/server/lib/oauth/pkce-handler.js
@@ -16,7 +16,7 @@ const PKCE_MAX_AGE = 60 * 15 // 15 minutes in seconds
 export async function handleCallback (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (![provider.protection].flat().includes('pkce')) { // Provider does not support PKCE, nothing to do.
+    if (!provider.protection.includes('pkce')) { // Provider does not support PKCE, nothing to do.
       return
     }
 
@@ -50,7 +50,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { cookies, provider, baseUrl, basePath } = req.options
   try {
-    if (![provider.protection].flat().includes('pkce')) { // Provider does not support PKCE, nothing to do.
+    if (!provider.protection.includes('pkce')) { // Provider does not support PKCE, nothing to do.
       return
     }
     // Started login flow, add generated pkce to req.options and (encrypted) code_verifier to a cookie

--- a/src/server/lib/oauth/state-handler.js
+++ b/src/server/lib/oauth/state-handler.js
@@ -12,7 +12,7 @@ import { OAuthCallbackError } from '../../../lib/errors'
 export async function handleCallback (req, res) {
   const { csrfToken, provider, baseUrl, basePath } = req.options
   try {
-    if (![provider.protection].flat().includes('state')) { // Provider does not support state, nothing to do.
+    if (!provider.protection.includes('state')) { // Provider does not support state, nothing to do.
       return
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix .flat is not a function when running node version lower than 11

<!-- Why are these changes necessary? -->

**Why**:
This problem started in #1565 
<!-- How were these changes implemented? -->

**How**:
A check was made to check if the provider.protection is a string and if this is true, the provider.protection is rewritten to array and the string is placed inside and the handlers were  edited again adjusted

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Fixes #1675