### PR TITLE
Made `ctxOrReq` optional in `getCsrfToken()`

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -52,7 +52,7 @@ export const session: typeof getSession
  *
  * [Documentation](https://next-auth.js.org/getting-started/client#getcsrftoken)
  */
-export function getCsrfToken(ctxOrReq: CtxOrReq): Promise<string | null>
+export function getCsrfToken(ctxOrReq?: CtxOrReq): Promise<string | null>
 
 /**
  * Alias for `getCsrfToken`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Made `ctxOrReq` optional in `getCsrfToken()`

<!-- Why are these changes necessary? -->

**Why**: Because in `client` it was unnecessary, but when used with typescript, TS makes unnecessary complaints.

<!-- How were these changes implemented? -->

**How**: Just adding a `?` at param of the function. `getCsrfToken(ctxOrReq?: ctxOrReq)`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

fixes #1847