### PR TITLE
chore: expose errors and logger for adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "exports": {
     ".": "./dist/server/index.js",
     "./jwt": "./dist/lib/jwt.js",
+    "./errors": "./dist/lib/errors.js",
+    "./logger": "./dist/lib/logger.js",
     "./adapters": "./dist/adapters/index.js",
     "./client": "./dist/client/index.js",
     "./providers": "./dist/providers/index.js",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "keywords": ["react", "nodejs", "oauth", "jwt", "oauth2", "authentication", "nextjs", "csrf", "oidc", "nextauth"],
   "exports": {
     ".": "./dist/server/index.js",
-    "./jwt": "./dist/lib/jwt.js",
     "./errors": "./dist/lib/errors.js",
+    "./jwt": "./dist/lib/jwt.js",
     "./logger": "./dist/lib/logger.js",
     "./adapters": "./dist/adapters/index.js",
     "./client": "./dist/client/index.js",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Exposing 2 new files through `package.json`.

**Why**:

So that [new adapters](https://github.com/nextauthjs/adapters) could reference them. Otherwise, an error like below pops up:

![Package subpath is not defined by "exports" in next-auth/package.json](https://user-images.githubusercontent.com/14854048/115759045-19549300-a3a0-11eb-9ca3-44e7118a95c3.png)

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
