### PR TITLE
fix(providers): Refactor Line Provider

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -32,7 +32,6 @@ TWITTER_SECRET=
 
 LINE_ID=
 LINE_SECRET=
-LINE_PROVIDER=
 
 # Example configuration for a Gmail account (will need SMTP enabled)
 EMAIL_SERVER=smtps://user@gmail.com:password@smtp.gmail.com:465

--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -30,6 +30,10 @@ TWITCH_SECRET=
 TWITTER_ID=
 TWITTER_SECRET=
 
+LINE_ID=
+LINE_SECRET=
+LINE_PROVIDER=
+
 # Example configuration for a Gmail account (will need SMTP enabled)
 EMAIL_SERVER=smtps://user@gmail.com:password@smtp.gmail.com:465
 EMAIL_FROM=user@gmail.com

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -120,6 +120,7 @@ export default NextAuth({
     LineProvider({
       clientId: process.env.LINE_ID,
       clientSecret: process.env.LINE_SECRET,
+      issuer: process.env.LINE_PROVIDER
     }),
     LinkedInProvider({
       clientId: process.env.LINKEDIN_ID,

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -120,7 +120,6 @@ export default NextAuth({
     LineProvider({
       clientId: process.env.LINE_ID,
       clientSecret: process.env.LINE_SECRET,
-      issuer: process.env.LINE_PROVIDER
     }),
     LinkedInProvider({
       clientId: process.env.LINKEDIN_ID,

--- a/src/providers/line.js
+++ b/src/providers/line.js
@@ -4,16 +4,15 @@ export default function LINE(options) {
     id: "line",
     name: "LINE",
     type: "oauth",
-    authorization:
-      "https://access.line.me/oauth2/v2.1/authorize?scope=openid+profile",
-    token: "https://api.line.me/oauth2/v2.1/token",
-    userinfo: "https://api.line.me/v2/profile",
+    authorization: { params: { scope: "openid profile" } },
+    idToken: true,
+    wellKnown: `${options.issuer}/.well-known/openid-configuration`,
     profile(profile) {
       return {
-        id: profile.userId,
-        name: profile.displayName,
+        id: profile.sub,
+        name: profile.name,
         email: null,
-        image: profile.pictureUrl,
+        image: profile.picture,
       }
     },
     options,

--- a/src/providers/line.js
+++ b/src/providers/line.js
@@ -6,12 +6,12 @@ export default function LINE(options) {
     type: "oauth",
     authorization: { params: { scope: "openid profile" } },
     idToken: true,
-    wellKnown: `${options.issuer}/.well-known/openid-configuration`,
+    wellKnown: "https://access.line.me/.well-known/openid-configuration",
     profile(profile) {
       return {
         id: profile.sub,
         name: profile.name,
-        email: null,
+        email: profile.email,
         image: profile.picture,
       }
     },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡
Refactor Line Provider. This PR uses the `wellKnown` option since LINE is not supporting `userinfo`. See: https://access.line.me/.well-known/openid-configuration
The code still not working; I'm kind of getting stuck at this error:
```
[next-auth][error][OAUTH_CALLBACK_ERROR] 
https://next-auth.js.org/errors#oauth_callback_error unexpected JWT alg received, expected RS256, got: HS256 {
  error: {
    message: 'unexpected JWT alg received, expected RS256, got: HS256',
    stack: 'RPError: unexpected JWT alg received, expected RS256, got: HS256\n' +
      '    at Client.validateJWT (/Users/lw70972/repos/github/next-auth/node_modules/openid-client/lib/client.js:814:13)\n' +
      '    at Client.validateIdToken (/Users/lw70972/repos/github/next-auth/node_modules/openid-client/lib/client.js:693:60)\n' +
      '    at Client.callback (/Users/lw70972/repos/github/next-auth/node_modules/openid-client/lib/client.js:469:18)\n' +
      '    at runMicrotasks (<anonymous>)\n' +
      '    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n' +
      '    at async oAuthCallback (webpack-internal:///../src/server/lib/oauth/callback.ts:101:16)\n' +
      '    at async Module.callback (webpack-internal:///../src/server/routes/callback.js:52:11)\n' +
      '    at async NextAuthHandler (webpack-internal:///../src/server/index.ts:186:18)\n' +
      '    at async eval (webpack-internal:///../src/server/index.ts:273:32)\n' +
      '    at async Object.apiResolver (/Users/lw70972/repos/github/next-auth/app/node_modules/next/dist/server/api-utils.js:101:9)',
    name: 'RPError'
  },
  providerId: 'line',
  message: 'unexpected JWT alg received, expected RS256, got: HS256'
}
```
I can get it working by making the following changes in `src/server/lib/oauth/client.ts`:
```ts
  const client = new issuer.Client(
    {
      client_id: provider.clientId,
      client_secret: provider.clientSecret,
      redirect_uris: [provider.callbackUrl],
      ...provider.client,
      id_token_signed_response_alg: 'HS256' // -> Add this line.
    },
    provider.jwks
  )
```
@balazsorban44 Can you help on how to fix/do this properly? 
## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation https://github.com/nextauthjs/docs/pull/68
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟
https://github.com/nextauthjs/next-auth/issues/2524
<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
Update: For future references, here is the working configuration for me:
```ts
LineProvider({
  clientId: process.env.LINE_ID,
  clientSecret: process.env.LINE_SECRET,
  client: {
    id_token_signed_response_alg: "HS256"
  }
}),
```