### PR TITLE
fix(build): use optional-require dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14081,8 +14081,7 @@
     "optional-require": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
-      "dev": true
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
     },
     "optionator": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "jose": "^1.27.2",
     "jsonwebtoken": "^8.5.1",
     "oauth": "^0.9.15",
+    "optional-require": "^1.0.3",
     "pkce-challenge": "^2.1.0",
     "preact": "^10.4.1",
     "preact-render-to-string": "^5.1.14"

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -8,6 +8,8 @@ import Models from './models'
 
 import { updateConnectionEntities } from './lib/utils'
 
+import optionalRequire from 'optional-require'
+
 const Adapter = (typeOrmConfig, options = {}) => {
   // Ensure typeOrmConfigObject is normalized to an object
   const typeOrmConfigObject = (typeof typeOrmConfig === 'string')
@@ -93,7 +95,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
     let ObjectId
     if (config.type === 'mongodb') {
       idKey = '_id'
-      const mongodb = (await import('mongodb')).default
+      const mongodb = optionalRequire('mongodb')
       ObjectId = mongodb.ObjectID
     }
 

--- a/src/providers/email.js
+++ b/src/providers/email.js
@@ -1,4 +1,5 @@
 import logger from '../lib/logger'
+import optionalRequire from 'optional-require'
 
 export default (options) => {
   return {
@@ -26,7 +27,7 @@ async function sendVerificationRequest ({ identifier: email, url, baseUrl, provi
   // Strip protocol from URL and use domain as site name
   const site = baseUrl.replace(/^https?:\/\//, '')
   try {
-    const nodemailer = (await import('nodemailer')).default
+    const nodemailer = optionalRequire('nodemailer')
     await nodemailer
       .createTransport(server)
       .sendMail({

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -14,6 +14,8 @@ import csrfTokenHandler from './lib/csrf-token-handler'
 import * as pkce from './lib/oauth/pkce-handler'
 import * as state from './lib/oauth/state-handler'
 
+import optionalRequire from 'optional-require'
+
 // To work properly in production with OAuth providers the NEXTAUTH_URL
 // environment variable must be set.
 if (!process.env.NEXTAUTH_URL) {
@@ -87,7 +89,7 @@ async function NextAuthHandler (req, res, userOptions) {
     // If database URI or config object is provided, use it (simple usage)
     let adapter = userOptions.adapter
     if ((!adapter && !!userOptions.database)) {
-      const TypeOrm = (await import('../adapters/typeorm')).default
+      const TypeOrm = optionalRequire('../adapters/typeorm')
       adapter = TypeOrm.Adapter(userOptions.database)
     }
 


### PR DESCRIPTION
**What**:

Use `optional-require` to require certain modules optionally.

**Why**:

To my sadness, after trying out #1682 on a local project, I discovered that Next.js Webpack will try to include modules in the dev/prod builds that were added through dynamic imports, **even though they are wrapped in a conditional that is never `true`.*. That just seem to be a limitation/behaviour I do not understand fully, to be honest. If someone visits this PR, please enlighten me 💡, or show me to some documentation/reasoning! In the meantime, let's see that using a wrapper for importing helps.

I am trying `optional-require` instead of `require_optional` first, as the latter looks to be unmaintained (with still a number of downloads/week though), and even the `mondodb` module (that we used as an example when implementing optional modules) switched from it, as it introduced a bug in Windows.

**How**:

Switch out the failed dynamic imports to `optionalRequire` calls, and see if solves the problem.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
