### PR TITLE
fix(ts): move AppProvider out of internals

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -1,7 +1,7 @@
 import { AppOptions } from "./internals"
 import { ConnectionOptions, EntitySchema } from "typeorm"
 import { User } from "."
-import { AppProvider } from "./internals/providers"
+import { AppProvider } from "./providers"
 
 export interface Profile {
   id: string

--- a/types/internals/index.d.ts
+++ b/types/internals/index.d.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "./utils"
 import { NextAuthOptions } from ".."
-import { AppProvider } from "./providers"
+import { AppProvider } from "../providers"
 
 /** Options that are the same both in internal and user provided options. */
 export type NextAuthSharedOptions =

--- a/types/internals/providers.d.ts
+++ b/types/internals/providers.d.ts
@@ -1,6 +1,0 @@
-import { CommonProviderOptions } from "../providers"
-
-export interface AppProvider extends CommonProviderOptions {
-  signinUrl: string
-  callbackUrl: string
-}

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -161,6 +161,11 @@ export type AppProviders = Array<
   Provider | ReturnType<BuiltInProviders[keyof BuiltInProviders]>
 >
 
+export interface AppProvider extends CommonProviderOptions {
+  signinUrl: string
+  callbackUrl: string
+}
+
 declare const Providers: BuiltInProviders
 
 export default Providers

--- a/types/tests/server.test.ts
+++ b/types/tests/server.test.ts
@@ -1,4 +1,4 @@
-import Providers, { OAuthConfig } from "next-auth/providers"
+import Providers, { AppProvider, OAuthConfig } from "next-auth/providers"
 import {
   Adapter,
   EmailAppProvider,
@@ -12,7 +12,6 @@ import * as JWTType from "next-auth/jwt"
 import { Socket } from "net"
 import { NextApiRequest, NextApiResponse } from "internals/utils"
 import { AppOptions } from "internals"
-import { AppProvider } from "internals/providers"
 
 const req: NextApiRequest = Object.assign(new IncomingMessage(new Socket()), {
   query: {},


### PR DESCRIPTION
**What**:

Moved a TS interface out of the internal types

**Why**:

`AppProvider` can be used in certain user land scenarios.

**How**:

deleted `types/internals/providers.d.ts`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


Thanks to @kripod for noticing! :pray: