### PR TITLE
feat(client): improved basepath detection

### DIFF
--- a/src/client/__tests__/parse-url.test.js
+++ b/src/client/__tests__/parse-url.test.js
@@ -1,0 +1,59 @@
+import parseUrl from "../../lib/parse-url"
+
+// https://stackoverflow.com/questions/48033841/test-process-env-with-jest
+describe("parseUrl() tests", () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules() // Most important - it clears the cache
+    process.env = { ...OLD_ENV } // Make a copy
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV // Restore old environment
+  })
+
+  test("when on client side and NEXT_PUBLIC_NEXTAUTH_URL is defined, correctly returns baseUrl and basePath", () => {
+    process.env.NEXT_PUBLIC_NEXTAUTH_URL = "http://localhost:3000/api/v1/auth"
+
+    const { baseUrl, basePath } = parseUrl()
+
+    expect(baseUrl).toBe("http://localhost:3000")
+    expect(basePath).toBe("/api/v1/auth")
+  })
+
+  test("when on client side and NEXT_PUBLIC_NEXTAUTH_URL is not defined, falls back to default values", () => {
+    const { baseUrl, basePath } = parseUrl()
+
+    expect(baseUrl).toBe("http://localhost:3000")
+    expect(basePath).toBe("/api/auth")
+  })
+
+  test("when on server side, correctly parses any given URL", () => {
+    let url = "http://localhost:3000"
+    let { baseUrl, basePath } = parseUrl(url)
+
+    expect(baseUrl).toBe("http://localhost:3000")
+    expect(basePath).toBe("/api/auth")
+
+    url = "http://localhost:3000/api/v1/authentication/"
+    // this semi-colon is needed, otherwise js thinks the string
+    // above is a function
+    ;({ baseUrl, basePath } = parseUrl(url))
+
+    expect(baseUrl).toBe("http://localhost:3000")
+    expect(basePath).toBe("/api/v1/authentication")
+
+    url = "https://www.mydomain.com"
+    ;({ baseUrl, basePath } = parseUrl(url))
+
+    expect(baseUrl).toBe("https://www.mydomain.com")
+    expect(basePath).toBe("/api/auth")
+
+    url = "https://www.mydomain.com/api/v3/auth"
+    ;({ baseUrl, basePath } = parseUrl(url))
+
+    expect(baseUrl).toBe("https://www.mydomain.com")
+    expect(basePath).toBe("/api/v3/auth")
+  })
+})

--- a/src/client/react.js
+++ b/src/client/react.js
@@ -56,7 +56,7 @@ export function useSession(options = {}) {
 
   React.useEffect(() => {
     if (requiredAndNotLoading) {
-      const url = `/api/auth/signin?${new URLSearchParams({
+      const url = `${_apiBaseUrl()}/signin?${new URLSearchParams({
         error: "SessionRequired",
         callbackUrl: window.location.href,
       })}`
@@ -337,6 +337,17 @@ function _apiBaseUrl() {
     // NEXTAUTH_URL should always be set explicitly to support server side calls - log warning if not set
     if (!process.env.NEXTAUTH_URL) {
       logger.warn("NEXTAUTH_URL", "NEXTAUTH_URL environment variable not set")
+    }
+
+    if (
+      process.env.NODE_ENV === "development" &&
+      !/^http:\/\/localhost:\d+$/.test(process.env.NEXTAUTH_URL) &&
+      !process.env.NEXT_PUBLIC_NEXTAUTH_URL
+    ) {
+      logger.warn(
+        "NEXT_PUBLIC_NEXTAUTH_URL",
+        `NEXTAUTH_URL is set to "${process.env.NEXTAUTH_URL}" instead of the default "http://localhost:3000", and NEXT_PUBLIC_NEXTAUTH_URL is not set. Client side path detections will fail.`
+      )
     }
 
     // Return absolute path when called server side

--- a/src/lib/parse-url.js
+++ b/src/lib/parse-url.js
@@ -5,23 +5,36 @@
  * supporting a default value, so a simple split is sufficent.
  * @param {string} url
  */
-export default function parseUrl (url) {
+export default function parseUrl(url) {
   // Default values
-  const defaultHost = 'http://localhost:3000'
-  const defaultPath = '/api/auth'
+  const defaultHost = "http://localhost:3000"
+  const defaultPath = "/api/auth"
 
-  if (!url) { url = `${defaultHost}${defaultPath}` }
-
+  if (!url) {
+    if (process.env.NEXT_PUBLIC_NEXTAUTH_URL) {
+      /* 
+        if the user has defined NEXT_PUBLIC_NEXTAUTH_URL, which should be mandatory
+        if they are using a different path other than 'http://localhost:3000'
+        in NEXTAUTH_URL variable in their .env file, use that variable instead, 
+        otherwise, the clientside path detection will fail.
+      */
+      url = process.env.NEXT_PUBLIC_NEXTAUTH_URL
+    } else {
+      // fallback to default values, user should see a warning if NEXTAUTH_URL is different
+      // and NEXT_PUBLIC_NEXTAUTH_URL is not set
+      url = `${defaultHost}${defaultPath}`
+    }
+  }
   // Default to HTTPS if no protocol explictly specified
-  const protocol = url.startsWith('http:') ? 'http' : 'https'
+  const protocol = url.startsWith("http:") ? "http" : "https"
 
   // Normalize URLs by stripping protocol and no trailing slash
-  url = url.replace(/^https?:\/\//, '').replace(/\/$/, '')
+  url = url.replace(/^https?:\/\//, "").replace(/\/$/, "")
 
   // Simple split based on first /
-  const [_host, ..._path] = url.split('/')
+  const [_host, ..._path] = url.split("/")
   const baseUrl = _host ? `${protocol}://${_host}` : defaultHost
-  const basePath = _path.length > 0 ? `/${_path.join('/')}` : defaultPath
+  const basePath = _path.length > 0 ? `/${_path.join("/")}` : defaultPath
 
   return { baseUrl, basePath }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -20,6 +20,17 @@ if (!process.env.NEXTAUTH_URL) {
   logger.warn("NEXTAUTH_URL", "NEXTAUTH_URL environment variable not set")
 }
 
+if (
+  process.env.NODE_ENV === "development" &&
+  !/^http:\/\/localhost:\d+$/.test(process.env.NEXTAUTH_URL) &&
+  !process.env.NEXT_PUBLIC_NEXTAUTH_URL
+) {
+  logger.warn(
+    "NEXT_PUBLIC_NEXTAUTH_URL",
+    `NEXTAUTH_URL is set to "${process.env.NEXTAUTH_URL}" instead of the default "http://localhost:\${PORT}", and NEXT_PUBLIC_NEXTAUTH_URL is not set. Client side path detections will fail.`
+  )
+}
+
 /**
  * @param {import("next").NextApiRequest} req
  * @param {import("next").NextApiResponse} res

--- a/www/docs/getting-started/example.md
+++ b/www/docs/getting-started/example.md
@@ -114,7 +114,7 @@ This assumes that `[...nextauth].js` is inside `/pages/api/v1/auth/`.
 
 You can use a [Next.js feature](https://nextjs.org/docs/basic-features/environment-variables) to refer to environment variables by their names within the file.
 ```
-NEXTAUTH_URL=https://example.com/api/v1
+NEXTAUTH_URL=https://example.com/api/v1/auth
 NEXT_PUBLIC_NEXTAUTH_URL=$NEXTAUTH_URL
 ```
 

--- a/www/docs/getting-started/example.md
+++ b/www/docs/getting-started/example.md
@@ -103,6 +103,21 @@ When deploying your site set the `NEXTAUTH_URL` environment variable to the cano
 NEXTAUTH_URL=https://example.com
 ```
 
+If you are using a URL for the API endpoints that is different than this (hence, a different folder structure as well), for example `NEXTAUTH_URL=https://example.com/api/v1/auth`, you also need to set a second environment variable with the key `NEXT_PUBLIC_NEXTAUTH_URL` and point it to the same URL. Otherwise, client side path detections will fail.
+
+```
+NEXTAUTH_URL=https://example.com/api/v1/auth
+NEXT_PUBLIC_NEXTAUTH_URL=https://example.com/api/v1/auth
+```
+
+This assumes that `[...nextauth].js` is inside `/pages/api/v1/auth/`.
+
+You can use a [Next.js feature](https://nextjs.org/docs/basic-features/environment-variables) to refer to environment variables by their names within the file.
+```
+NEXTAUTH_URL=https://example.com/api/v1
+NEXT_PUBLIC_NEXTAUTH_URL=$NEXTAUTH_URL
+```
+
 :::tip
 In production, this needs to be set as an environment variable on the service you use to deploy your app.
 

--- a/www/docs/getting-started/rest-api.md
+++ b/www/docs/getting-started/rest-api.md
@@ -59,4 +59,17 @@ e.g.
  `NEXTAUTH_URL=https://example.com/myapp/api/authentication`
 
 `/api/auth/signin` -> `/myapp/api/authentication/signin`
+
+However, you need to do two things:
+1. You must declare a `NEXT_PUBLIC_NEXTAUTH_URL` environment variable that points to the same URL as above.
+2. Your folder structure must match the above URL. e.g.
+
+```
+.
+└── pages
+    └── api
+        └── authentication
+            └── [...nextauth].js
+
+```
 :::

--- a/www/docs/getting-started/rest-api.md
+++ b/www/docs/getting-started/rest-api.md
@@ -62,7 +62,7 @@ e.g.
 
 However, you need to do two things:
 1. You must declare a `NEXT_PUBLIC_NEXTAUTH_URL` environment variable that points to the same URL as above.
-2. Your folder structure must match the above URL. e.g.
+2. Your folder structure must match what's set on `NEXT_PUBLIC_NEXTAUTH_URL`, for instance, if it's set to `https://mywebsite.com/api/authentication`, your folder structure should be:
 
 ```
 .

--- a/www/docs/warnings.md
+++ b/www/docs/warnings.md
@@ -5,7 +5,7 @@ title: Warnings
 
 This is a list of warning output from NextAuth.js.
 
-All warnings indicate things which you should take a look at, but do not inhibit normal operation.
+All warnings indicate things which you should take a look at, but in most cases do not inhibit normal operation.
 
 ---
 
@@ -14,6 +14,10 @@ All warnings indicate things which you should take a look at, but do not inhibit
 #### NEXTAUTH_URL
 
 Environment variable `NEXTAUTH_URL` missing. Please set it in your `.env` file.
+
+#### NEXT_PUBLIC_NEXTAUTH_URL
+
+You are using a folder structure and `NEXTAUTH_URL` other than the default one, but you haven't set `NEXT_PUBLIC_NEXTAUTH_URL` or `NEXT_PUBLIC_NEXTAUTH_URL` points to a different endpoint. This will make client side path detections fail if not addressed.
 
 ---
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

This PR attempts to improve client side path detection by leveraging a second environment variable named `NEXT_PUBLIC_NEXTAUTH_URL` to ensure client side path detections are always consistent, regardless of folder structure and URL.

Currently, there are some issues with the client side path detection. e.g. [signIn()](https://github.com/nextauthjs/next-auth/blob/next/src/client/react.js#L59) function assumes that the folder structure is like the following:

```
test-project
    └── pages
        └── api
            └── auth
                └── [...nextauth].js
```
and `NEXTAUTH_URL` to be set to `http://localhost:3000` or `https://mydomain.com`. The above breaks if the URL and/or folder structure of the user's project is different.

With these changes, users will be able to use a different folder structure if they want, such as:

```
test-project
└── pages
    └── api
       └── v1
          └── authentication
             └── [...nextauth].js
```
And set `NEXTAUTH_URL` to something like `http://localhost:3000/api/v1/authentication`.  As compensation for the flexibility, they now need to declare a second environment variable:

```
NEXTAUTH_URL=http://localhost:3000/api/v1/authentication
NEXT_PUBLIC_NEXTAUTH_URL=http://localhost:3000/api/v1/authentication
```

Luckily, this can be simplified by using [variables expansion feature of Next.js](https://nextjs.org/docs/basic-features/environment-variables)
```
NEXTAUTH_URL=http://localhost:3000/api/authentication
NEXT_PUBLIC_NEXTAUTH_URL=$NEXTAUTH_URL
```

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
Closes #1713, #2316. Related to #689, #1712, #1517, #900, #499, #1676