### PR TITLE
Signin: Allow client to override redirect_uri

### DIFF
--- a/src/server/lib/signin/oauth.js
+++ b/src/server/lib/signin/oauth.js
@@ -16,8 +16,8 @@ export default async function getAuthorizationUrl (req) {
     // Handle OAuth v2.x
     let url = client.getAuthorizeUrl({
       scope: provider.scope,
-      ...params,
-      redirect_uri: provider.callbackUrl
+      redirect_uri: provider.callbackUrl,
+      ...params
     })
 
     // If the authorizationUrl specified in the config has query parameters on it

--- a/www/docs/getting-started/client.md
+++ b/www/docs/getting-started/client.md
@@ -266,7 +266,7 @@ You can also set these parameters through [`provider.authorizationParams`](/conf
 :::
 
 :::note
-The following parameters are always overridden server-side: `redirect_uri`, `state`
+The following parameters are always overridden server-side: `state`
 :::
 
 ---


### PR DESCRIPTION
## Reasoning 💡

Allow client to override `redirect_uri` via query params, so getting a new separate set of tokens (potentially for different scopes) for an account is possible

## Checklist 🧢

- [x] Documentation
- [ ] Tests (*couldn't find relevant tests for this override)
- [x] Ready to be merged

## Affected issues 🎟

Discussion with context here: https://github.com/nextauthjs/next-auth/discussions/2068#discussioncomment-801705