### PR TITLE
Changed default Github scope to read-only

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -3,7 +3,7 @@ export default function GitHub(options) {
     id: "github",
     name: "GitHub",
     type: "oauth",
-    authorization: "https://github.com/login/oauth/authorize?scope=user",
+    authorization: "https://github.com/login/oauth/authorize?scope=read:user+user:email",
     token: "https://github.com/login/oauth/access_token",
     userinfo: "https://api.github.com/user",
     profile(profile) {


### PR DESCRIPTION
When using the default settings of the Github provider, with the "user" scope, it grants read/write access to profile info only. By changing to "read:user" and "user:email" it will only request read-only access https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps


## Reasoning 💡

When using the next-auth defaults for the GitHub provider, it requests read/write access to user profile info, which is more access than should be provided. This pull requests reduces the scope of the request to be read-only

## Checklist 🧢

- ~[ ] Documentation~
- ~[ ] Tests~
- [ X] Ready to be merged

## Affected issues 🎟


