### PR TITLE
fix(ts): create DefaultUser/DefaultProfile interfaces

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -204,6 +204,7 @@ declare class TypeORMUserModel implements User {
     image?: string,
     emailVerified?: Date
   )
+  [x: string]: unknown
 }
 
 declare class TypeORMSessionModel implements Session {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -251,13 +251,15 @@ export interface Account extends TokenSet, Record<string, unknown> {
   type: string
 }
 
-/** The OAuth profile returned from your provider */
-export interface Profile extends Record<string, unknown> {
+export interface DefaultProfile {
   sub?: string
   name?: string
   email?: string
   image?: string
 }
+
+/** The OAuth profile returned from your provider */
+export interface Profile extends Record<string, unknown>, DefaultProfile {}
 
 /** [Documentation](https://next-auth.js.org/configuration/callbacks) */
 export interface CallbacksOptions<

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -391,6 +391,12 @@ export interface SessionOptions {
   updateAge?: number
 }
 
+export interface DefaultUser {
+  name?: string | null
+  email?: string | null
+  image?: string | null
+}
+
 /**
  * The shape of the returned object in the OAuth providers' `profile` callback,
  * available in the `jwt` and `session` callbacks,
@@ -401,11 +407,7 @@ export interface SessionOptions {
  * [`jwt` callback](https://next-auth.js.org/configuration/callbacks#jwt-callback) |
  * [`profile` OAuth provider callback](https://next-auth.js.org/configuration/providers#using-a-custom-provider)
  */
-export interface User {
-  name?: string | null
-  email?: string | null
-  image?: string | null
-}
+export interface User extends Record<string, unknown>, DefaultUser {}
 
 declare function NextAuth(
   req: NextApiRequest,


### PR DESCRIPTION
**What**:

Same as #1794, just for the `User` and `Profile` interfaces.

**Why**:

So `User` and `Profile` interfaces can also be completely rewritten.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Thanks again, @kripod 