### PR TITLE
fix(ts): adjust properties on default interfaces

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -375,7 +375,6 @@ export interface PagesOptions {
  */
 export interface Session extends Record<string, unknown> {
   user?: User
-  accessToken?: string
   expires: string
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -365,12 +365,12 @@ export interface PagesOptions {
 }
 
 export interface DefaultSession extends Record<string, unknown> {
-  user: {
-    name: string | null
-    email: string | null
-    picture: string | null
+  user?: {
+    name?: string | null
+    email?: string | null
+    image?: string | null
   }
-  expires: string
+  expires?: string
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -375,7 +375,7 @@ export interface PagesOptions {
  */
 export interface Session extends Record<string, unknown> {
   user?: User
-  expires: string
+  expires?: string
 }
 
 /** [Documentation](https://next-auth.js.org/configuration/options#session) */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -364,6 +364,15 @@ export interface PagesOptions {
   newUser?: string
 }
 
+export interface DefaultSession extends Record<string, unknown> {
+  user: {
+    name: string | null
+    email: string | null
+    picture: string | null
+  }
+  expires: string
+}
+
 /**
  * Returned by `useSession`, `getSession`, returned by the `session` callback
  * and also the shape received as a prop on the `Provider` React Context
@@ -373,10 +382,7 @@ export interface PagesOptions {
  * [`Provider`](https://next-auth.js.org/getting-started/client#provider) |
  * [`session` callback](https://next-auth.js.org/configuration/callbacks#jwt-callback)
  */
-export interface Session extends Record<string, unknown> {
-  user?: User
-  expires?: string
-}
+export interface Session extends Record<string, unknown>, DefaultSession {}
 
 /** [Documentation](https://next-auth.js.org/configuration/options#session) */
 export interface SessionOptions {

--- a/types/jwt.d.ts
+++ b/types/jwt.d.ts
@@ -1,17 +1,19 @@
 import { JWT as JoseJWT, JWE } from "jose"
 import { NextApiRequest } from "./internals/utils"
 
+export interface DefaultJWT extends Record<string, unknown> {
+  name: string | null
+  email: string | null
+  picture: string | null
+  sub: string | undefined
+}
+
 /**
  * Returned by the `jwt` callback and `getToken`, when using JWT sessions
  *
  * [`jwt` callback](https://next-auth.js.org/configuration/callbacks#jwt-callback) | [`getToken`](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#using-gettoken)
  */
-export interface JWT extends Record<string, unknown> {
-  name?: string | null
-  email?: string | null
-  picture?: string | null
-  sub?: string
-}
+export interface JWT extends Record<string, unknown>, DefaultJWT {}
 
 export interface JWTEncodeParams {
   token?: JWT

--- a/types/jwt.d.ts
+++ b/types/jwt.d.ts
@@ -2,10 +2,10 @@ import { JWT as JoseJWT, JWE } from "jose"
 import { NextApiRequest } from "./internals/utils"
 
 export interface DefaultJWT extends Record<string, unknown> {
-  name: string | null
-  email: string | null
-  picture: string | null
-  sub: string | undefined
+  name?: string | null
+  email?: string | null
+  picture?: string | null
+  sub?: string
 }
 
 /**

--- a/types/jwt.d.ts
+++ b/types/jwt.d.ts
@@ -10,6 +10,7 @@ export interface JWT extends Record<string, unknown> {
   name?: string | null
   email?: string | null
   picture?: string | null
+  sub?: string
 }
 
 export interface JWTEncodeParams {


### PR DESCRIPTION
**What**:

Adjusting the `JWT` and `Session` interfaces

**Why**:

Here is the shape of the default JWT payload:
https://github.com/nextauthjs/next-auth/blob/cb1e5a717459d2b975f7f157d1d99d60ae0c4e39/src/server/routes/callback.js#L86-L91

Here is the default Session payload:
https://github.com/nextauthjs/next-auth/blob/cb1e5a717459d2b975f7f157d1d99d60ae0c4e39/src/server/routes/session.js#L32-L39

We should make it possible for users to make their own assumptions about the default properties. Currently, because of how type augmentation works, even if you made for example the `user` field required, it would have been shown as optional, because our default said it was optional. By extracting the default session and JWT interfaces, the user will have full control of those interfaces

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Thanks to @kripod for the heads-up!
