### PR TITLE
feat(provider): add 42 School provider

### DIFF
--- a/src/providers/42.js
+++ b/src/providers/42.js
@@ -1,0 +1,20 @@
+export default function FortyTwo(options) {
+  return {
+    id: '42',
+    name: '42 School',
+    type: 'oauth',
+    version: '2.0',
+    params: { grant_type: 'authorization_code' },
+    accessTokenUrl: 'https://api.intra.42.fr/oauth/token',
+    authorizationUrl:
+      'https://api.intra.42.fr/oauth/authorize?response_type=code',
+    profileUrl: 'https://api.intra.42.fr/v2/me',
+    profile: (profile) => ({
+      id: profile.id,
+      email: profile.email,
+      image: profile.image_url,
+      name: profile.usual_full_name,
+    }),
+    ...options,
+  }
+}

--- a/src/providers/42.js
+++ b/src/providers/42.js
@@ -1,6 +1,6 @@
 export default function FortyTwo(options) {
   return {
-    id: '42',
+    id: '42-school',
     name: '42 School',
     type: 'oauth',
     version: '2.0',

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -67,6 +67,7 @@ export type OAuthProviderType =
   | "EVEOnline"
   | "Facebook"
   | "FACEIT"
+  | "FortyTwo"
   | "Foursquare"
   | "FusionAuth"
   | "GitHub"

--- a/www/docs/providers/42.md
+++ b/www/docs/providers/42.md
@@ -1,5 +1,5 @@
 ---
-id: 42
+id: 42-school
 title: 42 School
 ---
 

--- a/www/docs/providers/42.md
+++ b/www/docs/providers/42.md
@@ -14,7 +14,7 @@ https://profile.intra.42.fr/oauth/applications/new
 ## Example
 
 ```js
-import FortyTwo from `next-auth/42`
+import Providers from `next-auth/providers`
 ...
 providers: [
   Providers.FortyTwo({

--- a/www/docs/providers/42.md
+++ b/www/docs/providers/42.md
@@ -1,0 +1,26 @@
+---
+id: 42
+title: 42 School
+---
+
+## Documentation
+
+https://api.intra.42.fr/apidoc/guides/web_application_flow
+
+## Configuration
+
+https://profile.intra.42.fr/oauth/applications/new
+
+## Example
+
+```js
+import FortyTwo from `next-auth/42`
+...
+providers: [
+  Providers.FortyTwo({
+    clientId: process.env.FORTY_TWO_CLIENT_ID,
+    clientSecret: process.env.FORTY_TWO_CLIENT_SECRET
+  })
+]
+...
+```


### PR DESCRIPTION
## Reasoning 💡

Add 42 School provider.

### What is 42?

42 is an IT school with a network of more than 29 campuses around the globe, sharing the same learning platform and unique pedagogy with more than 8,000 students, for more information: https://www.codam.nl/en/the-42-network, https://www.42.fr/en/

### Why this provider?

42 School provider will make it easy for students to build useful Next.js apps for their campuses and the network, I already used it as a custom provider and I would like to share it with the community.

## Checklist 🧢

- [x] Documentation
- [ ] Tests N/A (manually)
- [x] Ready to be merged