### PR TITLE
Fix: Convert Github profile.id from int to string

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -10,7 +10,7 @@ export default function GitHub(options) {
     profileUrl: "https://api.github.com/user",
     profile(profile) {
       return {
-        id: profile.id,
+        id: profile.id.toString(),
         name: profile.name || profile.login,
         email: profile.email,
         image: profile.avatar_url,


### PR DESCRIPTION
## Reasoning 💡

This Github profile.id should be converted from integer to string as described here: [https://github.com/nextauthjs/adapters/issues/111](https://github.com/nextauthjs/adapters/issues/111). We should check if other adapters/functions still rely on profile.id being an integer.


BREAKING CHANGE:

For consistency around our built-in providers, the profile id is now converted to a string. If you had assumptions about the id being a number, you can do `parseInt(profile.id, 10)`
