### PR TITLE
support yuque && add `authHeaders` option

### DIFF
--- a/src/providers/yuque.js
+++ b/src/providers/yuque.js
@@ -1,0 +1,24 @@
+export default function Yuque(options) {
+  return {
+    id: "yuque",
+    name: "Yuque",
+    type: "oauth",
+    version: "2.0",
+    scope: ["doc:read"],
+    params: { grant_type: "authorization_code" },
+    accessTokenUrl: "https://www.yuque.com/oauth2/token",
+    requestTokenUrl: "https://www.yuque.com/oauth2/authorize",
+    authorizationUrl: "https://www.yuque.com/oauth2/authorize?response_type=code",
+    profileUrl: "https://www.yuque.com/api/v2/user",
+    profile(profile) {
+      return {
+        id: profile.data.id,
+        name: profile.data.username,
+        image: profile.data.avatar_url,
+        // Yuque doesn't expose `email` in api
+        email: profile.data.email,
+      };
+    },
+    ...options,
+  };
+}

--- a/src/providers/yuque.js
+++ b/src/providers/yuque.js
@@ -10,6 +10,11 @@ export default function Yuque(options) {
     requestTokenUrl: "https://www.yuque.com/oauth2/authorize",
     authorizationUrl: "https://www.yuque.com/oauth2/authorize?response_type=code",
     profileUrl: "https://www.yuque.com/api/v2/user",
+    authHeaders({ accessToken }) {
+      return {
+        "X-Auth-Token": accessToken,
+      };
+    },
     profile(profile) {
       return {
         id: profile.data.id,

--- a/src/providers/yuque.js
+++ b/src/providers/yuque.js
@@ -18,7 +18,7 @@ export default function Yuque(options) {
     profile(profile) {
       return {
         id: profile.data.id,
-        name: profile.data.username,
+        name: profile.data.name,
         image: profile.data.avatar_url,
         // Yuque doesn't expose `email` in api
         email: profile.data.email,

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -218,6 +218,10 @@ async function getOAuth2 (provider, accessToken, results) {
   let httpMethod = 'GET'
   const headers = { ...provider.headers }
 
+  if (provider.authHeaders) {
+    Object.assign(headers, provider.authHeaders({ accessToken }))
+  }
+
   if (this._useAuthorizationHeaderForGET) {
     headers.Authorization = this.buildAuthHeader(accessToken)
 

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -33,6 +33,7 @@ export interface OAuthConfig<P extends Record<string, unknown> = Profile>
   requestTokenUrl?: string
   authorizationUrl: string
   profileUrl: string
+  authHeaders?(info: { accessToken: string }): Record<string, string>,
   profile(profile: P, tokens: TokenSet): Awaitable<User & { id: string }>
   protection?: ProtectionType | ProtectionType[]
   clientId: string
@@ -99,6 +100,7 @@ export type OAuthProviderType =
   | "WordPress"
   | "WorkOS"
   | "Yandex"
+  | "Yuque"
   | "Zoho"
   | "Zoom"
 

--- a/types/tests/providers.test.ts
+++ b/types/tests/providers.test.ts
@@ -257,3 +257,9 @@ Providers.Zoho({
   clientId: "foo123",
   clientSecret: "bar123",
 })
+
+// $ExpectType OAuthConfig<Profile>
+Providers.Zoho({
+  clientId: "foo123",
+  clientSecret: "bar123",
+})

--- a/www/docs/providers/yuque.md
+++ b/www/docs/providers/yuque.md
@@ -1,0 +1,38 @@
+---
+id: yuque
+title: Yuque
+---
+
+## Documentation
+
+https://www.yuque.com/yuque/developer/api
+
+## Configuration
+
+https://www.yuque.com/settings/applications
+
+## Options
+
+The **Yuque Provider** comes with a set of default options:
+
+- [Yuque Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/yuque.js)
+
+You can override any of the options to suit your own use case.
+
+## Example
+
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.Yuque({
+    clientId: process.env.YUQUE_CLIENT_ID,
+    clientSecret: process.env.YUQUE_CLIENT_SECRET
+  })
+]
+...
+```
+
+:::warning
+Yuque doesn't expose user's email in API
+:::

--- a/www/docs/providers/yuque.md
+++ b/www/docs/providers/yuque.md
@@ -34,5 +34,5 @@ providers: [
 ```
 
 :::warning
-Yuque doesn't expose user's email in API
+Yuque doesn't expose the user's email in API
 :::


### PR DESCRIPTION
This PR support a new provider [Yuque](https://yuque.com), which is a documentation platform from China.

According to Yuque's API authorization [definition](https://www.yuque.com/yuque/developer/api), every secured API call (such as the profile API) should pass access token in header `X-Auth-Token`, but I can't find an option that can pass the access token as a header value. So I add an `authHeaders` option in this PR. 