### PR TITLE
Include profile on signIn events

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -139,7 +139,7 @@ export default async function callback(req, res) {
           })
         }
 
-        await dispatchEvent(events.signIn, { user, account, isNewUser })
+        await dispatchEvent(events.signIn, { user, account, profile, isNewUser })
 
         // Handle first logins on new accounts
         // e.g. option to send users to a new account landing page on initial login
@@ -286,7 +286,7 @@ export default async function callback(req, res) {
         })
       }
 
-      await dispatchEvent(events.signIn, { user, account, isNewUser })
+      await dispatchEvent(events.signIn, { user, account, profile, isNewUser })
 
       // Handle first logins on new accounts
       // e.g. option to send users to a new account landing page on initial login
@@ -409,7 +409,7 @@ export default async function callback(req, res) {
       ...cookies.sessionToken.options,
     })
 
-    await dispatchEvent(events.signIn, { user, account })
+    await dispatchEvent(events.signIn, { user, account, profile: null })
 
     return res.redirect(callbackUrl || baseUrl)
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -363,6 +363,7 @@ export type EventCallback<MessageType = unknown> = (
 export interface SignInEventMessage {
   user: User
   account: Account
+  profile: Profile | null
   isNewUser?: boolean
 }
 


### PR DESCRIPTION
`profile` added to `event.signIn` message

## Reasoning 💡

I use the profile information to fire updates on the user object after any successful sign-in. Before this change, I had to stuff handlers to sync `profile.name` and `platform` against the `User` model in 3 separate places. This change allows me to have a complete "source of truth" within the `signIn` event :)

## Checklist 🧢

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation (likely needed, will add if y'all like the changes)
- [ ] Tests (not sure if needed for this)
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I would like some thoughts from the team on this solution before cleanup + merge. I am happy to make any docs changes and add tests if this is a solution y'all are happy with :)

## Affected issues 🎟

Didn't file one, went straight to source :)