### PR TITLE
docs(adapter): Typo in filepath for firebase auth in docs.

### DIFF
--- a/www/docs/adapters/firebase.md
+++ b/www/docs/adapters/firebase.md
@@ -15,7 +15,7 @@ This is the Firebase Adapter for [`next-auth`](https://next-auth.js.org). This p
 npm install next-auth @next-auth/firebase-adapter
 ```
 
-2. Add this adapter to your `pages/api/[...nextauth].js` next-auth configuration object.
+2. Add this adapter to your `pages/api/auth/[...nextauth].js` next-auth configuration object.
 
 ```javascript title="pages/api/auth/[...nextauth].js"
 import NextAuth from "next-auth"


### PR DESCRIPTION
Just a typo, confused me for a moment.