### PR TITLE
fix: replace Twitter profile image for other formats

### DIFF
--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -15,7 +15,7 @@ export default function Twitter(options) {
         id: profile.id_str,
         name: profile.name,
         email: profile.email,
-        image: profile.profile_image_url_https.replace(/_normal\.jpg$/, ".jpg"),
+        image: profile.profile_image_url_https.replace(/_normal\.(jpg|png|gif)$/, ".$1"),
       }
     },
     ...options,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<img width="491" alt="Screen Shot 2021-05-14 at 4 41 03 PM" src="https://user-images.githubusercontent.com/9481405/118238248-3bd75900-b4d3-11eb-9617-72f368b74bb5.png">

Fixed a bug that default Twitter provider gives downscaled version of profile pic. It doesn't remove `_normal` suffix for `.png` or `.gif` URLs for now.

[Documentation from Twitter](https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_image) says that profile images could be `.jpg`, `.png` or `.gif`.

## Checklist 🧢

~[] Documentation~
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

None