### PR TITLE
replace .flat() to support Node <11 in handleSignin

### DIFF
--- a/src/server/lib/oauth/state-handler.js
+++ b/src/server/lib/oauth/state-handler.js
@@ -41,7 +41,7 @@ export async function handleCallback (req, res) {
 export async function handleSignin (req, res) {
   const { provider, baseUrl, basePath, csrfToken } = req.options
   try {
-    if (![provider.protection].flat().includes('state')) { // Provider does not support state, nothing to do.
+    if (!provider.protection.includes('state')) { // Provider does not support state, nothing to do.
       return
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix .flat is not a function in handlesignIn when running node version lower than 11

<!-- Why are these changes necessary? -->

**Why**:
This problem started in #1565, I made a change recently (PR #1684), but I ended up forgetting to change the old function
<!-- How were these changes implemented? -->

**How**:
A check was made to check if the provider.protection is a string and if this is true, the provider.protection is rewritten to array and the string is placed inside and the handlers were  edited again adjusted

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Fixes #1675