### PR TITLE
fix(ts): wrap adapter option in ReturnType

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -124,7 +124,7 @@ export type Adapter<
   P = Profile,
   S = Session
 > = (
-  config: C,
+  config?: C,
   options?: O
 ) => {
   getAdapter(appOptions: AppOptions): Promise<AdapterInstance<U, P, S>>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -127,7 +127,7 @@ export interface NextAuthOptions {
    * [Default adapter](https://next-auth.js.org/schemas/adapters#typeorm-adapter) |
    * [Community adapters](https://github.com/nextauthjs/adapters)
    */
-  adapter?: Adapter
+  adapter?: ReturnType<Adapter>
   /**
    * Set debug to true to enable debug messages for authentication and database operations.
    * * **Default value**: `false`

--- a/types/tests/server.test.ts
+++ b/types/tests/server.test.ts
@@ -65,7 +65,7 @@ const exampleVerificationRequest = {
   expires: new Date(),
 }
 
-const adapter: Adapter = () => {
+const MyAdapter: Adapter = () => {
   return {
     async getAdapter(appOptions: AppOptions) {
       return {
@@ -190,7 +190,7 @@ const allConfig: NextAuthTypes.NextAuthOptions = {
       return undefined
     },
   },
-  adapter,
+  adapter: MyAdapter(),
   useSecureCookies: true,
   cookies: {
     sessionToken: {


### PR DESCRIPTION
## Reasoning 💡

When someone passes an adapter configuration to the `adapter` property, they will invoke it to configure the Adapter. This means that the corresponding type must be the returned type of that Adapter, rather than the actual `Adapter` interface

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊
