### PR TITLE
fix(page): don't pass params to custom signout page

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -159,7 +159,16 @@ async function NextAuthHandler (req, res, userOptions) {
           return render.signin()
         case 'signout':
           if (pages.signOut) {
-            return res.redirect(`${pages.signOut}${pages.signOut.includes('?') ? '&' : '?'}error=${error}`)
+            let signoutUrl = `${pages.signOut}`
+
+            // Append a callback param if one was specified in the request options.
+            if (req.options.callbackUrl)
+              signoutUrl = `${signoutUrl}${pages.signOut.includes('?') ? '&' : '?'}callbackUrl=${req.options.callbackUrl}`
+
+            // Append the error code param when there's an error.
+            if (error) { signoutUrl = `${signoutUrl}${pages.signOut.includes('?') ? '&' : '?'}&error=${error}` }
+
+            return res.redirect(signoutUrl)
           }
           return render.signout()
         case 'callback':

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -158,18 +158,8 @@ async function NextAuthHandler (req, res, userOptions) {
 
           return render.signin()
         case 'signout':
-          if (pages.signOut) {
-            let signoutUrl = `${pages.signOut}`
+          if (pages.signOut) return res.redirect(pages.signOut)
 
-            // Append a callback param if one was specified in the request options.
-            if (req.options.callbackUrl)
-              signoutUrl = `${signoutUrl}${pages.signOut.includes('?') ? '&' : '?'}callbackUrl=${req.options.callbackUrl}`
-
-            // Append the error code param when there's an error.
-            if (error) { signoutUrl = `${signoutUrl}${pages.signOut.includes('?') ? '&' : '?'}&error=${error}` }
-
-            return res.redirect(signoutUrl)
-          }
           return render.signout()
         case 'callback':
           if (provider) {


### PR DESCRIPTION
Modified the handling of two querystring params on the custom signout page url. A conditional check on an "error" value is now made and an error query param is no longer added when 'error' is 'undefined'. Also added a conditional check on the callbackUrl in the options and if one is present a matching query param for that gets added to the signout api call. 

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

What changes are being made? What feature/bug is being fixed here?
https://github.com/nextauthjs/next-auth/issues/1910

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
The fix for the "error=undefined" on custom signout page url seems straightforward but I'm not entirely certain that adding the callbackUrl param to the custom signout page url won't have side effects. Because the default signout page handler references the callbackUrl my reasoning was that the custom page should get this param passed to it as well.

## Affected issues 🎟

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊
