### PR TITLE
feat: pass all of providerAccount in linkAccount cb

### DIFF
--- a/src/server/lib/callback-handler.js
+++ b/src/server/lib/callback-handler.js
@@ -161,8 +161,7 @@ export default async function callbackHandler(
           providerAccount.id,
           providerAccount.refreshToken,
           providerAccount.accessToken,
-          providerAccount.accessTokenExpires,
-          ...providerAccount
+          providerAccount.accessTokenExpires
         )
         await dispatchEvent(events.linkAccount, {
           user,
@@ -223,8 +222,7 @@ export default async function callbackHandler(
         providerAccount.id,
         providerAccount.refreshToken,
         providerAccount.accessToken,
-        providerAccount.accessTokenExpires,
-        ...providerAccount
+        providerAccount.accessTokenExpires
       )
       await dispatchEvent(events.linkAccount, {
         user,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Passed all `providerAccount` tokens to the `linkAccount` cb

<!-- Why are these changes necessary? -->

**Why**: https://github.com/nextauthjs/adapters/issues/48

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation ?
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

New PR based off the correct branch (`main`) - replaces #1758.

Also applies new eslint/prettier formatting to this `callback-handler.js` file.

Original PR comment: 

@balazsorban44  @RazerMoon - so this PR passes the rest of the providerAccount object along in the linkAccount cb. However, they are not persisted in the Account table yet obviously as that would require breaking changes to the db model. I also didn't do the named parameter part yet as that would also be a pretty big breaking change. 

What do you guys think? Is the named parameter thing a breaking change we can live with in 4.x, for example? If so, I can do that here as well.
