### PR TITLE
fix(ts): tweak Adapter related types

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -118,13 +118,13 @@ export interface AdapterInstance<U = User, P = Profile, S = Session> {
  * [Create a custom adapter](https://next-auth.js.org/tutorials/creating-a-database-adapter)
  */
 export type Adapter<
-  C = Record<string, unknown>,
+  C = unknown,
   O = Record<string, unknown>,
   U = User,
   P = Profile,
   S = Session
 > = (
-  config?: C,
+  client: C,
   options?: O
 ) => {
   getAdapter(appOptions: AppOptions): Promise<AdapterInstance<U, P, S>>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -180,7 +180,7 @@ export interface NextAuthOptions {
    *
    * [Documentation](https://next-auth.js.org/configuration/options#theme) | [Pages documentation]("https://next-auth.js.org/configuration/pages")
    */
-  theme?: "auto" | "dark" | "light"
+  theme?: Theme
   /**
    * When set to `true` then all cookies set by NextAuth.js will only be accessible from HTTPS URLs.
    * This option defaults to `false` on URLs that start with `http://` (e.g. http://localhost:3000) for developer convenience.
@@ -214,6 +214,14 @@ export interface NextAuthOptions {
    */
   cookies?: CookiesOptions
 }
+
+/**
+ * Change the theme of the built-in pages.
+ *
+ * [Documentation](https://next-auth.js.org/configuration/options#theme) |
+ * [Pages](https://next-auth.js.org/configuration/pages)
+ * */
+export type Theme = "auto" | "dark" | "light"
 
 /**
  * Override any of the methods, and the rest will use the default logger.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -220,7 +220,7 @@ export interface NextAuthOptions {
  *
  * [Documentation](https://next-auth.js.org/configuration/options#theme) |
  * [Pages](https://next-auth.js.org/configuration/pages)
- * */
+ */
 export type Theme = "auto" | "dark" | "light"
 
 /**

--- a/types/internals/index.d.ts
+++ b/types/internals/index.d.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "./utils"
-import { NextAuthOptions } from ".."
+import { LoggerInstance, NextAuthOptions, SessionOptions, Theme } from ".."
 import { AppProvider } from "../providers"
 
 /** Options that are the same both in internal and user provided options. */
@@ -9,12 +9,7 @@ export type NextAuthSharedOptions =
   | "events"
   | "callbacks"
   | "cookies"
-  | "secret"
   | "adapter"
-  | "theme"
-  | "debug"
-  | "logger"
-  | "session"
 
 export interface AppOptions
   extends Required<Pick<NextAuthOptions, NextAuthSharedOptions>> {
@@ -42,6 +37,11 @@ export interface AppOptions
   provider?: AppProvider
   csrfToken?: string
   csrfTokenVerified?: boolean
+  secret: string
+  theme: Theme
+  debug: boolean
+  logger: LoggerInstance
+  session: Required<SessionOptions>
 }
 
 export interface NextAuthRequest extends NextApiRequest {

--- a/types/tests/server.test.ts
+++ b/types/tests/server.test.ts
@@ -65,7 +65,7 @@ const exampleVerificationRequest = {
   expires: new Date(),
 }
 
-const MyAdapter: Adapter = () => {
+const MyAdapter: Adapter<Record<string, unknown>> = () => {
   return {
     async getAdapter(appOptions: AppOptions) {
       return {
@@ -131,6 +131,8 @@ const MyAdapter: Adapter = () => {
   }
 }
 
+const client = {} // Create a fake db client
+
 const allConfig: NextAuthTypes.NextAuthOptions = {
   providers: [
     Providers.Twitter({
@@ -190,7 +192,7 @@ const allConfig: NextAuthTypes.NextAuthOptions = {
       return undefined
     },
   },
-  adapter: MyAdapter(),
+  adapter: MyAdapter(client),
   useSecureCookies: true,
   cookies: {
     sessionToken: {


### PR DESCRIPTION
## Reasoning 💡

1. The first parameter of an adapter will always be something like a client that is used to communicate with a database, so we can require it. The second parameter will be reserved for any additional configuration for the adapter.

2. some parameters in the `AppOptions` interface were nullable, but in reality, we set a default for almost all of them here:
https://github.com/nextauthjs/next-auth/blob/66473054f5f2f2f117504148d467f42d15aa473e/src/server/index.js#L93-L136

This means that the internal interface for `AppOptions` can be assumed to have much more non-nullable fields and thus playing better with the `Adapter` interface and when it is used to type custom adapters.

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟
