### PR TITLE
fix(provider): Set idToken for cognito provider as true by default

### DIFF
--- a/src/providers/cognito.js
+++ b/src/providers/cognito.js
@@ -9,6 +9,7 @@ export default function Cognito(options) {
     params: { grant_type: "authorization_code" },
     accessTokenUrl: `https://${domain}/oauth2/token`,
     authorizationUrl: `https://${domain}/oauth2/authorize?response_type=code`,
+    idToken: true,
     profileUrl: `https://${domain}/oauth2/userInfo`,
     profile(profile) {
       return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
 Set `idToken` for cognito provider as true by default
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡
Cognito provider currently does not set `idToken` option to `true` even though Cognito supports it. This limits the `profileData` being passed to `profile` mapper function. 
<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~- [ ] Documentation~
~- [ ] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
