### PR TITLE
fix(client): export getCsrfToken directly to support Webpack 5

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -145,7 +145,7 @@ export async function getSession (ctx) {
   return session
 }
 
-async function getCsrfToken (ctx) {
+export async function getCsrfToken (ctx) {
   return (await _fetchData('csrf', ctx))?.csrfToken
 }
 


### PR DESCRIPTION
**What**:

The async function `getCsrfToken` in client needs to be exported in order to be usable when using webpack 5 (e.g. next-js 10.x.x with `future: { webpack5: true }`).

**Why**:

When you try to use `getCsrfToken()` after using `import { getCsrfToken } from "next-auth/client";` you will be prompted with `Attempted import error: 'getCsrfToken' is not exported from 'next-auth/client' (imported as 'getCsrfToken').` when building/using.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests
- [x] Ready to be merged
