### PR TITLE
Added compatibility to use behind a proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@next-auth/prisma-legacy-adapter": "0.0.1-canary.127",
     "@next-auth/typeorm-legacy-adapter": "0.0.2-canary.129",
     "futoin-hkdf": "^1.3.2",
+    "https-proxy-agent": "5.0.0",
     "jose": "^1.27.2",
     "jsonwebtoken": "^8.5.1",
     "nodemailer": "^6.4.16",

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -2,6 +2,7 @@ import { OAuth, OAuth2 } from 'oauth'
 import querystring from 'querystring'
 import logger from '../../../lib/logger'
 import { sign as jwtSign } from 'jsonwebtoken'
+import HttpsProxyAgent from 'https-proxy-agent'
 
 /**
  * @TODO Refactor to remove dependancy on 'oauth' package
@@ -156,6 +157,11 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
   const postData = querystring.stringify(params)
 
   return new Promise((resolve, reject) => {
+    if (process.env.http_proxy) {
+      const agent = new HttpsProxyAgent(process.env.http_proxy)
+      this.setAgent(agent)
+    }
+    
     this._request(
       'POST',
       url,
@@ -247,6 +253,11 @@ async function getOAuth2 (provider, accessToken, results) {
   }
 
   return new Promise((resolve, reject) => {
+    if (process.env.http_proxy) {
+      const agent = new HttpsProxyAgent(process.env.http_proxy)
+      this.setAgent(agent)
+    }
+    
     this._request(httpMethod, url, headers, null, accessToken, (error, profileData) => {
       if (error) {
         return reject(error)

--- a/src/server/lib/oauth/client.js
+++ b/src/server/lib/oauth/client.js
@@ -2,6 +2,7 @@ import { OAuth, OAuth2 } from 'oauth'
 import querystring from 'querystring'
 import logger from '../../../lib/logger'
 import { sign as jwtSign } from 'jsonwebtoken'
+import UrlLib from 'url'
 import HttpsProxyAgent from 'https-proxy-agent'
 
 /**
@@ -157,7 +158,8 @@ async function getOAuth2AccessToken (code, provider, codeVerifier) {
   const postData = querystring.stringify(params)
 
   return new Promise((resolve, reject) => {
-    if (process.env.http_proxy) {
+    const parsedUrl = UrlLib.parse(url, true)
+    if (parsedUrl.protocol == "https:" && process.env.http_proxy) {
       const agent = new HttpsProxyAgent(process.env.http_proxy)
       this.setAgent(agent)
     }
@@ -253,7 +255,8 @@ async function getOAuth2 (provider, accessToken, results) {
   }
 
   return new Promise((resolve, reject) => {
-    if (process.env.http_proxy) {
+    const parsedUrl = UrlLib.parse(url, true)
+    if (parsedUrl.protocol == "https:" && process.env.http_proxy) {
       const agent = new HttpsProxyAgent(process.env.http_proxy)
       this.setAgent(agent)
     }


### PR DESCRIPTION
# Added compatibility to use behind a proxy

## Reasoning 💡

**NextAuth don't work behind a proxy.**

NextAuth makes use of the ["node-auth" library (npm package "oauth")](https://github.com/ciaranj/node-oauth) in it's "oAuthClient" (_src/server/lib/oauth/client.js_), on methods "getOAuth2AccessToken" and "getOAuth2".

To make requests on its OAuth2 implementation, "node-auth" makes use of the "https" library. To make "https" work behind an Proxy, a new dependency was added: ["https-proxy-agent"](https://www.npmjs.com/package/https-proxy-agent).

The NextAuth client now creates an "agent" with the "HttpsProxyAgent" library before every use of the method "_request" (from the "node-auth" library), ONLY IF the "http_proxy" env variable was set. It will check if "process.env.http_proxy" has a value. If there is no proxy env variable set, nothing will change in the way NextAuth behaves today.

After creating the "agent", the method "setAgent" from the "node-auth" library is called. "setAgent" was created on version 0.9.15 of the "node-auth" library and is the way to make "node-auth" work behind an Proxy (see, for example, issue ciaranj/node-oauth#307).

**About the use of the "https" library by "node-auth":**

In case the url sent to the "_request" method from "node-oauth" has an HTTP protocol and not an HTTPS protocol, "node-oauth" will use the "http" library, not the "https" library, as can be seen in:

https://github.com/ciaranj/node-oauth/blob/a7f8a1e21c362eb4ed2039431fb9ac2ae749f26a/lib/oauth2.js#L61-L68

In that case, the "HttpProxyAgent" library should be used to create the "agent", not the "HttpsProxyAgent" library.
But, in NextAuth case, we are dealing in a more controlled scenario, so we can assume that ANY provider will have an HTTPS url.
If not, it will probably be a custom Provider running in a local network, in which case there will be no need to configure an Proxy anyway.
Because of that, the "agent" will only be created if the url has an "https:" protocol and the "http_proxy" env variable was set.
To validate the protocol, i'm using the same validation made on the "node-oauth" library:

https://github.com/ciaranj/node-oauth/blob/a7f8a1e21c362eb4ed2039431fb9ac2ae749f26a/lib/oauth2.js#L64


## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ x] Ready to be merged

_I did not create any new test case, but the solution was tested._

## Affected issues 🎟

No issue was created before the creation of this PR.
