### PR TITLE
feat(provider): add-request-to-credentials-authorize

### DIFF
--- a/app/pages/api/auth/[...nextauth].js
+++ b/app/pages/api/auth/[...nextauth].js
@@ -56,7 +56,7 @@ export default NextAuth({
       credentials: {
         password: { label: 'Password', type: 'password' }
       },
-      async authorize (credentials) {
+      async authorize (credentials, req) {
         if (credentials.password === 'password') {
           return {
             id: 1,

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -336,7 +336,7 @@ export default async function callback(req, res) {
     let userObjectReturnedFromAuthorizeHandler
     try {
       userObjectReturnedFromAuthorizeHandler = await provider.authorize(
-        credentials, provider.type === "credentials" ? req : null
+        credentials, {...req, options: {}, cookies: {}}
       )
       if (!userObjectReturnedFromAuthorizeHandler) {
         return res

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -336,7 +336,7 @@ export default async function callback(req, res) {
     let userObjectReturnedFromAuthorizeHandler
     try {
       userObjectReturnedFromAuthorizeHandler = await provider.authorize(
-        credentials
+        credentials, provider.type === "credentials" ? req : null
       )
       if (!userObjectReturnedFromAuthorizeHandler) {
         return res

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -1,5 +1,5 @@
 import { Profile, TokenSet, User } from "."
-import { Awaitable } from "./internals/utils"
+import { Awaitable, NextApiRequest } from "./internals/utils"
 
 export type ProviderType = "oauth" | "email" | "credentials"
 
@@ -115,7 +115,7 @@ interface CredentialsConfig<C extends Record<string, CredentialInput> = {}>
   extends CommonProviderOptions {
   type: "credentials"
   credentials: C
-  authorize(credentials: Record<keyof C, string>): Awaitable<User | null>
+  authorize(credentials: Record<keyof C, string>, req?: NextApiRequest): Awaitable<User | null>
 }
 
 export type CredentialsProvider = (

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -115,7 +115,7 @@ interface CredentialsConfig<C extends Record<string, CredentialInput> = {}>
   extends CommonProviderOptions {
   type: "credentials"
   credentials: C
-  authorize(credentials: Record<keyof C, string>, req?: NextApiRequest): Awaitable<User | null>
+  authorize(credentials: Record<keyof C, string>, req: NextApiRequest): Awaitable<User | null>
 }
 
 export type CredentialsProvider = (

--- a/www/docs/configuration/providers.md
+++ b/www/docs/configuration/providers.md
@@ -254,12 +254,14 @@ providers: [
       username: { label: "Username", type: "text", placeholder: "jsmith" },
       password: {  label: "Password", type: "password" }
     },
-   async authorize(credentials) {
-      const user = (credentials) => {
+   async authorize(credentials, req) {
+      const user = (credentials, req) => {
         // You need to provide your own logic here that takes the credentials
         // submitted and returns either a object representing a user or value
         // that is false/null if the credentials are invalid.
         // e.g. return { id: 1, name: 'J Smith', email: 'jsmith@example.com' }
+        // You can also use the request object to obtain additional parameters 
+        // (i.e., the request IP address)   
         return null
       }
       if (user) {
@@ -282,10 +284,10 @@ The Credentials provider can only be used if JSON Web Tokens are enabled for ses
 
 ### Options
 
-|    Name     |                    Description                    |               Type               | Required |
-| :---------: | :-----------------------------------------------: | :------------------------------: | :------: |
-|     id      |            Unique ID for the provider             |             `string`             |   Yes    |
-|    name     |         Descriptive name for the provider         |             `string`             |   Yes    |
-|    type     |   Type of provider, in this case `credentials`    |         `"credentials"`          |   Yes    |
-| credentials |          The credentials to sign-in with          |             `Object`             |   Yes    |
-|  authorize  | Callback to execute once user is to be authorized | `(credentials) => Promise<User>` |   Yes    |
+|    Name     |                    Description                    |               Type                    | Required |
+| :---------: | :-----------------------------------------------: | :-----------------------------------: | :------: |
+|     id      |            Unique ID for the provider             |             `string`                  |   Yes    |
+|    name     |         Descriptive name for the provider         |             `string`                  |   Yes    |
+|    type     |   Type of provider, in this case `credentials`    |         `"credentials"`               |   Yes    |
+| credentials |          The credentials to sign-in with          |             `Object`                  |   Yes    |
+|  authorize  | Callback to execute once user is to be authorized | `(credentials, req) => Promise<User>` |   Yes    |

--- a/www/docs/providers/credentials.md
+++ b/www/docs/providers/credentials.md
@@ -92,7 +92,7 @@ As with all providers, the order you specify them is the order they are displaye
     Providers.Credentials({
       id: 'domain-login',
       name: "Domain Account",
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         const user = { /* add function to get user */ }
         return user
       },
@@ -105,7 +105,7 @@ As with all providers, the order you specify them is the order they are displaye
     Providers.Credentials({
       id: 'intranet-credentials',
       name: "Two Factor Auth",
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         const user = { /* add function to get user */ } 
         return user
       },

--- a/www/docs/providers/credentials.md
+++ b/www/docs/providers/credentials.md
@@ -39,6 +39,8 @@ The Credentials provider is specified like other providers, except that you need
 
   If you throw an Error, the user will be sent to the error page with the error message as a query parameter. If throw a URL (a string), the user will be redirected to the URL.
 
+Credentials provider `authorize()` method also provides request object as second parameter `req` (see example below).
+
 ```js title="pages/api/auth/[...nextauth].js"
 import Providers from `next-auth/providers`
 ...
@@ -53,7 +55,7 @@ providers: [
       username: { label: "Username", type: "text", placeholder: "jsmith" },
       password: {  label: "Password", type: "password" }
     },
-    async authorize(credentials) {
+    async authorize(credentials, req) {
       // Add logic here to look up the user from the credentials supplied
       const user = { id: 1, name: 'J Smith', email: 'jsmith@example.com' }
 

--- a/www/docs/providers/credentials.md
+++ b/www/docs/providers/credentials.md
@@ -39,7 +39,7 @@ The Credentials provider is specified like other providers, except that you need
 
   If you throw an Error, the user will be sent to the error page with the error message as a query parameter. If throw a URL (a string), the user will be redirected to the URL.
 
-Credentials provider `authorize()` method also provides request object as second parameter `req` (see example below).
+The Credentials provider's `authorize()` method also provides the request object as the second parameter (see example below).
 
 ```js title="pages/api/auth/[...nextauth].js"
 import Providers from `next-auth/providers`

--- a/www/docs/tutorials/ldap-auth.md
+++ b/www/docs/tutorials/ldap-auth.md
@@ -22,7 +22,7 @@ export default NextAuth({
         username: { label: "DN", type: "text", placeholder: "" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         // You might want to pull this call out so we're not making a new LDAP client on every login attemp
         const client = ldap.createClient({
           url: process.env.LDAP_URI,


### PR DESCRIPTION
## Reasoning 💡

Credentials provider `authorize` method currently supplies only username/password as method parameters, and there is no way to obtain the remote IP address of the request. Knowing an IP address is crucial for robust authentication implementation as most authentication backends have IP rate limit filters in place. In most cases an IP address can be obtained from HTTP headers (`x-real-ip`, `x-forwarded-for`, etc.) depending on deployment, hence the request to add request object (or at least HTTP headers) to the `authorize` method. 

Additional details on the use case can be found in the comments under [#1975](https://github.com/nextauthjs/next-auth/issues/1975#issuecomment-838977935)

I'm limiting the scope of this PR to Credentials provider only unless project maintainers make a call that it's okay to expose the request object to all providers.

## Checklist 🧢

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged (note to reviewer: please review whether any additional ts related changes are required)

## Affected issues 🎟

Closes #1975
