### PR TITLE
Fix | JWT Options | Use plain object instead for string for `signingKey`

### DIFF
--- a/src/lib/jwt.js
+++ b/src/lib/jwt.js
@@ -31,7 +31,7 @@ export async function encode({
 } = {}) {
   // Signing Key
   const _signingKey = signingKey
-    ? jose.JWK.asKey(JSON.parse(signingKey))
+    ? jose.JWK.asKey(signingKey)
     : getDerivedSigningKey(secret)
 
   // Sign token

--- a/types/jwt.d.ts
+++ b/types/jwt.d.ts
@@ -32,7 +32,12 @@ export interface JWTDecodeParams {
   token?: string
   maxAge?: number
   secret: string | Buffer
-  signingKey?: string
+  signingKey?: {
+    kty: string;
+    kid: string;
+    alg: string;
+    k: string;
+  };
   verificationKey?: string
   verificationOptions?: JoseJWT.VerifyOptions<false>
   encryptionKey?: string


### PR DESCRIPTION
Currently as pointed out in the docs for JWT options:
https://next-auth.js.org/configuration/options#json-web-token-options

An object must be provided to the `signingKey` JWT options object.
But actually a `string` is required by the types definition.

In order to make it fit the documentation I'm replacing the `string`
type with the same structure provided in the docs.