### PR TITLE
fix(deps): pin down legacy adapter versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.14.0",
-    "@next-auth/prisma-legacy-adapter": "canary",
-    "@next-auth/typeorm-legacy-adapter": "canary",
+    "@next-auth/prisma-legacy-adapter": "0.0.1-canary.127",
+    "@next-auth/typeorm-legacy-adapter": "0.0.2-canary.129",
     "futoin-hkdf": "^1.3.2",
     "jose": "^1.27.2",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
## Reasoning 💡

See #2008 for more info

## Checklist 🧢


## Affected issues 🎟

fixes #2008