### PR TITLE
Allow user options id for signinUrl and callbackUrl

### DIFF
--- a/src/server/lib/providers.ts
+++ b/src/server/lib/providers.ts
@@ -13,8 +13,8 @@ export default function parseProviders(params: {
   const { providers = [], base } = params
   return providers.map(({ options, ...defaultOptions }) =>
     merge(defaultOptions, {
-      signinUrl: `${base}/signin/${defaultOptions.id}`,
-      callbackUrl: `${base}/callback/${defaultOptions.id}`,
+      signinUrl: `${base}/signin/${options?.id ?? defaultOptions.id}`,
+      callbackUrl: `${base}/callback/${options?.id ?? defaultOptions.id}`,
       ...options,
     })
   )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

This will change the way providers are parsed and use the user `options.id` from their provider config in the `signinUrl` and `callbackUrl`.

This reason for this suggestion is to better align with v3 behavior, where it used the users chosen provider ID for these urls. In the current beta, it uses the `defaultOptions.id`

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [X] Documentation (N/A - Couldn't find any related documentation)
- [X] Tests (N/A - Couldn't find any related tests)
- [X] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Haven't found any.

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
