### PR TITLE
fix(providers): set 42 default scope

### DIFF
--- a/src/providers/42.js
+++ b/src/providers/42.js
@@ -4,7 +4,10 @@ export default function FortyTwo(options) {
     id: "42-school",
     name: "42 School",
     type: "oauth",
-    authorization: "https://api.intra.42.fr/oauth/authorize",
+    authorization: {
+      url: "https://api.intra.42.fr/oauth/authorize",
+      params: { scope: "public" },
+    },
     token: "https://api.intra.42.fr/oauth/token",
     userinfo: "https://api.intra.42.fr/v2/me",
     profile(profile) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡
Specifying the scope for the 42 provider as `public`, since it get defaulted to `openid` which is a invalid scope for 42 api.
Default has been set to `public` not an empty string which is mandatory for all 42 api apps.
<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~- [ ] Documentation~
~- [ ] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟
NONE
<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
