### PR TITLE
fix: check url starts with http

### DIFF
--- a/src/lib/parse-url.ts
+++ b/src/lib/parse-url.ts
@@ -13,6 +13,11 @@ export interface InternalUrl {
 
 export default function parseUrl(url?: string): InternalUrl {
   const defaultUrl = new URL("http://localhost:3000/api/auth")
+
+  if (url && !url.startsWith("http")) {
+    url = `https://${url}`
+  }
+
   const _url = new URL(url ?? defaultUrl)
   const path = (_url.pathname === "/" ? defaultUrl.pathname : _url.pathname)
     // Remove trailing slash


### PR DESCRIPTION
## Reasoning 💡

If the url does not start with 'http', prefix it with 'https://' to be in compliance with the URL API

## Affected issues 🎟

Fixes #3074
