### PR TITLE
docs(callbacks): don't use `signIn` for redirects

### DIFF
--- a/www/docs/configuration/callbacks.md
+++ b/www/docs/configuration/callbacks.md
@@ -78,6 +78,11 @@ When using NextAuth.js with a database, the User object will be either a user ob
 When using NextAuth.js without a database, the user object it will always be a prototype user object, with information extracted from the profile.
 :::
 
+:::note
+Redirects returned by this callback cancel the authentication flow. Only redirect to error pages that, for example, tell the user why they're not allowed to sign in.
+
+To redirect to a page after a successful sign in, please use [the `callbackUrl` option](/getting-started/client#specifying-a-callbackurl) or [the redirect callback](/configuration/callbacks#redirect-callback).
+:::
 
 ## Redirect callback
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Updates the callback documentation to specify that you shouldn't use the `signIn` callback for arbitrary redirects. Instead, use the `callbackUrl` option or the redirect callback.

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

I was previously using the `signIn` callback to redirect to a relative path (as mentioned [here](https://next-auth.js.org/getting-started/client#specifying-a-callbackurl)). I didn't realize that doing so canceled the current sign in and that I should instead use [the redirect callback](https://next-auth.js.org/configuration/callbacks#redirect-callback).

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->