### PR TITLE
fix(providers): add default `id_token_signed_response_alg` to LINE

### DIFF
--- a/src/providers/line.js
+++ b/src/providers/line.js
@@ -1,5 +1,6 @@
 /** @type {import(".").OAuthProvider} */
 export default function LINE(options) {
+  const { client, ...rest } = options;
   return {
     id: "line",
     name: "LINE",
@@ -15,6 +16,10 @@ export default function LINE(options) {
         image: profile.picture,
       }
     },
-    options,
+    client: {
+      id_token_signed_response_alg: "HS256",
+      ...client
+    },
+    ...rest,
   }
 }

--- a/src/providers/line.ts
+++ b/src/providers/line.ts
@@ -1,6 +1,20 @@
-/** @type {import(".").OAuthProvider} */
-export default function LINE(options) {
-  const { client, ...rest } = options;
+import { OAuthConfig, OAuthUserConfig } from "."
+
+export interface LineProfile {
+    iss: string;
+    sub: string;
+    aud: string;
+    exp: number;
+    iat: number;
+    amr: string[];
+    name: string;
+    picture: string;
+    user: any;
+}
+
+export default function LINE<
+  P extends Record<string, any> = LineProfile
+>(options: OAuthUserConfig<P>): OAuthConfig<P> {
   return {
     id: "line",
     name: "LINE",
@@ -18,8 +32,7 @@ export default function LINE(options) {
     },
     client: {
       id_token_signed_response_alg: "HS256",
-      ...client
     },
-    ...rest,
+    options
   }
 }


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Line uses `HS256` in `id_token_signed_response_alg` by default. This means for now, developers have to set this value by themselves when setting up for Line Provider. Adding this to `next-auth` default config helps simplify the setup.

## Checklist 🧢

- ~Documentation~ 
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟
Fixes #2935
Previous issue: #2917
