### PR TITLE
Add sub to defaultJwtPayload for credentials provider.

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -262,7 +262,8 @@ export default async function callback (req, res) {
     const defaultJwtPayload = {
       name: user.name,
       email: user.email,
-      picture: user.image
+      picture: user.image,
+      sub: user.id?.toString()
     }
     const jwtPayload = await callbacks.jwt(defaultJwtPayload, user, account, userObjectReturnedFromAuthorizeHandler, false)
 


### PR DESCRIPTION
**What**:
The default jwt payload for the credentials provider is missing the sub field. This fix adds the sub field to the jwt payload, making it consistent with the jwt payload for the oauth and email providers.

**Why**:
The sub is missing when using jwt sessions and credentials provider. This means that users can only be identified by their email and not by the sub value.

**How**:

In src/server/routes/session.js:

Change
```javascript
    const defaultJwtPayload = {
      name: user.name,
      email: user.email,
      picture: user.image
    }
```
to
```javascript
    const defaultJwtPayload = {
      name: user.name,
      email: user.email,
      picture: user.image,
      sub: user.id?.toString()
    }
```

**Checklist**:

- [ ] Documentation - NA
- [ ] Tests - NA
- [X] Ready to be merged

It's a single line code change, so should be a pretty safe change.