### PR TITLE
fix: add meta information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,16 @@
   "repository": "https://github.com/nextauthjs/next-auth.git",
   "author": "Iain Collins <me@iaincollins.com>",
   "main": "index.js",
+  "types": "./index.d.ts",
+  "keywords": ["react", "nodejs", "oauth", "jwt", "oauth2", "authentication", "nextjs", "csrf", "oidc", "nextauth"],
+  "exports": {
+    ".": "./dist/server/index.js",
+    "./jwt": "./dist/lib/jwt.js",
+    "./adapters": "./dist/adapters/index.js",
+    "./client": "./dist/client/index.js",
+    "./providers": "./dist/providers/index.js",
+    "./providers/*": "./dist/providers/*.js"
+  },
   "scripts": {
     "build": "npm run build:js && npm run build:css",
     "build:js": "node ./config/build.js && babel --config-file ./config/babel.config.json src --out-dir dist",


### PR DESCRIPTION
**What**:

Add some new fields (`keywords`, `exports`, `types`) to `package.json`.

**Why**:
Recommended by SkyPack, a modern JavaScript Delivery Network:
![image](https://user-images.githubusercontent.com/18369201/115460359-76c5d400-a228-11eb-88b4-75be5c16baf4.png)

**How**:

Updated the `package.json` file.

Currently, only Webpack 5 can take advantage of the `exports`, Webpack 4 seemed to simply ignore it in my case.

These should be safe, but in case something goes wrong or bugs get reported because of this, we can revert some of these changes pretty fast.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
