### PR TITLE
refactor: use universal modules in `next-auth/jwt`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
-        "futoin-hkdf": "^1.4.2",
+        "@panva/hkdf": "^1.0.0",
         "jose": "^4.1.2",
         "oauth": "^0.9.15",
         "openid-client": "^5.0.1",
@@ -2961,6 +2961,14 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
       "dev": true
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.0.tgz",
+      "integrity": "sha512-xPlCwVdEGjGObIn+s1jV0WNDm2fRBtf9j/F+TlQ+AgrkJTOLLK6mQ8iVqRZ6m/cnSdN+sbtp1GoXfWwqruHjTQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -6876,14 +6884,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "node_modules/futoin-hkdf": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.4.2.tgz",
-      "integrity": "sha512-2BggwLEJOTfXzKq4Tl2bIT37p0IqqKkblH4e0cMp2sXTdmwg/ADBKMxvxaEytYYcgdxgng8+acsi3WgMVUl6CQ==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -16885,6 +16885,11 @@
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
       "dev": true
     },
+    "@panva/hkdf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.0.tgz",
+      "integrity": "sha512-xPlCwVdEGjGObIn+s1jV0WNDm2fRBtf9j/F+TlQ+AgrkJTOLLK6mQ8iVqRZ6m/cnSdN+sbtp1GoXfWwqruHjTQ=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -19895,11 +19900,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "futoin-hkdf": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.4.2.tgz",
-      "integrity": "sha512-2BggwLEJOTfXzKq4Tl2bIT37p0IqqKkblH4e0cMp2sXTdmwg/ADBKMxvxaEytYYcgdxgng8+acsi3WgMVUl6CQ=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "futoin-hkdf": "^1.4.2",
+    "@panva/hkdf": "^1.0.0",
     "jose": "^4.1.2",
     "oauth": "^0.9.15",
     "openid-client": "^5.0.1",


### PR DESCRIPTION
This updates the `src/jwt/index.ts` module to only use universal modules for uuid and hkdf (in addition to already universal jose) to get around bundle issues and sizes towards #3037