### PR TITLE
fix: use upgraded require optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2259,6 +2259,30 @@
         }
       }
     },
+    "@balazsorban/require-optional": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@balazsorban/require-optional/-/require-optional-1.0.0.tgz",
+      "integrity": "sha512-LD5glsU1iRvfIpv+1HGjvN7IhUjN4WM6Fe+hvSHOZPY3XsQ59117b5cvozA1CHzdod6XeYl3J54UICap9AWM1Q==",
+      "requires": {
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -8603,7 +8627,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -14081,7 +14104,8 @@
     "optional-require": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -19246,8 +19270,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
   ],
   "license": "ISC",
   "dependencies": {
+    "@balazsorban/require-optional": "^1.0.0",
     "futoin-hkdf": "^1.3.2",
     "jose": "^1.27.2",
     "jsonwebtoken": "^8.5.1",
     "oauth": "^0.9.15",
-    "optional-require": "^1.0.3",
     "pkce-challenge": "^2.1.0",
     "preact": "^10.4.1",
     "preact-render-to-string": "^5.1.14"

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -8,7 +8,7 @@ import Models from './models'
 
 import { updateConnectionEntities } from './lib/utils'
 
-import optionalRequire from 'optional-require'
+import requireOptional from '@balazsorban/require-optional'
 
 const Adapter = (typeOrmConfig, options = {}) => {
   // Ensure typeOrmConfigObject is normalized to an object
@@ -95,7 +95,11 @@ const Adapter = (typeOrmConfig, options = {}) => {
     let ObjectId
     if (config.type === 'mongodb') {
       idKey = '_id'
-      const mongodb = optionalRequire('mongodb')
+      // We should/could use dynamic import here, but
+      // bundlers like webpack will try to import the module,
+      // even if this conditional branch is never entered.
+      // We work around this with requireOptional.
+      const mongodb = requireOptional('mongodb')
       ObjectId = mongodb.ObjectID
     }
 

--- a/src/providers/email.js
+++ b/src/providers/email.js
@@ -1,5 +1,5 @@
 import logger from '../lib/logger'
-import optionalRequire from 'optional-require'
+import requireOptional from '@balazsorban/require-optional'
 
 export default (options) => {
   return {
@@ -27,7 +27,7 @@ async function sendVerificationRequest ({ identifier: email, url, baseUrl, provi
   // Strip protocol from URL and use domain as site name
   const site = baseUrl.replace(/^https?:\/\//, '')
   try {
-    const nodemailer = optionalRequire('nodemailer')
+    const nodemailer = requireOptional('nodemailer')
     await nodemailer
       .createTransport(server)
       .sendMail({

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -14,7 +14,7 @@ import csrfTokenHandler from './lib/csrf-token-handler'
 import * as pkce from './lib/oauth/pkce-handler'
 import * as state from './lib/oauth/state-handler'
 
-import optionalRequire from 'optional-require'
+import optionalRequire from '@balazsorban/require-optional'
 
 // To work properly in production with OAuth providers the NEXTAUTH_URL
 // environment variable must be set.


### PR DESCRIPTION
**What**:

Having another stab at #1682

**Why**:

The end goal is to not bundle/require `typeorm` and `nodemailer`, if someone doesn't use any of these in their project.

**How**:

I took [`require_optional`](https://github.com/christkv/require_optional) as a base, but published my own version under [`@balazsorban/require-optional`](https://www.npmjs.com/package/@balazsorban/require-optional). The difference is that it will use the now seemingly established fields `peerDependencies` and `peerDependenciesMeta`, instead of `peerOptionalDependencies`, which doesn't appear to be anywhere. In fact, googling it will point to one of this repository's issue with mongodb!


Side note, mongodb themselves decided to turn away from `peerOptionalDependencies`: https://jira.mongodb.org/browse/NODE-2867

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
