### PR TITLE
docs(providers): update providers documentation

### DIFF
--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -96,6 +96,25 @@ providers: [
 |       domain        |                Only when using certain Providers                 |             `string`              |    No    |
 |      tenantId       |     Only when using Azure, Active Directory, B2C, FusionAuth     |             `string`              |    No    |
 
+:::tip
+Even if you are using a built-in provider, you can override any of these options to tweak the default configuration.
+
+```js title=[...nextauth].js
+import Providers from "next-auth/providers"
+
+Providers.Auth0({
+  clientId: process.env.CLIENT_ID,
+  clientSecret: process.env.CLIENT_SECRET,
+  domain: process.env.DOMAIN,
+  scope: "openid your_custom_scope", // We do provide a default, but this will override it if defined
+  profile(profile) {
+    return {} // Return the profile in a shape that is different from the built-in one.
+  },
+})
+```
+
+:::
+
 ### Using a custom provider
 
 You can use an OAuth provider that isn't built-in by using a custom object.

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -130,7 +130,7 @@ As an example of what this looks like, this is the provider object returned for 
 }
 ```
 
-You can replace all the options in this JSON object with the ones from your custom provider - be sure to give it a unique ID and specify the correct OAuth version - and add it to the providers option when initializing the library:
+Replace all the options in this JSON object with the ones from your custom provider - be sure to give it a unique ID and specify the correct OAuth version - and add it to the providers option when initializing the library:
 
 ```js title="pages/api/auth/[...nextauth].js"
 import Providers from `next-auth/providers`

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -18,7 +18,7 @@ NextAuth.js is designed to work with any OAuth service, it supports **OAuth 1.0*
 
 ## OAuth Providers
 
-### 📓 Available providers
+### Available providers
 
 <ul>
 {Object.entries(require("../../providers.json"))
@@ -29,7 +29,7 @@ NextAuth.js is designed to work with any OAuth service, it supports **OAuth 1.0*
 )}
 </ul>
 
-### 💭 How to
+### How to
 
 1. Register your application at the developer portal of your provider. There are links above to the developer docs for most supported providers with details on how to register your application.
 
@@ -70,7 +70,7 @@ providers: [
 
 <Image src="/img/signin.png" alt="Signin Screenshot" />
 
-### ⚙️ Options
+### Options
 
 |        Name         |                           Description                            |               Type                | Required |
 | :-----------------: | :--------------------------------------------------------------: | :-------------------------------: | :------: |
@@ -96,7 +96,7 @@ providers: [
 |       domain        |                Only when using certain Providers                 |             `string`              |    No    |
 |      tenantId       |     Only when using Azure, Active Directory, B2C, FusionAuth     |             `string`              |    No    |
 
-### 🔖 Using a custom provider
+### Using a custom provider
 
 You can use an OAuth provider that isn't built-in by using a custom object.
 
@@ -152,7 +152,7 @@ providers: [
 ...
 ```
 
-### 🍵 Adding a new provider
+### Adding a new provider
 
 If you think your custom provider might be useful to others, we encourage you to open a PR and add it to the built-in list so others can discover it much more easily!
 
@@ -169,7 +169,7 @@ That's it! 🎉 Others will be able to discover this provider much more easily n
 
 ## Email Provider
 
-### 💭 How to
+### How to
 
 The Email provider uses email to send "magic links" that can be used sign in, you will likely have seen them before if you have used software like Slack.
 
@@ -196,7 +196,7 @@ See the [Email provider documentation](/providers/email) for more information on
 The email provider requires a database, it cannot be used without one.
 :::
 
-### ⚙️ Options
+### Options
 
 |          Name           |                                     Description                                     |               Type               | Required |
 | :---------------------: | :---------------------------------------------------------------------------------: | :------------------------------: | :------: |
@@ -210,7 +210,7 @@ The email provider requires a database, it cannot be used without one.
 
 ## Credentials Provider
 
-### 💭 How to
+### How to
 
 The Credentials provider allows you to handle signing in with arbitrary credentials, such as a username and password, two factor authentication or hardware device (e.g. YubiKey U2F / FIDO).
 
@@ -256,7 +256,7 @@ See the [Credentials provider documentation](/providers/credentials) for more in
 The Credentials provider can only be used if JSON Web Tokens are enabled for sessions. Users authenticated with the Credentials provider are not persisted in the database.
 :::
 
-### ⚙️ Options
+### Options
 
 |    Name     |                    Description                    |               Type               | Required |
 | :---------: | :-----------------------------------------------: | :------------------------------: | :------: |

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -3,13 +3,22 @@ id: providers
 title: Providers
 ---
 
-Authentication Providers in NextAuth.js are services that can be used to sign in (OAuth, Email, etc).
+Authentication Providers in **NextAuth.js** are services that can be used to sign in a user.
 
-## Sign in with OAuth
+There's four ways a user can be signed in:
 
-NextAuth.js is designed to work with any OAuth service, it supports OAuth 1.0, 1.0A and 2.0 and has built-in support for many popular OAuth sign-in services.
+- [Using a built-in OAuth Provider](#oauth-providers) (e.g Github, Twitter, Google, etc...)
+- [Using a custom OAuth Provider](#-using-a-custom-provider)
+- [Using Email](#email-provider)
+- [Using Credentials](#credentials-provider)
 
-### Built-in OAuth providers
+:::note
+NextAuth.js is designed to work with any OAuth service, it supports **OAuth 1.0**, **1.0A** and **2.0** and has built-in support for most popular sign-in services.
+:::
+
+## OAuth Providers
+
+### 📓 Available providers
 
 <ul>
 {Object.entries(require("../../providers.json"))
@@ -20,43 +29,74 @@ NextAuth.js is designed to work with any OAuth service, it supports OAuth 1.0, 1
 )}
 </ul>
 
-### Using a built-in OAuth provider
+### 💭 How to
 
 1. Register your application at the developer portal of your provider. There are links above to the developer docs for most supported providers with details on how to register your application.
 
 2. The redirect URI should follow this format:
-  ```
-  [origin]/api/auth/callback/[provider]
-  ```
-  For example, Twitter on `localhost` this would be:
-  ```
-  http://localhost:3000/api/auth/callback/twitter
-  ```
+
+```
+[origin]/api/auth/callback/[provider]
+```
+
+For example, Twitter on `localhost` this would be:
+
+```
+http://localhost:3000/api/auth/callback/twitter
+```
+
 3. Create a `.env` file at the root of your project and add the client ID and client secret. For Twitter this would be:
 
-  ```
-  TWITTER_ID=YOUR_TWITTER_CLIENT_ID
-  TWITTER_SECRET=YOUR_TWITTER_CLIENT_SECRET
-  ```
+```
+TWITTER_ID=YOUR_TWITTER_CLIENT_ID
+TWITTER_SECRET=YOUR_TWITTER_CLIENT_SECRET
+```
 
 4. Now you can add the provider settings to the NextAuth options object. You can add as many OAuth providers as you like, as you can see `providers` is an array.
 
-  ```js title="pages/api/auth/[...nextauth].js"
-  import Providers from `next-auth/providers`
-  ...
-  providers: [
-    Providers.Twitter({
-      clientId: process.env.TWITTER_ID,
-      clientSecret: process.env.TWITTER_SECRET
-    })
-  ],
-  ...
-  ```
-5. Once a provider has been setup, you can sign in at the following URL: `[origin]/api/auth/signin`. This is an unbranded auto-generated page with all the configured providers.   
+```js title="pages/api/auth/[...nextauth].js"
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.Twitter({
+    clientId: process.env.TWITTER_ID,
+    clientSecret: process.env.TWITTER_SECRET
+  })
+],
+...
+```
+
+5. Once a provider has been setup, you can sign in at the following URL: `[origin]/api/auth/signin`. This is an unbranded auto-generated page with all the configured providers.
 
 <Image src="/img/signin.png" alt="Signin Screenshot" />
 
-### Using a custom provider
+### ⚙️ Options
+
+|        Name         |                           Description                            |               Type                | Required |
+| :-----------------: | :--------------------------------------------------------------: | :-------------------------------: | :------: |
+|         id          |                    Unique ID for the provider                    |             `string`              |   Yes    |
+|        name         |                Descriptive name for the provider                 |             `string`              |   Yes    |
+|        type         |              Type of provider, in this case `oauth`              |              `oauth`              |   Yes    |
+|       version       |            OAuth version (e.g. '1.0', '1.0a', '2.0')             |             `string`              |   Yes    |
+|        scope        |          OAuth access scopes (expects array or string)           |      `string` or `string[]`       |   Yes    |
+|       params        |             Additional authorization URL parameters              |     `{ grant_type: string }`      |   Yes    |
+|   accessTokenUrl    |               Endpoint to retrieve an access token               |             `string`              |   Yes    |
+|  authorizationUrl   |         Endpoint to request authorization from the user          |             `string`              |   Yes    |
+|   requestTokenUrl   |               Endpoint to retrieve a request token               |             `string`              |   Yes    |
+|     profileUrl      |             Endpoint to retrieve the user's profile              |             `string`              |   Yes    |
+|      clientId       |                 Client ID of the OAuth provider                  |             `string`              |   Yes    |
+|    clientSecret     |               Client Secret of the OAuth provider                |             `string`              |   Yes    |
+|       profile       |       A callback returning an object with the user's info        |   `(profile, tokens) => Object`   |   Yes    |
+|     protection      | Additional security for OAuth login flows (defaults to `state`)  | `[pkce]`,`[state]`,`[pkce,state]` |    No    |
+|        state        | Same as `protection: "state"`. Being deprecated, use protection. |             `boolean`             |    No    |
+|       headers       |      Any headers that should be sent to the OAuth provider       |             `Object`              |    No    |
+| authorizationParams |    Additional params to be sent to the authorization endpoint    |             `Object`              |    No    |
+|       idToken       |   Set to `true` for services that use ID Tokens (e.g. OpenID)    |             `boolean`             |    No    |
+|       region        |                    Only when using BattleNet                     |             `string`              |    No    |
+|       domain        |                Only when using certain Providers                 |             `string`              |    No    |
+|      tenantId       |     Only when using Azure, Active Directory, B2C, FusionAuth     |             `string`              |    No    |
+
+### 🔖 Using a custom provider
 
 You can use an OAuth provider that isn't built-in by using a custom object.
 
@@ -89,7 +129,8 @@ As an example of what this looks like, this is the provider object returned for 
   clientSecret: ""
 }
 ```
-You can replace all the options in this JSON object with the ones from your custom provider - be sure to give it a unique ID and specify the correct OAuth version - and add it to the providers option:
+
+You can replace all the options in this JSON object with the ones from your custom provider - be sure to give it a unique ID and specify the correct OAuth version - and add it to the providers option when initializing the library:
 
 ```js title="pages/api/auth/[...nextauth].js"
 import Providers from `next-auth/providers`
@@ -111,33 +152,21 @@ providers: [
 ...
 ```
 
+### 🍵 Adding a new provider
 
+If you think your custom provider might be useful to others, we encourage you to open a PR and add it to the built-in list so others can discover it much more easily!
 
+You only need to add two changes:
 
-### OAuth provider options
+1. Add your config: [`src/providers/{provider}.js`](https://github.com/nextauthjs/next-auth/tree/main/src/providers)<br />
+   ( _make sure you use a named default export, like this_ `export default function YourProvider`)
+2. Add provider documentation: [`www/docs/providers/{provider}.md`](https://github.com/nextauthjs/next-auth/tree/main/www/docs/providers)
 
-|        Name         |                           Description                            |              Type               | Required |
-| :-----------------: | :--------------------------------------------------------------: | :-----------------------------: | :------: |
-|         id          |                    Unique ID for the provider                    |            `string`             |   Yes    |
-|        name         |                Descriptive name for the provider                 |            `string`             |   Yes    |
-|        type         |       Type of provider, in this case it should be `oauth`        | `oauth`, `email`, `credentials` |   Yes    |
-|       version       |            OAuth version (e.g. '1.0', '1.0a', '2.0')             |            `string`             |   Yes    |
-|   accessTokenUrl    |               Endpoint to retrieve an access token               |            `string`             |   Yes    |
-|  authorizationUrl   |         Endpoint to request authorization from the user          |            `string`             |   Yes    |
-|      clientId       |                 Client ID of the OAuth provider                  |            `string`             |   Yes    |
-|    clientSecret     |               Client Secret of the OAuth provider                |            `string`             |    No    |
-|        scope        |          OAuth access scopes (expects array or string)           |     `string` or `string[]`      |    No    |
-|       params        |             Additional authorization URL parameters              |            `object`             |    No    |
-|   requestTokenUrl   |               Endpoint to retrieve a request token               |            `string`             |    No    |
-| authorizationParams |    Additional params to be sent to the authorization endpoint    |            `object`             |    No    |
-|     profileUrl      |             Endpoint to retrieve the user's profile              |            `string`             |    No    |
-|       profile       |        A callback returning an object with the user's info       |            `object`             |    No    |
-|       idToken       |   Set to `true` for services that use ID Tokens (e.g. OpenID)    |            `boolean`            |    No    |
-|       headers       |      Any headers that should be sent to the OAuth provider       |            `object`             |    No    |
-|     protection      | Additional security for OAuth login flows (defaults to `state`)  |`[pkce]`,`[state]`,`[pkce,state]`|    No    |
-|        state        | Same as `protection: "state"`. Being deprecated, use protection. |            `boolean`            |    No    |
+That's it! 🎉 Others will be able to discover this provider much more easily now!
 
-## Sign in with Email
+## Email Provider
+
+### 💭 How to
 
 The Email provider uses email to send "magic links" that can be used sign in, you will likely have seen them before if you have used software like Slack.
 
@@ -164,8 +193,21 @@ See the [Email provider documentation](/providers/email) for more information on
 The email provider requires a database, it cannot be used without one.
 :::
 
+### ⚙️ Options
 
-## Sign in with Credentials
+|          Name           |                                     Description                                     |               Type               | Required |
+| :---------------------: | :---------------------------------------------------------------------------------: | :------------------------------: | :------: |
+|           id            |                             Unique ID for the provider                              |             `string`             |   Yes    |
+|          name           |                          Descriptive name for the provider                          |             `string`             |   Yes    |
+|          type           |                       Type of provider, in this case `email`                        |             `email`              |   Yes    |
+|         server          |                     Path or object pointing to the email server                     |       `string` or `Object`       |   Yes    |
+| sendVerificationRequest |               Callback to execute when a verification request is sent               | `(params) => Promise<undefined>` |   Yes    |
+|          from           |   The email address from which emails are sent, default: "<no-reply@example.com>"   |             `string`             |    No    |
+|         maxAge          | How long until the e-mail can be used to log the user in seconds. Defaults to 1 day |             `number`             |    No    |
+
+## Credentials Provider
+
+### 💭 How to
 
 The Credentials provider allows you to handle signing in with arbitrary credentials, such as a username and password, two factor authentication or hardware device (e.g. YubiKey U2F / FIDO).
 
@@ -211,26 +253,12 @@ See the [Credentials provider documentation](/providers/credentials) for more in
 The Credentials provider can only be used if JSON Web Tokens are enabled for sessions. Users authenticated with the Credentials provider are not persisted in the database.
 :::
 
-<!-- React Image Component -->
-export const Image = ({ children, src, alt = '' }) => (
-  <div
-    style={{
-      padding: '0.2rem',
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'center'
-    }}>
-    <img alt={alt} src={src} />
-  </div>
- )
+### ⚙️ Options
 
-
-## Adding a new built-in provider
-
-If you think your custom provider might be useful to others, we encourage you to open a PR and add it to the built-in list so others can discover it much more easily! You only need to add two changes:
-1. Add your config: [`src/providers/{provider}.js`](https://github.com/nextauthjs/next-auth/tree/main/src/providers) (Make sure you use a named default export, like `export default function YourProvider`!)
-2. Add provider documentation: [`www/docs/providers/{provider}.md`](https://github.com/nextauthjs/next-auth/tree/main/www/docs/providers)
-
-That's it! 🎉 Others will be able to discover this provider much more easily now!
-
-You can look at the existing built-in providers for inspiration.
+|    Name     |                    Description                    |               Type               | Required |
+| :---------: | :-----------------------------------------------: | :------------------------------: | :------: |
+|     id      |            Unique ID for the provider             |             `string`             |   Yes    |
+|    name     |         Descriptive name for the provider         |             `string`             |   Yes    |
+|    type     |   Type of provider, in this case `credentials`    |          `credentials`           |   Yes    |
+| credentials |          The credentials to sign-in with          |             `Object`             |   Yes    |
+|  authorize  | Callback to execute once user is to be authorized | `(credentials) => Promise<User>` |   Yes    |

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -159,8 +159,11 @@ If you think your custom provider might be useful to others, we encourage you to
 You only need to add two changes:
 
 1. Add your config: [`src/providers/{provider}.js`](https://github.com/nextauthjs/next-auth/tree/main/src/providers)<br />
-   ( _make sure you use a named default export, like this_ `export default function YourProvider`)
+   • make sure you use a named default export, like this: `export default function YourProvider`
 2. Add provider documentation: [`www/docs/providers/{provider}.md`](https://github.com/nextauthjs/next-auth/tree/main/www/docs/providers)
+3. Add it to our [provider types](https://github.com/nextauthjs/next-auth/blob/main/types/providers.d.ts) (for TS projects)<br />
+   • you just need to add your new provider name to [this list](https://github.com/nextauthjs/next-auth/blob/main/types/providers.d.ts#L56-L97)<br />
+   • in case you new provider accepts some custom options, you can [add them here](https://github.com/nextauthjs/next-auth/blob/main/types/providers.d.ts#L48-L53)
 
 That's it! 🎉 Others will be able to discover this provider much more easily now!
 

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -72,29 +72,29 @@ providers: [
 
 ### Options
 
-|        Name         |                           Description                            |               Type                | Required |
-| :-----------------: | :--------------------------------------------------------------: | :-------------------------------: | :------: |
-|         id          |                    Unique ID for the provider                    |             `string`              |   Yes    |
-|        name         |                Descriptive name for the provider                 |             `string`              |   Yes    |
-|        type         |              Type of provider, in this case `oauth`              |              `oauth`              |   Yes    |
-|       version       |            OAuth version (e.g. '1.0', '1.0a', '2.0')             |             `string`              |   Yes    |
-|        scope        |          OAuth access scopes (expects array or string)           |      `string` or `string[]`       |   Yes    |
-|       params        |             Additional authorization URL parameters              |     `{ grant_type: string }`      |   Yes    |
-|   accessTokenUrl    |               Endpoint to retrieve an access token               |             `string`              |   Yes    |
-|  authorizationUrl   |         Endpoint to request authorization from the user          |             `string`              |   Yes    |
-|   requestTokenUrl   |               Endpoint to retrieve a request token               |             `string`              |   Yes    |
-|     profileUrl      |             Endpoint to retrieve the user's profile              |             `string`              |   Yes    |
-|      clientId       |                 Client ID of the OAuth provider                  |             `string`              |   Yes    |
-|    clientSecret     |               Client Secret of the OAuth provider                |             `string`              |   Yes    |
-|       profile       |       A callback returning an object with the user's info        |   `(profile, tokens) => Object`   |   Yes    |
-|     protection      | Additional security for OAuth login flows (defaults to `state`)  | `[pkce]`,`[state]`,`[pkce,state]` |    No    |
-|        state        | Same as `protection: "state"`. Being deprecated, use protection. |             `boolean`             |    No    |
-|       headers       |      Any headers that should be sent to the OAuth provider       |             `Object`              |    No    |
-| authorizationParams |    Additional params to be sent to the authorization endpoint    |             `Object`              |    No    |
-|       idToken       |   Set to `true` for services that use ID Tokens (e.g. OpenID)    |             `boolean`             |    No    |
-|       region        |                    Only when using BattleNet                     |             `string`              |    No    |
-|       domain        |                Only when using certain Providers                 |             `string`              |    No    |
-|      tenantId       |     Only when using Azure, Active Directory, B2C, FusionAuth     |             `string`              |    No    |
+|        Name         |                           Description                            |             Type              | Required |
+| :-----------------: | :--------------------------------------------------------------: | :---------------------------: | :------: |
+|         id          |                    Unique ID for the provider                    |           `string`            |   Yes    |
+|        name         |                Descriptive name for the provider                 |           `string`            |   Yes    |
+|        type         |              Type of provider, in this case `oauth`              |           `"oauth"`           |   Yes    |
+|       version       |            OAuth version (e.g. '1.0', '1.0a', '2.0')             |           `string`            |   Yes    |
+|        scope        |          OAuth access scopes (expects array or string)           |    `string` or `string[]`     |   Yes    |
+|       params        |       Extra URL params sent when calling `accessTokenUrl`        |           `Object`            |   Yes    |
+|   accessTokenUrl    |               Endpoint to retrieve an access token               |           `string`            |   Yes    |
+|  authorizationUrl   |         Endpoint to request authorization from the user          |           `string`            |   Yes    |
+|   requestTokenUrl   |               Endpoint to retrieve a request token               |           `string`            |   Yes    |
+|     profileUrl      |             Endpoint to retrieve the user's profile              |           `string`            |   Yes    |
+|      clientId       |                 Client ID of the OAuth provider                  |           `string`            |   Yes    |
+|    clientSecret     |               Client Secret of the OAuth provider                |           `string`            |   Yes    |
+|       profile       |       A callback returning an object with the user's info        | `(profile, tokens) => Object` |   Yes    |
+|     protection      | Additional security for OAuth login flows (defaults to `state`)  |  `"pkce"`,`"state"`,`"none"`  |    No    |
+|        state        | Same as `protection: "state"`. Being deprecated, use protection. |           `boolean`           |    No    |
+|       headers       |      Any headers that should be sent to the OAuth provider       |           `Object`            |    No    |
+| authorizationParams |    Additional params to be sent to the authorization endpoint    |           `Object`            |    No    |
+|       idToken       |   Set to `true` for services that use ID Tokens (e.g. OpenID)    |           `boolean`           |    No    |
+|       region        |                    Only when using BattleNet                     |           `string`            |    No    |
+|       domain        |                Only when using certain Providers                 |           `string`            |    No    |
+|      tenantId       |     Only when using Azure, Active Directory, B2C, FusionAuth     |           `string`            |    No    |
 
 :::tip
 Even if you are using a built-in provider, you can override any of these options to tweak the default configuration.
@@ -221,7 +221,7 @@ The email provider requires a database, it cannot be used without one.
 | :---------------------: | :---------------------------------------------------------------------------------: | :------------------------------: | :------: |
 |           id            |                             Unique ID for the provider                              |             `string`             |   Yes    |
 |          name           |                          Descriptive name for the provider                          |             `string`             |   Yes    |
-|          type           |                       Type of provider, in this case `email`                        |             `email`              |   Yes    |
+|          type           |                       Type of provider, in this case `email`                        |            `"email"`             |   Yes    |
 |         server          |                     Path or object pointing to the email server                     |       `string` or `Object`       |   Yes    |
 | sendVerificationRequest |               Callback to execute when a verification request is sent               | `(params) => Promise<undefined>` |   Yes    |
 |          from           |   The email address from which emails are sent, default: "<no-reply@example.com>"   |             `string`             |    No    |
@@ -281,6 +281,6 @@ The Credentials provider can only be used if JSON Web Tokens are enabled for ses
 | :---------: | :-----------------------------------------------: | :------------------------------: | :------: |
 |     id      |            Unique ID for the provider             |             `string`             |   Yes    |
 |    name     |         Descriptive name for the provider         |             `string`             |   Yes    |
-|    type     |   Type of provider, in this case `credentials`    |          `credentials`           |   Yes    |
+|    type     |   Type of provider, in this case `credentials`    |         `"credentials"`          |   Yes    |
 | credentials |          The credentials to sign-in with          |             `Object`             |   Yes    |
 |  authorize  | Callback to execute once user is to be authorized | `(credentials) => Promise<User>` |   Yes    |

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -20,14 +20,19 @@ NextAuth.js is designed to work with any OAuth service, it supports **OAuth 1.0*
 
 ### Available providers
 
-<ul>
+<div className="provider-name-list">
 {Object.entries(require("../../providers.json"))
   .filter(([key]) => !["email", "credentials"].includes(key))
   .sort(([, a], [, b]) => a.localeCompare(b))
-  .map(([key, name]) =>
-    <li key={key}><a href={`/providers/${key}`}>{name}</a></li>
+  .map(([key, name]) => (
+    <span key={key}>
+      <a href={`/providers/${key}`}>{name}</a>
+      <span className="provider-name-list__comma">,</span>
+    </span>
+  )
+    
 )}
-</ul>
+</div>
 
 ### How to
 

--- a/www/src/css/index.css
+++ b/www/src/css/index.css
@@ -46,6 +46,7 @@ html[data-theme="dark"]:root {
 @import "buttons.css";
 @import "table-of-contents.css";
 @import "sidebar.css";
+@import "providers.css";
 
 @media screen and (max-width: 360px) {
   html {

--- a/www/src/css/providers.css
+++ b/www/src/css/providers.css
@@ -1,0 +1,9 @@
+.provider-name-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.provider-name-list__comma {
+  display: inline-flex;
+  margin-right: 5px;
+}


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## Reasoning 💡

[We realised](https://github.com/nextauthjs/next-auth/pull/1876/files/6df72b692e3e6427df3967be949b5265b8c76d4f#diff-7a1af8aab4c41d70f23eaf05d5d4fcf5f969a20f515122828f970ab3b008bd69) that the documentation for the different available provider options was out of date.

I took the opportunity to re-work a bit the **Providers** page in our docs to delineate better the 3 ways to sign-in

- `OAuth`
- `email`
- `credentials`

and the steps and options for each. When listing the options for each type of provider, it took [our types](https://github.com/nextauthjs/next-auth/blob/main/types/providers.d.ts) as the source of truth, as agreed with @balazsorban44. I also added emojis 🙈

<img width="600" alt="Screenshot 2021-04-30 at 18 07 23" src="https://user-images.githubusercontent.com/5938217/116723188-86d77380-a9df-11eb-9360-327ecd3be8c5.png">


## Checklist 🧢

- [x] Documentation
- [ ] ~Tests~
- [x] Ready to be merged

## Affected issues 🎟

#1792 