### PR TITLE
fix(types): accessTokenExpires can only be null

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -59,7 +59,7 @@ export interface AdapterInstance<
     providerAccountId: string,
     refreshToken: string,
     accessToken: string,
-    accessTokenExpires: number | null
+    accessTokenExpires: null
   ) => Promise<void>
   createSession: (user: TUser) => Promise<TSession>
   getSession: (sessionToken: string) => Promise<TSession | null>

--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -59,7 +59,7 @@ export interface AdapterInstance<
     providerAccountId: string,
     refreshToken: string,
     accessToken: string,
-    accessTokenExpires: number
+    accessTokenExpires: number | null
   ) => Promise<void>
   createSession: (user: TUser) => Promise<TSession>
   getSession: (sessionToken: string) => Promise<TSession | null>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

In adapters, the value of `accessTokenExpires` can either be `number` or `null`.

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

~- [] Documentation~
~- [] Tests~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->