### PR TITLE
fix(types): email provider `maxAge` is always set

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -35,7 +35,7 @@ export type EmailAppProvider = AppProvider & {
   sendVerificationRequest: (
     params: SendVerificationRequestParams
   ) => Promise<void>
-  maxAge: number | undefined
+  maxAge: number
 }
 
 export interface AdapterInstance<


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Please see the email provider’s default options: https://github.com/nextauthjs/next-auth/blob/ff05ac1e419e3c2cf709f6c6e6b671ace5f6f70f/src/providers/email.js#L19

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

~- [] Documentation~
~- [] Tests~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
