### PR TITLE
Adding OneLogin as a provider

### DIFF
--- a/src/providers/onelogin.js
+++ b/src/providers/onelogin.js
@@ -1,0 +1,19 @@
+export default function OneLogin(options) {
+  return {
+    id: "onelogin",
+    name: "OneLogin",
+    type: "oauth",
+    version: "2.0",
+    scope: "openid profile name email",
+    params: { grant_type: "authorization_code" },
+    // These will be different depending on the Org.
+    accessTokenUrl: `https://${options.domain}/oidc/2/token`,
+    requestTokenUrl: `https://${options.domain}/oidc/2/auth`,
+    authorizationUrl: `https://${options.domain}/oidc/2/auth?response_type=code`,
+    profileUrl: `https://${options.domain}/oidc/2/me`,
+    profile(profile) {
+      return { ...profile, id: profile.sub }
+    },
+    ...options,
+  }
+}

--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -87,6 +87,7 @@ export type OAuthProviderType =
   | "Naver"
   | "Netlify"
   | "Okta"
+  | "OneLogin"
   | "Osso"
   | "Reddit"
   | "Salesforce"

--- a/types/tests/providers.test.ts
+++ b/types/tests/providers.test.ts
@@ -33,7 +33,7 @@ Providers.Credentials({
       type: "password",
     },
   },
-  authorize: async ({username, password}) => {
+  authorize: async ({ username, password }) => {
     const user = {
       /* fetched user */
     }
@@ -150,6 +150,13 @@ Providers.Okta({
   clientId: "foo123",
   clientSecret: "bar123",
   domain: "https://foo.auth0.com",
+})
+
+// $ExpectType OAuthConfig<Profile>
+Providers.OneLogin({
+  clientId: "foo123",
+  clientSecret: "bar123",
+  domain: "foo.onelogin.com",
 })
 
 // $ExpectType OAuthConfig<Profile>

--- a/www/docs/providers/onelogin.md
+++ b/www/docs/providers/onelogin.md
@@ -1,0 +1,31 @@
+---
+id: onelogin
+title: OneLogin
+---
+
+## Documentation
+
+https://developers.onelogin.com/openid-connect
+
+## Options
+
+The **OneLogin Provider** comes with a set of default options:
+
+- [OneLogin Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/onelogin.js)
+
+You can override any of the options to suit your own use case.
+
+## Example
+
+```js
+import Providers from `next-auth/providers`
+...
+providers: [
+  Providers.OneLogin({
+    clientId: process.env.ONELOGIN_CLIENT_ID,
+    clientSecret: process.env.ONELOGIN_CLIENT_SECRET,
+    domain: process.env.ONELOGIN_DOMAIN
+  })
+]
+...
+```


### PR DESCRIPTION
## Reasoning 💡

Recently started using this and it's pretty great but we needed OneLogin for our use-case and saw it wasn't listed as a provider. So here's a small little addition to support it.

## Checklist 🧢

- [x ] Documentation
- [x ] Tests
- [x ] Ready to be merged
