### PR TITLE
fix(provider) dynamically require nodemailer for email provider

### DIFF
--- a/src/providers/email.js
+++ b/src/providers/email.js
@@ -1,5 +1,4 @@
 import logger from '../lib/logger'
-import nodemailer from "nodemailer"
 
 export default function Email(options) {
   return {
@@ -27,6 +26,7 @@ async function sendVerificationRequest ({ identifier: email, url, baseUrl, provi
   // Strip protocol from URL and use domain as site name
   const site = baseUrl.replace(/^https?:\/\//, '')
   try {
+    const nodemailer = require('nodemailer')
     await nodemailer
       .createTransport(server)
       .sendMail({


### PR DESCRIPTION
I still see a warning so there might be a better solution:
```
warn  - ../next-auth/dist/providers/email.js
Module not found: Can't resolve 'nodemailer' in '/Users/hughboylan/Development/next-auth/dist/providers'
```

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

The `nodemailer` dependency should be optional in case the email provider is not being used.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
