### PR TITLE
fix(callback): respect callbackUrl with Email Provider

### DIFF
--- a/src/server/lib/email/signin.js
+++ b/src/server/lib/email/signin.js
@@ -13,7 +13,7 @@ import { hashToken } from "../utils"
  * @param {import("types/internals").InternalOptions<EmailConfig>} options
  */
 export default async function email(identifier, options) {
-  const { baseUrl, basePath, adapter, provider, logger } = options
+  const { baseUrl, basePath, adapter, provider, logger, callbackUrl } = options
 
   // Generate token
   const token =
@@ -33,8 +33,8 @@ export default async function email(identifier, options) {
     expires,
   })
 
-  // Generate a link with email and the unhashed token
-  const params = new URLSearchParams({ token, email: identifier })
+  // Generate a link with email, unhashed token and callback url
+  const params = new URLSearchParams({ callbackUrl, token, email: identifier })
   const url = `${baseUrl}${basePath}/callback/${provider.id}?${params}`
 
   try {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Currently the `callbackUrl` passed to `signIn` has no effect if the user clicks the email verification link from a device other than the device used to create the verification request (when using the Email Provider).

This fixes that by putting the `callbackUrl` in the query string of the verification link. Now, regardless of which device is used to click the verification link, the `callbackUrl` is respected.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~- [ ] Documentation~
~- [ ] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

#1542
#2143

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
