### PR TITLE
docs(provider): clarify where user is created in db with email provider

### DIFF
--- a/www/docs/providers/email.md
+++ b/www/docs/providers/email.md
@@ -78,7 +78,7 @@ The Email Provider can be used with both JSON Web Tokens and database sessions, 
   ```
 3. You can now sign in with an email address at `/api/auth/signin`.
 
-  An account will not be created for the user until the first time they verify their email address. If an email address already associated with an account, the user will be signed in to that account when they use the link in the email.
+  A user account (i.e. an entry in the Users table) will not be created for the user until the first time they verify their email address. If an email address is already associated with an account, the user will be signed in to that account when they use the link in the email. 
 
 ## Customising emails
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Clarifying information about where exactly the User is being created in the DB once they verify their email based account.

## Checklist 🧢

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Closes #1313

