### PR TITLE
Fixes #1840

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -133,6 +133,8 @@ export default async function callback (req, res) {
       logger.error('OAUTH_CALLBACK_ERROR', error)
       return res.redirect(`${baseUrl}${basePath}/error?error=Callback`)
     }
+  } else if (provider.type === 'email' && req.method === 'HEAD') {
+    return res.redirect(baseUrl)
   } else if (provider.type === 'email') {
     try {
       if (!adapter) {


### PR DESCRIPTION
**What**:

Signing in with an Outlook email which has `SafeLinks` enabled does not work. This bug has been issued #1840.

**Why**:

The token gets invalidated because of some request that `SafeLinks` outlook protection link is making before the validation.

**How**:

When the provider is `email` and the request is a `HEAD` request, it gets redirected to the base URL. This avoids the token to be invalidated.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
