### PR TITLE
chore(dev): fix dev app imports

### DIFF
--- a/app/pages/api/auth/[...nextauth].js
+++ b/app/pages/api/auth/[...nextauth].js
@@ -1,5 +1,9 @@
-import NextAuth from 'next-auth'
-import Providers from 'next-auth/providers'
+import NextAuth from "next-auth"
+import EmailProvider from "next-auth/providers/email"
+import GitHubProvider from "next-auth/providers/github"
+import Auth0Provider from "next-auth/providers/auth0"
+import TwitterProvider from "next-auth/providers/twitter"
+import CredentialsProvider from "next-auth/providers/credentials"
 
 // import Adapters from 'next-auth/adapters'
 // import { PrismaClient } from '@prisma/client'
@@ -28,15 +32,15 @@ export default NextAuth({
   //   }
   // },
   providers: [
-    Providers.Email({
+    EmailProvider({
       server: process.env.EMAIL_SERVER,
-      from: process.env.EMAIL_FROM
+      from: process.env.EMAIL_FROM,
     }),
-    Providers.GitHub({
+    GitHubProvider({
       clientId: process.env.GITHUB_ID,
-      clientSecret: process.env.GITHUB_SECRET
+      clientSecret: process.env.GITHUB_SECRET,
     }),
-    Providers.Auth0({
+    Auth0Provider({
       clientId: process.env.AUTH0_ID,
       clientSecret: process.env.AUTH0_SECRET,
       domain: process.env.AUTH0_DOMAIN,
@@ -45,36 +49,36 @@ export default NextAuth({
       // authorizationParams: {
       //   response_mode: 'form_post'
       // }
-      protection: 'pkce'
+      protection: "pkce",
     }),
-    Providers.Twitter({
+    TwitterProvider({
       clientId: process.env.TWITTER_ID,
-      clientSecret: process.env.TWITTER_SECRET
+      clientSecret: process.env.TWITTER_SECRET,
     }),
-    Providers.Credentials({
-      name: 'Credentials',
+    CredentialsProvider({
+      name: "Credentials",
       credentials: {
-        password: { label: 'Password', type: 'password' }
+        password: { label: "Password", type: "password" },
       },
-      async authorize (credentials) {
-        if (credentials.password === 'password') {
+      async authorize(credentials) {
+        if (credentials.password === "password") {
           return {
             id: 1,
-            name: 'Fill Murray',
-            email: 'bill@fillmurray.com',
-            image: 'https://www.fillmurray.com/64/64'
+            name: "Fill Murray",
+            email: "bill@fillmurray.com",
+            image: "https://www.fillmurray.com/64/64",
           }
         }
         return null
-      }
-    })
+      },
+    }),
   ],
   jwt: {
     encryption: true,
-    secret: process.env.SECRET
+    secret: process.env.SECRET,
   },
   debug: false,
-  theme: 'auto'
+  theme: "auto",
 
   // Default Database Adapter (TypeORM)
   // database: process.env.DATABASE_URL


### PR DESCRIPTION
## Reasoning 💡

The dev application does some copy-pasting of the source code, so we can develop `next-auth` with Next.js's hot module reloading. Although there are certain files that are generated only build-time, (like `src/providers/index.js`) which if missing, will throw an error in the dev app. The technicalities for those interested are in the scripts in the `package.json` files:
https://github.com/nextauthjs/next-auth/blob/main/package.json#L31
https://github.com/nextauthjs/next-auth/blob/main/app/package.json#L6

For everyone else, testing a Provider in dev now requires the provider to be explicitly imported (which will be the official way at a later point anyway, as it helps with tree-shaking)

## Checklist 🧢

Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`.

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #1892