### PR TITLE
fix(provider): make WorkOS domain configurable from signIn

### DIFF
--- a/src/providers/workos.js
+++ b/src/providers/workos.js
@@ -1,4 +1,6 @@
 export default function WorkOS(options) {
+  const apiUrl = options.apiUrl || 'api.workos.com';
+
   return {
     id: 'workos',
     name: 'WorkOS',
@@ -10,9 +12,9 @@ export default function WorkOS(options) {
       client_id: options.clientId,
       client_secret: options.clientSecret
     },
-    accessTokenUrl: 'https://api.workos.com/sso/token/',
-    authorizationUrl: `https://api.workos.com/sso/authorize/?response_type=code&domain=${options.domain}`,
-    profileUrl: 'https://api.workos.com/sso/profile/',
+    accessTokenUrl: `https://${apiUrl}/sso/token`,
+    authorizationUrl: `https://${apiUrl}/sso/authorize?response_type=code`,
+    profileUrl: `https://${apiUrl}/sso/profile`,
     profile: (profile) => {
       return {
         ...profile,

--- a/src/providers/workos.js
+++ b/src/providers/workos.js
@@ -1,5 +1,5 @@
 export default function WorkOS(options) {
-  const apiUrl = options.apiUrl || 'api.workos.com';
+  const domain = options.domain || 'api.workos.com';
 
   return {
     id: 'workos',
@@ -12,9 +12,9 @@ export default function WorkOS(options) {
       client_id: options.clientId,
       client_secret: options.clientSecret
     },
-    accessTokenUrl: `https://${apiUrl}/sso/token`,
-    authorizationUrl: `https://${apiUrl}/sso/authorize?response_type=code`,
-    profileUrl: `https://${apiUrl}/sso/profile`,
+    accessTokenUrl: `https://${domain}/sso/token`,
+    authorizationUrl: `https://${domain}/sso/authorize?response_type=code`,
+    profileUrl: `https://${domain}/sso/profile`,
     profile: (profile) => {
       return {
         ...profile,

--- a/www/docs/providers/workos.md
+++ b/www/docs/providers/workos.md
@@ -24,7 +24,6 @@ providers: [
   Providers.WorkOS({
     clientId: process.env.WORKOS_ID,
     clientSecret: process.env.WORKOS_SECRET,
-    domain: process.env.WORKOS_DOMAIN
   }),
 ],
 ...

--- a/www/docs/providers/workos.md
+++ b/www/docs/providers/workos.md
@@ -7,6 +7,10 @@ title: WorkOS
 
 https://workos.com/docs/sso/guide
 
+## Configuration
+
+https://dashboard.workos.com
+
 ## Options
 
 The **WorkOS Provider** comes with a set of default options:
@@ -22,9 +26,87 @@ import Providers from `next-auth/providers`
 ...
 providers: [
   Providers.WorkOS({
-    clientId: process.env.WORKOS_ID,
-    clientSecret: process.env.WORKOS_SECRET,
+    clientId: process.env.WORKOS_CLIENT_ID,
+    clientSecret: process.env.WORKOS_API_KEY,
   }),
 ],
 ...
+```
+
+WorkOS is not an identity provider itself, but, rather, a bridge to multiple single sign-on (SSO) providers. As a result, we need to make some additional changes to authenticate users using WorkOS.
+
+In order to sign a user in using WorkOS, we need to specify which WorkOS Connection to use. A common way to do this is to collect the user's email address and extract the domain.
+
+This can be done using a custom login page.
+
+To add a custom login page, you can use the `pages` option:
+
+```javascript title="pages/api/auth/[...nextauth].js"
+...
+  pages: {
+    signIn: '/auth/signin',
+  }
+```
+
+We can then add a custom login page that displays an input where the user can enter their email address. We then extract the domain from the user's email address and pass it to the `authorizationParams` parameter on the `signIn` function:
+
+```jsx title="pages/auth/signin.js"
+import { getProviders, signIn } from 'next-auth/client'
+
+export default function SignIn({ providers }) {
+  const [email, setEmail] = useState('')
+
+  return (
+    <>
+      {Object.values(providers).map((provider) => {
+        if (provider.id === 'workos') {
+          return (
+            <div key={provider.id}>
+              <input
+                type="email"
+                value={email}
+                placeholder="Email"
+                onChange={(event) => setEmail(event.target.value)}
+              />
+              <button
+                onClick={() =>
+                  signIn(provider.id, undefined, {
+                    domain: email.split('@')[1],
+                  })
+                }
+              >
+                Sign in with SSO
+              </button>
+            </div>
+          );
+        }
+
+        return (
+          <div key={provider.id}>
+            <button onClick={() => signIn(provider.id)}>
+              Sign in with {provider.name}
+            </button>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+// This is the recommended way for Next.js 9.3 or newer
+export async function getServerSideProps(context){
+  const providers = await getProviders()
+  return {
+    props: { providers }
+  }
+}
+
+/*
+// If older than Next.js 9.3
+SignIn.getInitialProps = async () => {
+  return {
+    providers: await getProviders()
+  }
+}
+*/
 ```


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

This PR fixes some issues with the implementation of the WorkOS provider.

The `domain` parameter in the authorization URL needs to be set dynamically based on the user signing in. Previously the domain was being passed in as part of the static WorkOS provider configuration.

The `domain` can now be passed in using the `authorizationParams` on the `signIn` function, and the WorkOS provider docs have been updated to reflect this.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] ~Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Happy to answer any additional questions on the intended WorkOS provider usage if anyone has them.