### PR TITLE
fix(ts): unset generics defaults for overriding

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -120,9 +120,9 @@ export interface AdapterInstance<U = User, P = Profile, S = Session> {
 export type Adapter<
   C = Record<string, unknown>,
   O = Record<string, unknown>,
-  U = User,
-  P = Profile,
-  S = Session
+  U = unknown,
+  P = unknown,
+  S = unknown
 > = (
   config?: C,
   options?: O


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

As `Adapter` is specified on its own in the `NextAuthOptions` interface, `U`/`P`/`S` cannot be overrided from adapter instantiations (like the new Prisma adapter).

Also, `S` shouldn’t match `Session` in most cases, as the first one is for the _storage_ of session models, and the second one represents the session forwarded to the user (readable via `useSession`/`getSession`).

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

- ~[] Documentation~
- ~[] Tests~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

