### PR TITLE
fix: correctly set authorization url for OAuth1

### DIFF
--- a/src/server/lib/oauth/authorization-url.js
+++ b/src/server/lib/oauth/authorization-url.js
@@ -17,23 +17,16 @@ export default async function getAuthorizationUrl(req, res) {
     /** @type {import("src/providers").OAuthConfig} */
     const provider = req.options.provider
 
-    let params = {}
-
-    if (typeof provider.authorization === "string") {
-      const parsedUrl = new URL(provider.authorization)
-      const parsedParams = Object.fromEntries(parsedUrl.searchParams.entries())
-      params = { ...params, ...parsedParams }
-    } else {
-      params = { ...params, ...provider.authorization?.params }
+    const params = {
+      ...provider.authorization.params,
+      ...req.query,
     }
-
-    params = { ...params, ...req.query }
 
     // Handle OAuth v1.x
     if (provider.version?.startsWith("1.")) {
       const client = oAuth1Client(req.options)
       const tokens = await client.getOAuthRequestToken(params)
-      const url = `${provider.authorization}?${new URLSearchParams({
+      const url = `${provider.authorization.url}?${new URLSearchParams({
         oauth_token: tokens.oauth_token,
         oauth_token_secret: tokens.oauth_token_secret,
         ...tokens.params,


### PR DESCRIPTION
#2842 introduced a bug where we started normalizing the `authorization` object to always be an object internally, but the OAuth 1 flow assumed it is a string (as that's how we set it for Twitter by default, the only OAuth 1 provider we have built-in support for.)

This was pointed out in #2883, thanks to @kf106

Note: I also removed some now unnecessary code, which would parse the string form of `authorization`. This is unnecessary because of https://github.com/nextauthjs/next-auth/pull/2842/files#diff-ffb34958c6961fa2d5b709bb312692ca6e989b335b850631eb0b03b36afa586cR40-R48

Internal types will be improved in #2857 (as far as I can tell, that will convert **all** internal files to TS) to prevent issues elsewhere 