### PR TITLE
feat: github codespace setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,6 @@
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "npm run dev:setup && npm run dev",
 
-  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,20 +3,27 @@
   "build": {
     "dockerfile": "Dockerfile",
     // Update 'VARIANT' to pick a Node version: 12, 14, 16
-    "args": { "VARIANT": "16" }
+    "args": { "VARIANT": "16" },
+    "context": ".."
   },
 
   // Set *default* container specific settings.json values on container create.
   "settings": {},
 
   // Add the IDs of extensions you want installed when the container is created.
-  "extensions": ["dbaeumer.vscode-eslint"],
+  "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "next-auth-demo-app",
+      "onAutoForward": "notify"
+    }
+  },
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "cd app && npm install && npm run dev",
+  "postCreateCommand": "npm install && cd app && npm install && npm run dev",
 
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     // Update 'VARIANT' to pick a Node version: 12, 14, 16
     "args": { "VARIANT": "16" },
-    "context": ".."
+    "context": "../app"
   },
 
   // Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   },
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install && cd app && npm install && npm run dev",
+  "postCreateCommand": "npm run dev:setup && npm run dev",
 
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Node.js",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 12, 14, 16
+    "args": { "VARIANT": "16" }
+  },
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["dbaeumer.vscode-eslint"],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3000],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "cd app && npm install && npm run dev",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

This would make it super easy to checkout any PR, issue, etc. in a preconfigured dev env in the browser in the comfortable VS Code interface!

So I added a `.devcontainer` setup for enabling people to spin up a dev environment with codespaces in no time. Next to where you can set secrets for github actions, you can also set env vars for codespaces. There I set the auth0 id / secret / domain for testing. 

What works so far is spinning up the node container, installing the `next-auth` dependencies, as well as the `/app` dependencies and starting the dev server. You can then visit the example app homepage via the generated preview URL :tada: 

Things that still do not work:
- [ ] `copy:css` for some reason doesn't ocpy `dist/css/index.css` to where it should be, although `copy:app` **does** work :shrug: 
- [ ] programmatically getting the codespace preview URL to correctly be able to set `NEXTAUTH_URL`

Whenever you start a codespace, any ports you forward from the container get a dynamic preview URL like this:
![image](https://user-images.githubusercontent.com/7415984/130699106-3510b2cc-3d57-4ec7-9e06-c1c01c949387.png)

You can set env vars in the `.devcontainer.json` file in a few ways - but I'm not sure how we'd get that dynamic URL ahead of time, or if there is any programmatic way to get it..

You can open up any PR (like this one :wink:) in a codespace here:

![image](https://user-images.githubusercontent.com/7415984/130699542-6bd40ab6-8414-4f54-9be8-7d421d365b06.png)


## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
