### PR TITLE
Made `GetSessionOptions` optional

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -32,7 +32,7 @@ export function useSession(): [Session | null, boolean]
  *
  * [Documentation](https://next-auth.js.org/getting-started/client#getsession)
  */
-export function getSession(options: GetSessionOptions): Promise<Session | null>
+export function getSession(options?: GetSessionOptions): Promise<Session | null>
 
 /**
  * Alias for `getSession`


### PR DESCRIPTION
As it was confusing on client side to put in an empty object

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Made `GetSessionOptions` optional in `getSession()`

<!-- Why are these changes necessary? -->

**Why**: Because in client it was unnecessary, but when used with typescript, TS makes unnecessary complaints.


<!-- How were these changes implemented? -->

**How**: Just adding a `?` at param of the function. `getSession(options?: GetSessionOptions)`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
