### PR TITLE
fix(client): handle keepalive network failures (#2215)

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -15,6 +15,7 @@ export interface CtxOrReq {
 export type GetSessionOptions = CtxOrReq & {
   event?: "storage" | "timer" | "hidden" | string
   triggerEvent?: boolean
+  currentSession?: Session
 }
 
 /**


### PR DESCRIPTION
## Reasoning 💡

The current implementation does not tolerate network failures in keep-alive calls (see #2215 for a detailed scenario). Even a single keep-alive call that fails due to network failure or browser being offline results in client-side session eviction. Proposed change: continue using the existing session object if the underlying fetch call fails.

## Checklist 🧢

- [ ] ~Documentation~
- [ ] ~Tests~
- [x] Ready to be merged

## Affected issues 🎟

Fixes #2215