### PR TITLE
fix: error message passed to custom page

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -203,7 +203,7 @@ async function NextAuthHandler(req, res, userOptions) {
             return res.redirect(
               `${pages.error}${
                 pages.error.includes("?") ? "&" : "?"
-              }error=${error}`
+              }error=${req.query.error}`
             )
           }
 


### PR DESCRIPTION


## Reasoning 💡

I encountered a bug when using a custom page: the `error` querystring param is always undefined. This is a potential fix.

Steps to reproduce the bug on main:

1. set this config in `[...nextauth].ts` file like:

```ts
import { PrismaAdapter } from "@next-auth/prisma-adapter";
import NextAuth from "next-auth";
import EmailAuthProvider from "next-auth/providers/email";
import { PrismaClient } from "@prisma/client";

export default NextAuth({
  adapter: PrismaAdapter(new PrismaClient()),
  callbacks: {
    signIn({ user }) {
      if (typeof user.email !== "string") return false;
      return (user.email.endsWith("lycos.fr"))
    },
  },
  pages: {
    error: "/auth/error",
  },
  providers: [
    EmailAuthProvider({
      from: process.env.EMAIL_FROM,
      server: process.env.EMAIL_SERVER
    }),
  ],
});
```

2. set EMAIL_FROM and EMAIL_SERVER to variables that you can use (maybe use [`maildev`](https://github.com/maildev/maildev))
2. try to login using the email provider and an email address different from `*@lycos.fr`


## Checklist 🧢

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## Affected issues 🎟
