### PR TITLE
feat(signin): Support passing any argument to credentials input

### DIFF
--- a/src/server/pages/signin.tsx
+++ b/src/server/pages/signin.tsx
@@ -106,11 +106,10 @@ export default function Signin({
                       <input
                         name={credential}
                         id={`input-${credential}-for-${provider.id}-provider`}
-                        type={provider.credentials[credential].type || "text"}
-                        value={provider.credentials[credential].value || ""}
                         placeholder={
                           provider.credentials[credential].placeholder || "Password"
                         }
+                        {...provider.credentials[credential]}
                       />
                     </div>
                   )


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Spreading the object into the input tag allows developers to specify any attribute for the input tag used in the builtin sign-in page, such as 'autocomplete', 'autofocus', etc.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation (https://github.com/nextauthjs/docs/pull/55)
- [x] Tests
- [x] Ready to be merged

Tested manually, by passing the attributes previously supported (e.g. type, value), new ones (e.g. autocomplete), and nonexisting ones (e.g. bla), as well as not passing anything to test the defaults.

Documentation changes will be pushed to the docs repo.

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

No behavior change.
Removed the hardcoded attributes which just set the defaults of the 'input' tag and won't cause any behavior change in case they are absence from the object.
I left the placeholder attribute, as removing it would change behavior, but maybe this one can be removed as well.

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
