### PR TITLE
fix(oauth): correctly remove `code_verifier` cookie when used

### DIFF
--- a/src/server/lib/oauth/pkce-handler.js
+++ b/src/server/lib/oauth/pkce-handler.js
@@ -36,7 +36,11 @@ export async function handleCallback (req, res) {
       pkceLength: PKCE_LENGTH,
       method: PKCE_CODE_CHALLENGE_METHOD
     })
-    cookie.set(res, cookies.pkceCodeVerifier.name, null, { maxAge: 0 }) // remove PKCE after it has been used
+    // remove PKCE after it has been used
+    cookie.set(res, cookies.pkceCodeVerifier.name, "", { 
+      ...cookies.pkceCodeVerifier.options,
+      maxAge: 0 
+    })
   } catch (error) {
     logger.error('CALLBACK_OAUTH_ERROR', error)
     return res.redirect(`${baseUrl}${basePath}/error?error=OAuthCallback`)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

Once the pkce code verifier is used, the cookie is cleared but the browser blocks the deletion of this cookie, keeping it in the browser until it expires.

![image](https://user-images.githubusercontent.com/6553553/124883127-4f81d600-dfd1-11eb-8eee-51b79856bbe3.png)

This is because when using the cookie with the useSecureCookies option enabled (https environment), the cookie is prefixed with [__Secure-](https://datatracker.ietf.org/doc/html/draft-west-cookie-prefixes-05#section-3.1). and it must use the `cookies.pkceCodeVerifier.options` options to be valid (the secure attribute must be set to true). 

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
