### PR TITLE
feat(provider): add WordPress.com provider

### DIFF
--- a/src/providers/wordpress.js
+++ b/src/providers/wordpress.js
@@ -1,0 +1,23 @@
+export default function WordPress(options) {
+  return {
+    id: "wordpress",
+    name: "WordPress.com",
+    type: "oauth",
+    version: "2.0",
+    scope: "auth",
+    params: { grant_type: "authorization_code" },
+    accessTokenUrl: "https://public-api.wordpress.com/oauth2/token",
+    authorizationUrl:
+      "https://public-api.wordpress.com/oauth2/authorize?response_type=code",
+    profileUrl: "https://public-api.wordpress.com/rest/v1/me",
+    profile(profile) {
+      return {
+        id: profile.ID,
+        name: profile.display_name,
+        email: profile.email,
+        image: profile.avatar_URL,
+      }
+    },
+    ...options,
+  }
+}

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -91,6 +91,7 @@ export type OAuthProviderType =
   | "Twitch"
   | "Twitter"
   | "VK"
+  | "WordPress"
   | "Yandex"
   | "Zoho"
 

--- a/www/docs/providers/wordpress.md
+++ b/www/docs/providers/wordpress.md
@@ -1,0 +1,30 @@
+---
+id: wordpress
+title: WordPress.com
+---
+
+## Documentation
+
+https://developer.wordpress.com/docs/oauth2/
+
+## Configuration
+
+https://developer.wordpress.com/apps/
+
+## Example
+
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.WordPress({
+    clientId: process.env.WORDPRESS_CLIENT_ID,
+    clientSecret: process.env.WORDPRESS_CLIENT_SECRET
+  })
+}
+...
+```
+
+:::tip
+Register your application to obtain Client ID and Client Secret at https://developer.wordpress.com/apps/ Select Type as Web and set Redirect URL to `http://example.com/api/auth/callback/wordpress` where example.com is your site domain.
+:::


### PR DESCRIPTION
**What**:

Add WordPress.com provider

**Why**:

Others may find it useful. WordPress.com Connect is a secure and easy way for millions of WordPress.com users to log in.

**How**:

Implement as written in https://next-auth.js.org/configuration/providers#adding-a-new-built-in-provider + add Typescript type

**Checklist**:

- [x] Documentation
- [ ] Tests N/A (manually)
- [x] Ready to be merged