### PR TITLE
Remove claim that new users do not have an ID

### DIFF
--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -78,11 +78,6 @@ When using NextAuth.js with a database, the User object will be either a user ob
 When using NextAuth.js without a database, the user object it will always be a prototype user object, with information extracted from the profile.
 :::
 
-:::tip
-If you only want to allow users who already have accounts in the database to sign in, you can check for the existence of a `user.id` property and reject any sign in attempts from accounts that do not have one.
-
-If you are using NextAuth.js without database and want to control who can sign in, you can check their email address or profile against a hard coded list in the `signIn()` callback.
-:::
 
 ## Redirect callback
 


### PR DESCRIPTION
I'm not sure when this changed, but it's no longer true. If the person logging in doesn't have a stored user account, the ID will be the provider_account_id

The answer to #736 is no longer accurate. I'm not sure if there's a different field people can look at to tell if the user has an account already.
