### PR TITLE
fix(build): do not run husky on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "./errors": "./dist/lib/errors.js"
   },
   "scripts": {
-    "postinstall": "npx husky install",
     "build": "npm run build:js && npm run build:css",
     "build:js": "node ./config/build.js && babel --config-file ./config/babel.config.js src --out-dir dist",
     "build:css": "postcss --config config/postcss.config.js src/**/*.css --base src --dir dist && node config/wrap-css.js",


### PR DESCRIPTION
## Reasoning 💡

In an attempt to make contributions easier, #2130 introduced a postinstall script, that fails if installed in an environment without git (basically any user land usage)

cc @lluia @ndom91

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #2156