### PR TITLE
feat: allow relative redirects

### DIFF
--- a/src/core/lib/default-callbacks.ts
+++ b/src/core/lib/default-callbacks.ts
@@ -6,6 +6,7 @@ export const defaultCallbacks: CallbacksOptions = {
   },
   redirect({ url, baseUrl }) {
     if (url.startsWith(baseUrl)) return url
+    else if (url.startsWith("/")) return new URL(url, baseUrl).toString()
     return baseUrl
   },
   session({ session }) {


### PR DESCRIPTION
The `redirect` callback (https://next-auth.js.org/configuration/callbacks#redirect-callback) allows the user to control what kind of URLs can the user be redirected to in the different login flows. We generally allowed if the redirect URL started with the site's `baseUrl`, but for convenience, if the user provides a relative path `/some/page`, we can prepend it with `baseUrl` for convenience.

NOTE: The `baseUrl` prefix is important because the server needs the full URL to be able to redirect (using `Location` header under the hood.)

Fixes #3139

Docs update: https://github.com/nextauthjs/docs/pull/101