### PR TITLE
docs(github): fix GitHub issue forms by removing `title` property altogether

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: ""
 labels: bug
 
 # note: markdown sections will NOT appear as part of the issue as per documentation, rather they provide context to the user

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest an idea for NextAuth.js
-title: ""
 labels: enhancement
 
 # note: markdown sections will NOT appear as part of the issue as per documentation, rather they provide context to the user

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,6 +1,5 @@
 name: Question
 description: Ask a question about NextAuth.js or for help using it
-title: ""
 labels: question
 
 # note: markdown sections will NOT appear as part of the issue as per documentation, rather they provide context to the user

--- a/.github/ISSUE_TEMPLATE/typescript.yaml
+++ b/.github/ISSUE_TEMPLATE/typescript.yaml
@@ -1,6 +1,5 @@
 name: TypeScript
 description: Ask a question about NextAuth.js TypeScript integration
-title: ""
 labels: [question, TypeScript]
 assignees: [lluia, balazsorban44]
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡
#2306 introduced a bug by leaving `title` property as an empty string, which has been documented in #2305. This made it so that the New Issues no longer made use of the template forms, since GitHub believes they are invalid `yaml` files.

This PR addresses that issue by removing the `title` property altogether so that GitHub actually treats the templates as valid.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
~- [] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->

Closes #2305 
