### PR TITLE
Delete default type for generic param in CredentialsConfig

### DIFF
--- a/src/providers/credentials.ts
+++ b/src/providers/credentials.ts
@@ -10,7 +10,7 @@ export interface CredentialInput {
 }
 
 export interface CredentialsConfig<
-  C extends Record<string, CredentialInput> = {}
+  C extends Record<string, CredentialInput>
 > extends CommonProviderOptions {
   type: "credentials"
   credentials: C

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -21,7 +21,7 @@ export interface CommonProviderOptions {
   options?: Record<string, unknown>
 }
 
-export type Provider = OAuthConfig<any> | EmailConfig | CredentialsConfig
+export type Provider = OAuthConfig<any> | EmailConfig | CredentialsConfig<any>
 
 export type BuiltInProviders = Record<OAuthProviderType, OAuthProvider> &
   Record<CredentialsProviderType, CredentialsProvider> &


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

By setting the default type for generic like `{}` we are blocking the inference of type in credentials as the whole typing is intended to do (I think so).

After that change we are able to do the following code in TS with `strict` mode enabled:

```ts
import CredentialsProvider from 'next-auth/providers/credentials';

CredentialsProvider({
  credentials: {
    email: {
      label: 'email',
      type: 'text',
    },
    password: {
      label: 'password',
      type: 'password',
    },
  },
  async authorize() {
    try {
      await fetch('/testing');

      return {
        id: '',
      }
    } catch (err) {
      return null;
    }
  },
}),
```

I'm aware that marking it as `any` is never the best solution as I'm doing in the `Provider` type. But it can get any object shape from us in that case I guess.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

Don't know if resolves the following issues so they are just marked as affected.

#2701
#2677
