### PR TITLE
Signin: Allow client to override scope

### DIFF
--- a/src/server/lib/signin/oauth.js
+++ b/src/server/lib/signin/oauth.js
@@ -15,9 +15,9 @@ export default async function getAuthorizationUrl (req) {
   if (provider.version?.startsWith('2.')) {
     // Handle OAuth v2.x
     let url = client.getAuthorizeUrl({
+      scope: provider.scope,
       ...params,
-      redirect_uri: provider.callbackUrl,
-      scope: provider.scope
+      redirect_uri: provider.callbackUrl
     })
 
     // If the authorizationUrl specified in the config has query parameters on it

--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -266,7 +266,7 @@ You can also set these parameters through [`provider.authorizationParams`](/conf
 :::
 
 :::note
-The following parameters are always overridden server-side: `redirect_uri`, `scope`, `state`
+The following parameters are always overridden server-side: `redirect_uri`, `state`
 :::
 
 ---


### PR DESCRIPTION
## Reasoning 💡

Allow client to override `scope` via query params, so requesting new permissions for current account is possible (aka ["incremental auth"](https://developers.google.com/identity/sign-in/web/incremental-auth))

## Checklist 🧢

- [x] Documentation
- [ ] Tests (*couldn't find relevant tests for this override)
- [x] Ready to be merged

## Affected issues 🎟

Discussion with context here: https://github.com/nextauthjs/next-auth/discussions/2068 (OG via https://github.com/nextauthjs/next-auth/issues/2066)