### PR TITLE
fix(jwt): make decode overrideable in getToken

### DIFF
--- a/src/lib/jwt.js
+++ b/src/lib/jwt.js
@@ -106,7 +106,8 @@ async function getToken (params) {
     // or not set (e.g. development or test instance) case use unprefixed name
     secureCookie = !(!process.env.NEXTAUTH_URL || process.env.NEXTAUTH_URL.startsWith('http://')),
     cookieName = (secureCookie) ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
-    raw = false
+    raw = false,
+    decode: _decode = decode
   } = params
   if (!req) throw new Error('Must pass `req` to JWT getToken()')
 
@@ -126,7 +127,7 @@ async function getToken (params) {
   }
 
   try {
-    return decode({ token, ...params })
+    return _decode({ token, ...params })
   } catch {
     return null
   }


### PR DESCRIPTION
**What**:

Be able to pass a `decode` function to `getToken` like this.
```js
getToken({
  decode() {
    // ...
  }
})
```

The shape should match https://github.com/nextauthjs/next-auth/blob/17b789822de64eb845e1e8e49ea83dbff56344f4/src/lib/jwt.js#L52-L68

**Why**:

Currently, when `getToken` tries to decode the token, it always uses the one defined in `lib/jwt`.

**How**:

Add a new named parameter, and default to `lib/jwt` for backward compatibility.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Fixes #1437 
