### PR TITLE
chore(docs): remove title prefix and make reproductions required in Github Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-title: "[Bug]: "
+title: ""
 labels: bug
 
 # note: markdown sections will NOT appear as part of the issue as per documentation, rather they provide context to the user

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for NextAuth.js
-title: "[Feature Request]: "
+title: ""
 labels: enhancement
 
 # note: markdown sections will NOT appear as part of the issue as per documentation, rather they provide context to the user
@@ -43,7 +43,7 @@ body:
       label: How to reproduce ☕️ 
       description: If you have a CodeSandbox playground or some code snippets to help us visualize your idea better, please provide it here.
     validations:
-      required: false
+      required: true
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,6 +1,6 @@
 name: Question
 description: Ask a question about NextAuth.js or for help using it
-title: "[Question]: "
+title: ""
 labels: question
 
 # note: markdown sections will NOT appear as part of the issue as per documentation, rather they provide context to the user
@@ -39,7 +39,7 @@ body:
       label: How to reproduce ☕️ 
       description: Please provide a link to a minimal reproduction or code snippets that represents your question
     validations:
-      required: false 
+      required: true 
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/typescript.yaml
+++ b/.github/ISSUE_TEMPLATE/typescript.yaml
@@ -1,6 +1,6 @@
 name: TypeScript
 description: Ask a question about NextAuth.js TypeScript integration
-title: "[TypeScript | Question]: "
+title: ""
 labels: [question, TypeScript]
 assignees: [lluia, balazsorban44]
 
@@ -34,7 +34,7 @@ body:
       label: How to reproduce ☕️ 
       description: Please provide a link to a minimal reproduction or code snippets that represents your question
     validations:
-      required: false 
+      required: true 
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->
This PR addresses the following issues with the current GitHub issue forms:
- Remove prefix in title, making it more readable on smaller screens.
- Make some sort of reproduction always required across all templates.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
~- [ ] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
Closes #2305 
