### PR TITLE
fix(provider): remove extra brace from `jwks_uri`

### DIFF
--- a/src/providers/azure-ad-b2c.js
+++ b/src/providers/azure-ad-b2c.js
@@ -17,7 +17,7 @@ export default function AzureADB2C(options) {
       url: `https://${tenantName}.b2clogin.com/${tenantName}.onmicrosoft.com/${primaryUserFlow}/oauth2/v2.0/token`,
       idToken: true,
     },
-    jwks_uri: `https://${tenantName}.b2clogin.com/${tenantName}.onmicrosoft.com/${primaryUserFlow}}/discovery/v2.0/keys`,
+    jwks_uri: `https://${tenantName}.b2clogin.com/${tenantName}.onmicrosoft.com/${primaryUserFlow}/discovery/v2.0/keys`,
     profile(profile) {
       let name = ""
 


### PR DESCRIPTION
## Reasoning 💡

The Azure B2C adapter in 4.0.0-beta has an extra brace in the template literal, breaking the `jwks_uri` by default if it is not overridden using `options`.

## Checklist 🧢

~- [ ] Documentation~
- [X] Tests
- [X] Ready to be merged
