### PR TITLE
fix: use `error` query param if set

### DIFF
--- a/src/next/index.ts
+++ b/src/next/index.ts
@@ -44,7 +44,7 @@ async function NextAuthNextHandler(
       method: req.method ?? "GET",
       action: req.query.nextauth[0] as NextAuthAction,
       providerId: req.query.nextauth[1],
-      error: req.query.nextauth[1],
+      error: (req.query.error as string | undefined) ?? req.query.nextauth[1],
     },
     options,
   })


### PR DESCRIPTION
If a custom error page was defined, the `error` query param wasn't taken into account.

Fixes #3106 

See #3106 for more context. I now have tested this locally with a custom error page.