### PR TITLE
fix(ts): tweak pages option types for newUser

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -414,7 +414,7 @@ export interface PagesOptions {
   error?: string
   verifyRequest?: string
   /** If set, new users will be directed here on first sign in */
-  newUser?: string
+  newUser?: string | null
 }
 
 export interface DefaultSession extends Record<string, unknown> {


### PR DESCRIPTION
## Reasoning 💡

https://next-auth.js.org/configuration/pages
Because set `null` to `newUser` on pages options make type error...

![image](https://user-images.githubusercontent.com/19779874/123679433-6febbb00-d882-11eb-9614-83fc5333508f.png)



## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
