### PR TITLE
chore(release): do not mark released PRs/issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,18 @@
         "name": "next",
         "prerelease": true
       }
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      [
+        "@semantic-release/github",
+        {
+          "releasedLabels": false,
+          "successComment": false
+        }
+      ]
     ]
   },
   "funding": [


### PR DESCRIPTION
**What**:

Do not send out comments to issues/PRs and don't label them on new releases.

**Why**:

I recently discovered that `semantic-release` will send out multiple comments/labels to already handled PRs/issues, which created a lot of noise. Ideally, already handled items would not be notified again, and this could be easy to achieve if https://github.com/semantic-release/github/issues/359 was acknowledged and https://github.com/semantic-release/github/pull/360 merged.

**How**:

Turn off `successComment` and `releasedLabel` on the `@semantic-release/github` plugin.

Config: https://github.com/semantic-release/github#options

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
