### PR TITLE
docs(provider): remove en-us from Azure urls

### DIFF
--- a/www/docs/providers/azure-ad-b2c.md
+++ b/www/docs/providers/azure-ad-b2c.md
@@ -5,11 +5,11 @@ title: Azure Active Directory B2C
 
 ## Documentation
 
-https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
+https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow
 
 ## Configuration
 
-https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant
+https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant
 
 ## Options
 


### PR DESCRIPTION
MS Docs has a lot of local language translations, so it's best to remove locale information from the URLs so that when someone follows them, they land on the right language version of the content.
