### PR TITLE
feat(events): include `profile` on `signIn` events

### DIFF
--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -396,7 +396,7 @@ export default async function callback(req, res) {
       ...cookies.sessionToken.options,
     })
 
-    await events.signIn({ user, account, profile: null })
+    await events.signIn({ user, account })
 
     return res.redirect(callbackUrl || baseUrl)
   }

--- a/src/server/routes/callback.js
+++ b/src/server/routes/callback.js
@@ -132,7 +132,7 @@ export default async function callback(req, res) {
           })
         }
 
-        await events.signIn({ user, account, isNewUser })
+        await events.signIn({ user, account, profile, isNewUser })
 
         // Handle first logins on new accounts
         // e.g. option to send users to a new account landing page on initial login
@@ -274,7 +274,7 @@ export default async function callback(req, res) {
         })
       }
 
-      await events.signIn({ user, account, isNewUser })
+      await events.signIn({ user, account, profile, isNewUser })
 
       // Handle first logins on new accounts
       // e.g. option to send users to a new account landing page on initial login
@@ -396,7 +396,7 @@ export default async function callback(req, res) {
       ...cookies.sessionToken.options,
     })
 
-    await events.signIn({ user, account })
+    await events.signIn({ user, account, profile: null })
 
     return res.redirect(callbackUrl || baseUrl)
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -394,6 +394,7 @@ export interface EventCallbacks {
   signIn(message: {
     user: User
     account: Account
+    profile: Profile | null
     isNewUser?: boolean
   }): Awaitable<void>
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -394,7 +394,7 @@ export interface EventCallbacks {
   signIn(message: {
     user: User
     account: Account
-    profile: Profile | null
+    profile?: Profile
     isNewUser?: boolean
   }): Awaitable<void>
   /**

--- a/www/docs/configuration/events.md
+++ b/www/docs/configuration/events.md
@@ -21,7 +21,7 @@ The message will be an object and contain:
 
 - `user` (from your adapter or from the provider if a `credentials` type provider)
 - `account` (from your adapter or the provider)
-- `profile` (from the provider, resolves to `null` on `credentials` type provider)
+- `profile` (from the provider, is `undefined` on `credentials` provider, use `user` instead)
 - `isNewUser` (whether your adapter had a user for this account already)
 
 ### signOut

--- a/www/docs/configuration/events.md
+++ b/www/docs/configuration/events.md
@@ -21,6 +21,7 @@ The message will be an object and contain:
 
 - `user` (from your adapter or from the provider if a `credentials` type provider)
 - `account` (from your adapter or the provider)
+- `profile` (from the provider, resolves to `null` on `credentials` type provider)
 - `isNewUser` (whether your adapter had a user for this account already)
 
 ### signOut


### PR DESCRIPTION
Redo of https://github.com/nextauthjs/next-auth/pull/2354 rebased on `next` branch

_below is copy-pasted from last PR_

## What Changed
`profile` added to `event.signIn` message

## Reasoning 💡

I use the profile information to fire updates on the user object after any successful sign-in. Before this change, I had to stuff handlers to sync `profile.name` and `platform` against the `User` model in 3 separate places. This change allows me to have a complete "source of truth" within the `signIn` event :)

## Checklist 🧢

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation (likely needed, will add if y'all like the changes)
- [ ] Tests (not sure if needed for this)
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I would like some thoughts from the team on this solution before cleanup + merge. I am happy to make any docs changes and add tests if this is a solution y'all are happy with :)

## Affected issues 🎟

Didn't file one, went straight to source :)