### PR TITLE
added generateVerificationToken to EmailConfig type for Email Provider

### DIFF
--- a/types/providers.d.ts
+++ b/types/providers.d.ts
@@ -151,6 +151,7 @@ export interface EmailConfig extends CommonProviderOptions {
    */
   maxAge?: number
   sendVerificationRequest: SendVerificationRequest
+  generateVerificationToken: () => String
 }
 
 export type EmailProvider = (options: Partial<EmailConfig>) => EmailConfig

--- a/types/tests/providers.test.ts
+++ b/types/tests/providers.test.ts
@@ -19,6 +19,20 @@ Providers.Email({
   from: "path/from",
 })
 
+// $ExpectType EmailConfig
+Providers.Email({
+  server: {
+    host: "host",
+    port: 123,
+    auth: {
+      user: "foo",
+      pass: "123",
+    },
+  },
+  from: "path/from",
+  generateVerificationToken: () => { return 'abcd' },
+})
+
 // $ExpectType CredentialsConfig<{ username: { label: string; type: string; }; password: { label: string; type: string; }; }>
 Providers.Credentials({
   id: "login",


### PR DESCRIPTION
## Reasoning 💡
The type file `providers.d.ts` is missing a definition for `generateVerificationToken`. However, in `src/server/lib/signin/email.js`, there is a check to see if the `EmailConfig` object has defined the `generateVerificationToken` field, and if so it will use the custom function. The only way to override `generateVerificationToken` in TypeScript is to use `@ts-ignore`.

## Checklist 🧢
- Added `generateVerificationToken: () => String` to the `EmailConfig` type in `providers.d.ts`.

- [x] Documentation (the documentation already shows this as working in .js, extends to working in .ts now)
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

Closes #3080 
