### PR TITLE
refactor: decouple CSRF-state

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -61,8 +61,6 @@ export async function NextAuthHandler<
     req.cookies?.[options.cookies.sessionToken.name] ||
     req.headers?.Authorization?.replace("Bearer ", "")
 
-  const codeVerifier = req.cookies?.[options.cookies.pkceCodeVerifier.name]
-
   if (req.method === "GET") {
     const render = renderPage({ options, query: req.query, cookies })
     const { pages } = options
@@ -98,9 +96,9 @@ export async function NextAuthHandler<
             query: req.query,
             method: req.method,
             headers: req.headers,
+            cookies: req.cookies,
             options,
             sessionToken,
-            codeVerifier,
           })
           if (callback.cookies) cookies.push(...callback.cookies)
           return { ...callback, cookies }
@@ -180,9 +178,9 @@ export async function NextAuthHandler<
             query: req.query,
             method: req.method,
             headers: req.headers,
+            cookies: req.cookies,
             options,
             sessionToken,
-            codeVerifier,
           })
           if (callback.cookies) cookies.push(...callback.cookies)
           return { ...callback, cookies }

--- a/src/core/lib/cookie.ts
+++ b/src/core/lib/cookie.ts
@@ -202,6 +202,15 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
         secure: useSecureCookies,
       },
     },
+    state: {
+      name: `${cookiePrefix}next-auth.state`,
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: useSecureCookies,
+      },
+    },
   }
 }
 

--- a/src/core/routes/callback.ts
+++ b/src/core/routes/callback.ts
@@ -13,11 +13,10 @@ export default async function callback(params: {
   method: IncomingRequest["method"]
   body: IncomingRequest["body"]
   headers: IncomingRequest["headers"]
+  cookies: IncomingRequest["cookies"]
   sessionToken?: string
-  codeVerifier?: string
 }): Promise<OutgoingResponse> {
-  const { options, query, body, method, headers, sessionToken, codeVerifier } =
-    params
+  const { options, query, body, method, headers, sessionToken } = params
   const {
     provider,
     adapter,
@@ -45,7 +44,7 @@ export default async function callback(params: {
         body,
         method,
         options,
-        codeVerifier,
+        cookies: params.cookies,
       })
 
       if (oauthCookies) cookies.push(...oauthCookies)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -355,6 +355,7 @@ export interface CookiesOptions {
   callbackUrl: CookieOption
   csrfToken: CookieOption
   pkceCodeVerifier: CookieOption
+  state: CookieOption
 }
 
 /**


### PR DESCRIPTION
Instead of calculating the state value from the CSRF token, we create a unique value for every flow, save it in a cookie, and delete it after usage, much like with the PKCE flow.

This PR introduces a new cookie called `next-auth.state`.

The default expiry is 15 minutes.