### PR TITLE
fix: double-wrapped return values caused by `Promise.{reject,resolve}`

### DIFF
--- a/src/adapters/example/index.js
+++ b/src/adapters/example/index.js
@@ -81,7 +81,7 @@ const Adapter = (config, options = {}) => {
       return null
     }
 
-    return Promise.resolve({
+    return {
       createUser,
       getUser,
       getUserByEmail,
@@ -97,7 +97,7 @@ const Adapter = (config, options = {}) => {
       createVerificationRequest,
       getVerificationRequest,
       deleteVerificationRequest
-    })
+    }
   }
 
   return {

--- a/src/adapters/prisma/index.js
+++ b/src/adapters/prisma/index.js
@@ -50,7 +50,7 @@ const Adapter = (config) => {
         })
       } catch (error) {
         logger.error('CREATE_USER_ERROR', error)
-        return Promise.reject(new CreateUserError(error))
+        throw new CreateUserError(error)
       }
     }
 
@@ -60,18 +60,18 @@ const Adapter = (config) => {
         return prisma[User].findUnique({ where: { id } })
       } catch (error) {
         logger.error('GET_USER_BY_ID_ERROR', error)
-        return Promise.reject(new Error('GET_USER_BY_ID_ERROR', error))
+        throw new Error('GET_USER_BY_ID_ERROR', error)
       }
     }
 
     async function getUserByEmail (email) {
       debug('GET_USER_BY_EMAIL', email)
       try {
-        if (!email) { return Promise.resolve(null) }
+        if (!email) { return null }
         return prisma[User].findUnique({ where: { email } })
       } catch (error) {
         logger.error('GET_USER_BY_EMAIL_ERROR', error)
-        return Promise.reject(new Error('GET_USER_BY_EMAIL_ERROR', error))
+        throw new Error('GET_USER_BY_EMAIL_ERROR', error)
       }
     }
 
@@ -83,7 +83,7 @@ const Adapter = (config) => {
         return prisma[User].findUnique({ where: { id: account.userId } })
       } catch (error) {
         logger.error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
-        return Promise.reject(new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error))
+        throw new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
       }
     }
 
@@ -102,7 +102,7 @@ const Adapter = (config) => {
         })
       } catch (error) {
         logger.error('UPDATE_USER_ERROR', error)
-        return Promise.reject(new Error('UPDATE_USER_ERROR', error))
+        throw new Error('UPDATE_USER_ERROR', error)
       }
     }
 
@@ -112,7 +112,7 @@ const Adapter = (config) => {
         return prisma[User].delete({ where: { id: userId } })
       } catch (error) {
         logger.error('DELETE_USER_ERROR', error)
-        return Promise.reject(new Error('DELETE_USER_ERROR', error))
+        throw new Error('DELETE_USER_ERROR', error)
       }
     }
 
@@ -133,7 +133,7 @@ const Adapter = (config) => {
         })
       } catch (error) {
         logger.error('LINK_ACCOUNT_ERROR', error)
-        return Promise.reject(new Error('LINK_ACCOUNT_ERROR', error))
+        throw new Error('LINK_ACCOUNT_ERROR', error)
       }
     }
 
@@ -143,7 +143,7 @@ const Adapter = (config) => {
         return prisma[Account].delete({ where: { compoundId: getCompoundId(providerId, providerAccountId) } })
       } catch (error) {
         logger.error('UNLINK_ACCOUNT_ERROR', error)
-        return Promise.reject(new Error('UNLINK_ACCOUNT_ERROR', error))
+        throw new Error('UNLINK_ACCOUNT_ERROR', error)
       }
     }
 
@@ -167,7 +167,7 @@ const Adapter = (config) => {
         })
       } catch (error) {
         logger.error('CREATE_SESSION_ERROR', error)
-        return Promise.reject(new Error('CREATE_SESSION_ERROR', error))
+        throw new Error('CREATE_SESSION_ERROR', error)
       }
     }
 
@@ -185,7 +185,7 @@ const Adapter = (config) => {
         return session
       } catch (error) {
         logger.error('GET_SESSION_ERROR', error)
-        return Promise.reject(new Error('GET_SESSION_ERROR', error))
+        throw new Error('GET_SESSION_ERROR', error)
       }
     }
 
@@ -222,7 +222,7 @@ const Adapter = (config) => {
         return prisma[Session].update({ where: { id }, data: { expires: expires.toISOString() } })
       } catch (error) {
         logger.error('UPDATE_SESSION_ERROR', error)
-        return Promise.reject(new Error('UPDATE_SESSION_ERROR', error))
+        throw new Error('UPDATE_SESSION_ERROR', error)
       }
     }
 
@@ -232,7 +232,7 @@ const Adapter = (config) => {
         return prisma[Session].delete({ where: { sessionToken } })
       } catch (error) {
         logger.error('DELETE_SESSION_ERROR', error)
-        return Promise.reject(new Error('DELETE_SESSION_ERROR', error))
+        throw new Error('DELETE_SESSION_ERROR', error)
       }
     }
 
@@ -270,7 +270,7 @@ const Adapter = (config) => {
         return verificationRequest
       } catch (error) {
         logger.error('CREATE_VERIFICATION_REQUEST_ERROR', error)
-        return Promise.reject(new Error('CREATE_VERIFICATION_REQUEST_ERROR', error))
+        throw new Error('CREATE_VERIFICATION_REQUEST_ERROR', error)
       }
     }
 
@@ -295,7 +295,7 @@ const Adapter = (config) => {
         return verificationRequest
       } catch (error) {
         logger.error('GET_VERIFICATION_REQUEST_ERROR', error)
-        return Promise.reject(new Error('GET_VERIFICATION_REQUEST_ERROR', error))
+        throw new Error('GET_VERIFICATION_REQUEST_ERROR', error)
       }
     }
 
@@ -307,11 +307,11 @@ const Adapter = (config) => {
         await prisma[VerificationRequest].deleteMany({ where: { identifier, token: hashedToken } })
       } catch (error) {
         logger.error('DELETE_VERIFICATION_REQUEST_ERROR', error)
-        return Promise.reject(new Error('DELETE_VERIFICATION_REQUEST_ERROR', error))
+        throw new Error('DELETE_VERIFICATION_REQUEST_ERROR', error)
       }
     }
 
-    return Promise.resolve({
+    return {
       createUser,
       getUser,
       getUserByEmail,
@@ -327,7 +327,7 @@ const Adapter = (config) => {
       createVerificationRequest,
       getVerificationRequest,
       deleteVerificationRequest
-    })
+    }
   }
 
   return {

--- a/src/adapters/typeorm/index.js
+++ b/src/adapters/typeorm/index.js
@@ -126,7 +126,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return await manager.save(user)
       } catch (error) {
         logger.error('CREATE_USER_ERROR', error)
-        return Promise.reject(new CreateUserError(error))
+        throw new CreateUserError(error)
       }
     }
 
@@ -147,18 +147,18 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return manager.findOne(User, { [idKey]: id })
       } catch (error) {
         logger.error('GET_USER_BY_ID_ERROR', error)
-        return Promise.reject(new Error('GET_USER_BY_ID_ERROR', error))
+        throw new Error('GET_USER_BY_ID_ERROR', error)
       }
     }
 
     async function getUserByEmail (email) {
       debug('GET_USER_BY_EMAIL', email)
       try {
-        if (!email) { return Promise.resolve(null) }
+        if (!email) { return null }
         return manager.findOne(User, { email })
       } catch (error) {
         logger.error('GET_USER_BY_EMAIL_ERROR', error)
-        return Promise.reject(new Error('GET_USER_BY_EMAIL_ERROR', error))
+        throw new Error('GET_USER_BY_EMAIL_ERROR', error)
       }
     }
 
@@ -170,7 +170,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return manager.findOne(User, { [idKey]: account.userId })
       } catch (error) {
         logger.error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
-        return Promise.reject(new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error))
+        throw new Error('GET_USER_BY_PROVIDER_ACCOUNT_ID_ERROR', error)
       }
     }
 
@@ -193,7 +193,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return manager.save(account)
       } catch (error) {
         logger.error('LINK_ACCOUNT_ERROR', error)
-        return Promise.reject(new Error('LINK_ACCOUNT_ERROR', error))
+        throw new Error('LINK_ACCOUNT_ERROR', error)
       }
     }
 
@@ -220,7 +220,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return manager.save(session)
       } catch (error) {
         logger.error('CREATE_SESSION_ERROR', error)
-        return Promise.reject(new Error('CREATE_SESSION_ERROR', error))
+        throw new Error('CREATE_SESSION_ERROR', error)
       }
     }
 
@@ -238,7 +238,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return session
       } catch (error) {
         logger.error('GET_SESSION_ERROR', error)
-        return Promise.reject(new Error('GET_SESSION_ERROR', error))
+        throw new Error('GET_SESSION_ERROR', error)
       }
     }
 
@@ -274,7 +274,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return manager.save(Session, session)
       } catch (error) {
         logger.error('UPDATE_SESSION_ERROR', error)
-        return Promise.reject(new Error('UPDATE_SESSION_ERROR', error))
+        throw new Error('UPDATE_SESSION_ERROR', error)
       }
     }
 
@@ -284,7 +284,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return await manager.delete(Session, { sessionToken })
       } catch (error) {
         logger.error('DELETE_SESSION_ERROR', error)
-        return Promise.reject(new Error('DELETE_SESSION_ERROR', error))
+        throw new Error('DELETE_SESSION_ERROR', error)
       }
     }
 
@@ -317,7 +317,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return verificationRequest
       } catch (error) {
         logger.error('CREATE_VERIFICATION_REQUEST_ERROR', error)
-        return Promise.reject(new Error('CREATE_VERIFICATION_REQUEST_ERROR', error))
+        throw new Error('CREATE_VERIFICATION_REQUEST_ERROR', error)
       }
     }
 
@@ -338,7 +338,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
         return verificationRequest
       } catch (error) {
         logger.error('GET_VERIFICATION_REQUEST_ERROR', error)
-        return Promise.reject(new Error('GET_VERIFICATION_REQUEST_ERROR', error))
+        throw new Error('GET_VERIFICATION_REQUEST_ERROR', error)
       }
     }
 
@@ -350,11 +350,11 @@ const Adapter = (typeOrmConfig, options = {}) => {
         await manager.delete(VerificationRequest, { identifier, token: hashedToken })
       } catch (error) {
         logger.error('DELETE_VERIFICATION_REQUEST_ERROR', error)
-        return Promise.reject(new Error('DELETE_VERIFICATION_REQUEST_ERROR', error))
+        throw new Error('DELETE_VERIFICATION_REQUEST_ERROR', error)
       }
     }
 
-    return Promise.resolve({
+    return {
       createUser,
       getUser,
       getUserByEmail,
@@ -370,7 +370,7 @@ const Adapter = (typeOrmConfig, options = {}) => {
       createVerificationRequest,
       getVerificationRequest,
       deleteVerificationRequest
-    })
+    }
   }
 
   return {

--- a/src/server/lib/signin/email.js
+++ b/src/server/lib/signin/email.js
@@ -1,26 +1,19 @@
 import { randomBytes } from 'crypto'
 
 export default async function email (email, provider, options) {
-  try {
-    const { baseUrl, basePath, adapter } = options
+  const { baseUrl, basePath, adapter } = options
 
-    const { createVerificationRequest } = await adapter.getAdapter(options)
+  const { createVerificationRequest } = await adapter.getAdapter(options)
 
-    // Prefer provider specific secret, but use default secret if none specified
-    const secret = provider.secret || options.secret
+  // Prefer provider specific secret, but use default secret if none specified
+  const secret = provider.secret || options.secret
 
-    // Generate token
-    const token = await provider.generateVerificationToken?.() ?? randomBytes(32).toString('hex')
+  // Generate token
+  const token = await provider.generateVerificationToken?.() ?? randomBytes(32).toString('hex')
 
-    // Send email with link containing token (the unhashed version)
-    const url = `${baseUrl}${basePath}/callback/${encodeURIComponent(provider.id)}?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`
+  // Send email with link containing token (the unhashed version)
+  const url = `${baseUrl}${basePath}/callback/${encodeURIComponent(provider.id)}?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`
 
-    // @TODO Create invite (send secret so can be hashed)
-    await createVerificationRequest(email, url, token, secret, provider, options)
-
-    // Return promise
-    return Promise.resolve()
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  // @TODO Create invite (send secret so can be hashed)
+  await createVerificationRequest(email, url, token, secret, provider, options)
 }

--- a/test/docker/app/pages/api/auth/[...nextauth].js
+++ b/test/docker/app/pages/api/auth/[...nextauth].js
@@ -101,10 +101,10 @@ const options = {
   // when an action is performed.
   // https://next-auth.js.org/configuration/callbacks
   callbacks: {
-    // async signIn(user, account, profile) { return Promise.resolve(true) },
-    // async redirect(url, baseUrl) { return Promise.resolve(baseUrl) },
-    // async session(session, user) { return Promise.resolve(session) },
-    // async jwt(token, user, account, profile, isNewUser) { return Promise.resolve(token) }
+    // async signIn(user, account, profile) { return true },
+    // async redirect(url, baseUrl) { return baseUrl },
+    // async session(session, user) { return session },
+    // async jwt(token, user, account, profile, isNewUser) { return token }
   },
 
   // Events are useful for logging

--- a/test/integration/github.js
+++ b/test/integration/github.js
@@ -18,7 +18,6 @@ describe('GitHub (OAuth 2.0 flow)', function () {
   before(async () => {
     browser = await puppeteer.launch(puppeteerOptions)
     page = await browser.newPage()
-    return Promise.resolve()
   })
 
   it('should show button on sign in page', async function () {
@@ -26,7 +25,6 @@ describe('GitHub (OAuth 2.0 flow)', function () {
     await page.goto(`${BASE_URL}/api/auth/signin?callbackUrl=${encodeURIComponent(CALLBACK_URL)}`)
     await page.waitForSelector(`form[action="${BASE_URL}/api/auth/signin/github"] button`)
     await page.click(`form[action="${BASE_URL}/api/auth/signin/github"] button`)
-    return Promise.resolve()
   })
 
   it('should be redirected to provider', async function () {
@@ -39,13 +37,11 @@ describe('GitHub (OAuth 2.0 flow)', function () {
     await page.waitForSelector('input[name="password"]')
     await page.click('input[name="password"]')
     await page.keyboard.type(PASSWORD)
-    return Promise.resolve()
   })
 
   it('should be able to sign in with provider', async function () {
     // Click submit
     await page.click('form[action="/session"] [type="submit"]')
-    return Promise.resolve()
   })
 
   it('should be returned to callback URL', async function () {
@@ -54,18 +50,14 @@ describe('GitHub (OAuth 2.0 flow)', function () {
 
     // Check we are at the correct callback URL
     assert.equal(page.url(), CALLBACK_URL)
-
-    return Promise.resolve()
   })
 
   it('should be signed in', async function () {
     // Check we are signed in
     await page.waitForSelector('#nextauth-signed-in')
-    return Promise.resolve()
   })
 
   after(async () => {
     await browser.close()
-    return Promise.resolve()
   })
 })

--- a/test/integration/google.js
+++ b/test/integration/google.js
@@ -20,7 +20,6 @@ describe.skip('Google (OAuth 2.0 flow)', function () {
   before(async () => {
     browser = await puppeteer.launch(puppeteerOptions)
     page = await browser.newPage()
-    return Promise.resolve()
   })
 
   it('should show button on sign in page', async function () {
@@ -28,7 +27,6 @@ describe.skip('Google (OAuth 2.0 flow)', function () {
     await page.goto(`${BASE_URL}/api/auth/signin?callbackUrl=${encodeURIComponent(CALLBACK_URL)}`)
     await page.waitForSelector(`form[action="${BASE_URL}/api/auth/signin/google"] button`)
     await page.click(`form[action="${BASE_URL}/api/auth/signin/google"] button`)
-    return Promise.resolve()
   })
 
   it('should be redirected to provider', async function () {
@@ -48,13 +46,11 @@ describe.skip('Google (OAuth 2.0 flow)', function () {
     await page.waitForSelector('input[type="password"]')
     await page.click('input[type="password"]')
     await page.keyboard.type(PASSWORD)
-    return Promise.resolve()
   })
 
   it('should be able to sign in with provider', async function () {
     // Click submit
     await page.click('button[type="button"]')
-    return Promise.resolve()
   })
 
   it('should be returned to callback URL', async function () {
@@ -64,18 +60,14 @@ describe.skip('Google (OAuth 2.0 flow)', function () {
     // Check we are at the correct callback URL
     // Note: Google OAuth appends a # to the end of the URL in Chrome
     assert.equal(page.url(), `${CALLBACK_URL}#`)
-
-    return Promise.resolve()
   })
 
   it('should be signed in', async function () {
     // Check we are signed in
     await page.waitForSelector('#nextauth-signed-in')
-    return Promise.resolve()
   })
 
   after(async () => {
     await browser.close()
-    return Promise.resolve()
   })
 })

--- a/test/integration/twitter.js
+++ b/test/integration/twitter.js
@@ -18,7 +18,6 @@ describe('Twitter (OAuth 1.1 flow)', async function () {
   before(async () => {
     browser = await puppeteer.launch(puppeteerOptions)
     page = await browser.newPage()
-    return Promise.resolve()
   })
 
   it('should show button on sign in page', async function () {
@@ -26,7 +25,6 @@ describe('Twitter (OAuth 1.1 flow)', async function () {
     await page.goto(`${BASE_URL}/api/auth/signin?callbackUrl=${encodeURIComponent(CALLBACK_URL)}`)
     await page.waitForSelector(`form[action="${BASE_URL}/api/auth/signin/twitter"] button`)
     await page.click(`form[action="${BASE_URL}/api/auth/signin/twitter"] button`)
-    return Promise.resolve()
   })
 
   it('should be redirected to provider', async function () {
@@ -39,13 +37,11 @@ describe('Twitter (OAuth 1.1 flow)', async function () {
     await page.waitForSelector('input[name="session[password]"]')
     await page.click('input[name="session[password]"]')
     await page.keyboard.type(PASSWORD)
-    return Promise.resolve()
   })
 
   it('should be able to sign in with provider', async function () {
     // Click submit
     await page.click('form[action="https://api.twitter.com/oauth/authenticate"] [type="submit"]')
-    return Promise.resolve()
   })
 
   it('should be returned to callback URL', async function () {
@@ -54,18 +50,14 @@ describe('Twitter (OAuth 1.1 flow)', async function () {
 
     // Check we are at the correct callback URL
     assert.equal(page.url(), CALLBACK_URL)
-
-    return Promise.resolve()
   })
 
   it('should be signed in', async function () {
     // Check we are signed in
     await page.waitForSelector('#nextauth-signed-in')
-    return Promise.resolve()
   })
 
   after(async () => {
     await browser.close()
-    return Promise.resolve()
   })
 })

--- a/test/mssql.js
+++ b/test/mssql.js
@@ -39,8 +39,6 @@ function printSchema() {
           {}
         )
       );
-    } catch (error) {
-      return Promise.reject(error);
     } finally {
       if (connection) {
         connection.close();
@@ -51,34 +49,30 @@ function printSchema() {
 const assert = require('assert');
 /** RUN */
 (async () => {
-  try {
-    const testResultSchema = await printSchema();
-    const actualTables = Object.keys(testResultSchema);
-    assert.equal(
-      TABLES,
-      actualTables.join(),
-      `MSSQL Schema: Expected tables [${TABLES.join()}]\n to be [${actualTables.join()}]`
-    );
-    //cheap deepEquals, with hints
-    for (const tableName of TABLES) {
-      const newLocal = expectedSchema[tableName];
-      for (const columnName of Object.keys(newLocal)) {
-        const expected = expectedSchema[tableName][columnName];
-        const actual = testResultSchema[tableName][columnName];
-        for (const propKey of Object.keys(expected)) {
-          assert.equal(
-            expected[propKey],
-            actual[propKey],
-            `Expected ${tableName}.${columnName}.${propKey}=${actual[propKey]}` +
-              ` to be ${expected[propKey]}`
-          );
-        }
+  const testResultSchema = await printSchema();
+  const actualTables = Object.keys(testResultSchema);
+  assert.equal(
+    TABLES,
+    actualTables.join(),
+    `MSSQL Schema: Expected tables [${TABLES.join()}]\n to be [${actualTables.join()}]`
+  );
+  //cheap deepEquals, with hints
+  for (const tableName of TABLES) {
+    const newLocal = expectedSchema[tableName];
+    for (const columnName of Object.keys(newLocal)) {
+      const expected = expectedSchema[tableName][columnName];
+      const actual = testResultSchema[tableName][columnName];
+      for (const propKey of Object.keys(expected)) {
+        assert.equal(
+          expected[propKey],
+          actual[propKey],
+          `Expected ${tableName}.${columnName}.${propKey}=${actual[propKey]}` +
+            ` to be ${expected[propKey]}`
+        );
       }
     }
-    console.log('mssql: schema ok');
-  } catch (error) {
-    return Promise.reject(error);
   }
+  console.log('mssql: schema ok');
 })()
   .then(() => process.exit())
   .catch((error) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Both `Promise.reject` and `Promise.resolve` return a `Promise` on their own. They are meant to be called inside non-async functions and serve as an escape hatch when native `async`/`await` syntax isn’t available.

The code of NextAuth is transpiled, though, so all the async functions already return a `Promise` by default. Thus, `Promise.reject` and `Promise.resolve` aren’t necessary anymore, and they may cause issues like #602.

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

- ~[ ] Documentation~
- ~[ ] Tests~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Possibly fixes #602
