### PR TITLE
Remove `staleTime` option from client 

### DIFF
--- a/src/client/react.js
+++ b/src/client/react.js
@@ -190,7 +190,7 @@ export async function signOut(options = {}) {
 
 /** @param {import("types/react-client").SessionProviderProps} props */
 export function SessionProvider(props) {
-  const { children, basePath, staleTime = 0 } = props
+  const { children, basePath } = props
 
   if (basePath) __NEXTAUTH.basePath = basePath
 
@@ -230,14 +230,14 @@ export function SessionProvider(props) {
           // If there is no time defined for when a session should be considered
           // stale, then it's okay to use the value we have until an event is
           // triggered which updates it
-          (staleTime === 0 && !event) ||
+          !event ||
           // If the client doesn't have a session then we don't need to call
           // the server to check if it does (if they have signed in via another
           // tab or window that will come through as a "stroage" event
           // event anyway)
-          (staleTime > 0 && __NEXTAUTH._session === null) ||
+          __NEXTAUTH._session === null ||
           // Bail out early if the client session is not stale yet
-          (staleTime > 0 && _now() < __NEXTAUTH._lastSync + staleTime)
+          _now() < __NEXTAUTH._lastSync
         ) {
           return
         }
@@ -254,7 +254,7 @@ export function SessionProvider(props) {
     }
 
     __NEXTAUTH._getSession()
-  }, [staleTime])
+  }, [])
 
   React.useEffect(() => {
     // Listen for storage events and update session if event fired from
@@ -320,7 +320,7 @@ export function SessionProvider(props) {
  * If passed 'appContext' via getInitialProps() in _app.js
  * then get the req object from ctx and use that for the
  * req value to allow _fetchData to
- * work seemlessly in getInitialProps() on server side
+ * work seamlessly in getInitialProps() on server side
  * pages *and* in _app.js.
  */
 async function _fetchData(path, { ctx, req = ctx?.req } = {}) {

--- a/types/react-client.d.ts
+++ b/types/react-client.d.ts
@@ -157,11 +157,6 @@ export interface SessionProviderProps {
   baseUrl?: string
   basePath?: string
   /**
-   * The amount of time (in seconds) after a session should be considered stale.
-   * If set to `0` (default), the session will never be re-fetched.
-   */
-  staleTime?: number
-  /**
    * A time interval (in seconds) after which the session will be re-fetched.
    * If set to `0` (default), the session is not polled.
    */

--- a/types/tests/react.test.ts
+++ b/types/tests/react.test.ts
@@ -72,7 +72,6 @@ client.SessionProvider({
   session: clientSession,
   baseUrl: "https://foo.com",
   basePath: "/",
-  staleTime: 1234,
 })
 
 // $ExpectType ReactElement<any, any> | null
@@ -94,6 +93,5 @@ client.SessionProvider({
   },
   baseUrl: "https://foo.com",
   basePath: "/",
-  staleTime: 1234,
   refetchInterval: 4321,
 })


### PR DESCRIPTION
## Reasoning 💡

[We reasoned](https://github.com/nextauthjs/next-auth/pull/2295#issuecomment-905920641) that `staleTime`, a new option for `<SessionProvider />` was unnecessary as another new option, `refetchInterval`, already covers this behaviour implicitly. Hence removing it from the client module 🗑.

## Checklist 🧢

<!-- Feel free to cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] ~~Documentation~~
- [ ] ~~Tests~~
- [x] Ready to be merged

## Affected issues 🎟

None.
