### PR TITLE
feat: rename session strategy

### DIFF
--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -85,7 +85,8 @@ export async function init({
     providers,
     // Session options
     session: {
-      jwt: !userOptions.adapter, // If no adapter specified, force use of JSON Web Tokens (stateless)
+      // If no adapter specified, force use of JSON Web Tokens (stateless)
+      strategy: userOptions.adapter ? "database" : "jwt",
       maxAge,
       updateAge: 24 * 60 * 60,
       ...userOptions.session,

--- a/src/core/lib/callback-handler.ts
+++ b/src/core/lib/callback-handler.ts
@@ -36,7 +36,7 @@ export default async function callbackHandler(params: {
     adapter,
     jwt,
     events,
-    session: { jwt: useJwtSession },
+    session: { strategy: sessionStrategy },
   } = options
 
   // If no adapter is configured then we don't have a database and cannot
@@ -60,6 +60,8 @@ export default async function callbackHandler(params: {
   let session: AdapterSession | JWT | null = null
   let user: AdapterUser | null = null
   let isNewUser = false
+
+  const useJwtSession = sessionStrategy === "jwt"
 
   if (sessionToken) {
     if (useJwtSession) {

--- a/src/core/lib/cookie.ts
+++ b/src/core/lib/cookie.ts
@@ -1,8 +1,8 @@
 // REVIEW: Is there any way to defer two types of strings?
-import { NextAuthResponse } from "../../lib/types"
-import { CookiesOptions } from "../.."
-import { CookieOption } from "../types"
-import { ServerResponse } from "http"
+import type { NextAuthResponse } from "../../lib/types"
+import type { CookiesOptions } from "../.."
+import type { CookieOption, SessionStrategy } from "../types"
+import type { ServerResponse } from "http"
 
 /** Stringified form of `JWT`. Extract the content with `jwt.decode` */
 export type JWTString = string
@@ -12,8 +12,11 @@ export type SetCookieOptions = Partial<CookieOption["options"]> & {
   encode?: (val: unknown) => string
 }
 
-/** If `options.session.jwt` is set to `true`, this is a stringified `JWT`. In case of a database persisted session, this is the `sessionToken` of the session in the database.. */
-export type SessionToken<T extends "jwt" | "db" = "jwt"> = T extends "jwt"
+/**
+ * If `options.session.strategy` is set to `jwt`, this is a stringified `JWT`.
+ * In case of `strategy: "database"`, this is the `sessionToken` of the session in the database.
+ */
+export type SessionToken<T extends SessionStrategy = "jwt"> = T extends "jwt"
   ? JWTString
   : string
 

--- a/src/core/routes/callback.ts
+++ b/src/core/routes/callback.ts
@@ -27,11 +27,13 @@ export default async function callback(params: {
     jwt,
     events,
     callbacks,
-    session: { jwt: useJwtSession, maxAge: sessionMaxAge },
+    session: { strategy: sessionStrategy, maxAge: sessionMaxAge },
     logger,
   } = options
 
   const cookies: cookie.Cookie[] = []
+
+  const useJwtSession = sessionStrategy === "jwt"
 
   if (provider.type === "oauth") {
     try {

--- a/src/core/routes/signout.ts
+++ b/src/core/routes/signout.ts
@@ -9,15 +9,14 @@ export default async function signout(params: {
   sessionToken?: string
 }): Promise<OutgoingResponse> {
   const { options, sessionToken } = params
-  const { adapter, cookies, events, jwt, callbackUrl, logger } = options
+  const { adapter, cookies, events, jwt, callbackUrl, logger, session } =
+    options
 
   if (!sessionToken) {
     return { redirect: callbackUrl }
   }
 
-  const useJwtSession = options.session.jwt
-
-  if (useJwtSession) {
+  if (session.strategy === "jwt") {
     // Dispatch signout event
     try {
       const decodedJwt = await jwt.decode({ ...jwt, token: sessionToken })

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -429,9 +429,23 @@ export interface DefaultSession extends Record<string, unknown> {
  */
 export interface Session extends Record<string, unknown>, DefaultSession {}
 
+export type SessionStrategy = "jwt" | "database"
+
 /** [Documentation](https://next-auth.js.org/configuration/options#session) */
 export interface SessionOptions {
-  jwt: boolean
+  /**
+   * Choose how you want to save the user session.
+   * The default is `"jwt"`, an encrypted JWT (JWE) in the session cookie.
+   *
+   * If you use an `adapter` however, we default it to `"database"` instead.
+   * You can still force a JWT session by explicitly defining `"jwt"`.
+   *
+   * When using `"database"`, the session cookie will only contain a `sessionToken` value,
+   * which is used to look up the session in the database.
+   *
+   * [Documentation](https://next-auth.js.org/configuration/options#session) | [Adapter](https://next-auth.js.org/configuration/options#adapter) | [About JSON Web Tokens](https://next-auth.js.org/faq#json-web-tokens)
+   */
+  strategy: SessionStrategy
   /**
    * Relative time from now in seconds when to expire the session
    * @default 2592000 // 30 days
@@ -463,13 +477,3 @@ export interface DefaultUser {
  * [`profile` OAuth provider callback](https://next-auth.js.org/configuration/providers#using-a-custom-provider)
  */
 export interface User extends Record<string, unknown>, DefaultUser {}
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace NodeJS {
-    interface ProcessEnv {
-      NEXTAUTH_URL?: string
-      VERCEL_URL?: string
-    }
-  }
-}

--- a/src/next/index.ts
+++ b/src/next/index.ts
@@ -121,3 +121,13 @@ export async function getServerSession(
   if (body && Object.keys(body).length) return body as Session
   return null
 }
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace NodeJS {
+    interface ProcessEnv {
+      NEXTAUTH_URL?: string
+      VERCEL_URL?: string
+    }
+  }
+}


### PR DESCRIPTION
This PR makes it hopefully more clear how the user can use the different session strategies.

1. No adapter, `strategy: "jwt"`: This is the default. The session is saved in a cookie and never persisted anywhere.
2. With Adapter, `strategy: "database"`: If an Adapter is defined, this will be the implicit setting. No user config is needed.
3. With Adapter, `strategy: "jwt"`: The user can explicitly instruct `next-auth` to use JWT even if a database is available. This can result in faster lookups in compromise of lowered security. Read more about: https://next-auth.js.org/faq#json-web-tokens

Docs: https://github.com/nextauthjs/docs/pull/105