### PR TITLE
fix(build): export aliases from client

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -355,6 +355,22 @@ function BroadcastChannel (name = 'nextauth.message') {
   }
 }
 
+
+
+// Some methods are exported with more than one name. This provides some
+// flexibility over how they can be invoked and backwards compatibility
+// with earlier releases. These should be removed in a newer release, as it only
+// creates problems for bundlers and adds confusion to users. TypeScript declarations
+// will provide sufficient help when importing
+export {
+  setOptions as options,
+  getSession as session,
+  getProviders as providers,
+  getCsrfToken as csrfToken,
+  signIn as signin,
+  signOut as signout
+}
+
 export default {
   getSession,
   getCsrfToken,


### PR DESCRIPTION
## Reasoning 💡

We have been exporting with `export default { }` for a while, but that makes bundlers/compilers harder to distinguish between what can be tree-shaken, amongst other things. We also provided some aliases that are kept around for some kind of legacy backward compatibility. Unfortunately, it bloats our exports, so we should get rid of it in a future release. with introduced TypeScript declarations, users will have a nice developer experience and will get suggestions for imports, so no need to keep multiple versions around.

This bug :bug: has potentially been introduced in #1791, but I have no intention of removing the `exports` field, which is finally something the ecosystem seems to land on. We should aim for removing legacy workarounds the moment they can be dropped. (Would be nice to get this done in 4.0)

@lluia I am inclined that we should erase any trace of the alias exports from the documentation, so people will stop using them, so eventually, we can just drop support for them in the next major release!

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

- [x] Documentation
- [x] Tests (I tested this by creating a release at `next-auth@3.19.5-beta.0` and pulled it in in a project with both Webpack 4 and Webpack 5 to verify that all kinds of imports are working)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #1884