### PR TITLE
docs: Fix link to model source in typeorm tutorial

### DIFF
--- a/www/docs/tutorials/typeorm-custom-models.md
+++ b/www/docs/tutorials/typeorm-custom-models.md
@@ -48,7 +48,7 @@ export default {
 ```
 
 :::note
-[View source for built-in TypeORM models and schemas](https://github.com/nextauthjs/next-auth/tree/main/src/adapters/typeorm/models)
+[View source for built-in TypeORM models and schemas](https://github.com/nextauthjs/adapters/tree/canary/packages/typeorm-legacy/src/models)
 :::
 
 ## Using custom models


### PR DESCRIPTION
## Reasoning 💡

With the changes which were made with #1862 the url to the model source has been changed.

## Checklist 🧢

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## Affected issues 🎟

Haven't found any issues for this one