### PR TITLE
fix validation of provider existence before looking for protection property

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -79,7 +79,7 @@ async function NextAuthHandler (req, res, userOptions) {
       provider.protection = 'state' // Default to state, as we did in 3.1 REVIEW: should we use "pkce" or "none" as default?
     }
 
-    if (provider && typeof provider.protection === 'string') {
+    if (typeof provider?.protection === 'string') {
       provider.protection = [provider.protection]
     }
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -79,7 +79,7 @@ async function NextAuthHandler (req, res, userOptions) {
       provider.protection = 'state' // Default to state, as we did in 3.1 REVIEW: should we use "pkce" or "none" as default?
     }
 
-    if (typeof provider.protection === 'string') {
+    if (provider && typeof provider.protection === 'string') {
       provider.protection = [provider.protection]
     }
 


### PR DESCRIPTION
**What**:

Validate provider exists before accessing protection property in NextAuthHandler

**Why**:

NextAuthHandler reads all requests to api, including endpoints that does not include `providerId` as /api/auth/session, on line 73, result of finding a provider with providerId = undefined, is an undefined provider, that leads to an `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'protection' of undefined` on line 82.

**How**:

Validate provider exists before accessing protection property.

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

Fixes #1686 