### PR TITLE
fix(signin): Set default input type to text to fix CSS

### DIFF
--- a/src/server/pages/signin.tsx
+++ b/src/server/pages/signin.tsx
@@ -106,6 +106,7 @@ export default function Signin({
                       <input
                         name={credential}
                         id={`input-${credential}-for-${provider.id}-provider`}
+                        type={provider.credentials[credential].type || "text"}
                         placeholder={
                           provider.credentials[credential].placeholder || "Password"
                         }


### PR DESCRIPTION
Partially reverts c5bd99d92a4728d8ace6f41e07da02a3a94f0e15, as CSS doesn't consider type="text" the default for the input tag, so the styles break if no type is specified.

Signed-off-by: Gegham Zakaryan <zakaryan.2004@outlook.com>

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Partially reverts c5bd99d92a4728d8ace6f41e07da02a3a94f0e15.

Even though all major browsers have HTML input tag's type set to "text" by default, CSS doesn't consider this the default, and the current stylesheet won't style an input field which doesn't have the "type" attribute set.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] ~Documentation~
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
