### PR TITLE
feat(providers): ensure GitHub provider always gives an email

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -6,7 +6,31 @@ export default function GitHub(options) {
     type: "oauth",
     authorization: "https://github.com/login/oauth/authorize?scope=read:user+user:email",
     token: "https://github.com/login/oauth/access_token",
-    userinfo: "https://api.github.com/user",
+    userinfo: {
+      url: "https://api.github.com/user",
+      request: async ({ client, tokens }) => {
+        // Get base profile
+        const profile = await client.userinfo(tokens)
+
+        // If user has email hidden, get their primary email from the GitHub API
+        if (!profile.email) {
+          const emails = await (
+            await fetch("https://api.github.com/user/emails", {
+              headers: { Authorization: `token ${tokens.access_token}` },
+            })
+          ).json()
+
+          if (emails?.length > 0) {
+            // Get primary email
+            profile.email = emails.find(email => email.primary)?.email;
+            // And if for some reason it doesn't exist, just use the first
+            if (!profile.email) profile.email = emails[0].email;
+          }
+        }
+
+        return profile
+      },
+    },
     profile(profile) {
       return {
         id: profile.id.toString(),

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -8,7 +8,7 @@ export default function GitHub(options) {
     token: "https://github.com/login/oauth/access_token",
     userinfo: {
       url: "https://api.github.com/user",
-      request: async ({ client, tokens }) => {
+      async request({ client, tokens }) {
         // Get base profile
         const profile = await client.userinfo(tokens)
 


### PR DESCRIPTION
## Reasoning 💡

Currently, if a GitHub user doesn't have an email public, it's not given in their profile. This is rather meaningless -- since email scope is requested, all you have to do is make another request to GitHub in order to get it. This functionality might as well be built directly into Next Auth -- and that's what this PR does. 

#374 shows that this is a common issue, and there are several workarounds listed in the issue. It was said that this functionality would be included in v4, so I've taken the initiative to get it done, since my organization would benefit greatly from it being built in directly.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~- [ ] Documentation~ Note that [documentation](https://next-auth.js.org/v3/providers/github) will have to be updated when this is merged in.
~- [ ] Tests~
- [x] Ready to be merged

## Affected issues 🎟
#2524 
