### PR TITLE
fix(provider): refactor LinkedIn provider

### DIFF
--- a/app/components/header.js
+++ b/app/components/header.js
@@ -44,7 +44,8 @@ export default function Header() {
               <span className={styles.signedInText}>
                 <small>Signed in as</small>
                 <br />
-                <strong>{session.user.email || session.user.name}</strong>
+                <strong>{session.user.email} </strong>
+                {session.user.name ? `(${session.user.name})` : null}
               </span>
               <a
                 href="/api/auth/signout"

--- a/src/providers/linkedin.js
+++ b/src/providers/linkedin.js
@@ -4,17 +4,30 @@ export default function LinkedIn(options) {
     id: "linkedin",
     name: "LinkedIn",
     type: "oauth",
-    authorization:
-      "https://www.linkedin.com/oauth/v2/authorization?scope=r_liteprofile",
+    authorization: {
+      url: "https://www.linkedin.com/oauth/v2/authorization",
+      params: { scope: "r_liteprofile r_emailaddress" },
+    },
     token: "https://www.linkedin.com/oauth/v2/accessToken",
-    userinfo:
-      "https://api.linkedin.com/v2/me?projection=(id,localizedFirstName,localizedLastName)",
-    profile(profile) {
+    userinfo: {
+      url: "https://api.linkedin.com/v2/me",
+      params: {
+        projection: `(id,localizedFirstName,localizedLastName,profilePicture(displayImage~digitalmediaAsset:playableStreams))`,
+      },
+    },
+    async profile(profile, tokens) {
+      const emailResponse = await fetch(
+        "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))",
+        { headers: { Authorization: `Bearer ${tokens.access_token}` } }
+      )
+      const emailData = await emailResponse.json()
       return {
         id: profile.id,
         name: `${profile.localizedFirstName} ${profile.localizedLastName}`,
-        email: null,
-        image: null,
+        email: emailData?.elements?.[0]?.["handle~"]?.emailAddress,
+        image:
+          profile.profilePicture?.["displayImage~"]?.elements?.[0]
+            ?.identifiers?.[0]?.identifier,
       }
     },
     options,

--- a/src/providers/linkedin.ts
+++ b/src/providers/linkedin.ts
@@ -1,5 +1,27 @@
-/** @type {import(".").OAuthProvider} */
-export default function LinkedIn(options) {
+import { OAuthConfig, OAuthUserConfig } from "."
+
+interface Identifier {
+  identifier: string
+}
+
+interface Element {
+  identifiers?: Identifier[]
+}
+
+export interface LinkedInProfile {
+  id: string
+  localizedFirstName: string
+  localizedLastName: string
+  profilePicture: {
+    "displayImage~": {
+      elements?: Element[]
+    }
+  }
+}
+
+export default function LinkedIn<
+  P extends Record<string, any> = LinkedInProfile
+>(options: OAuthUserConfig<P>): OAuthConfig<P> {
   return {
     id: "linkedin",
     name: "LinkedIn",


### PR DESCRIPTION
Fixed `linkedin` provider config to support v4

#2524, #1238

Proof after login:

![](https://i.imgur.com/LpAfGab.png)

This also adds a profile picture and e-mail by default.