### PR TITLE
fix(providers): forward missing data to token request of Instagram

### DIFF
--- a/src/providers/instagram.js
+++ b/src/providers/instagram.js
@@ -32,7 +32,30 @@ export default function Instagram(options) {
     type: "oauth",
     authorization:
       "https://api.instagram.com/oauth/authorize?scope=user_profile",
-    token: "https://api.instagram.com/oauth/access_token",
+    token: {
+      url: "https://api.instagram.com/oauth/access_token",
+      async request(context) {
+        const {
+          provider,
+          params: { code },
+        } = context
+        const body = new URLSearchParams([
+          ["grant_type", "authorization_code"],
+          ["code", code],
+          ["client_id", provider.clientId],
+          ["client_secret", provider.clientSecret],
+          ["redirect_uri", provider.callbackUrl],
+        ])
+        const response = await (
+          await fetch(provider.token.url, {
+            method: "POST",
+            body,
+          })
+        ).json()
+        const { access_token } = response
+        return { tokens: { access_token } }
+      },
+    },
     userinfo:
       "https://graph.instagram.com/me?fields=id,username,account_type,name",
     async profile(profile) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

In the Instagram provider, the token request was missing `client_id` and `client_secret` in the body ([reference](https://developers.facebook.com/docs/instagram-basic-display-api/getting-started#step-5--exchange-the-code-for-a-token)), resulting in a bad request error as you see below:

<img width="651" alt="image" src="https://user-images.githubusercontent.com/1501013/144925385-f36190f0-891c-40c0-a7b7-c87ceedc61cc.png">

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1501013/144925722-7f1277a5-1de1-4eba-a56a-2e1d30af862c.png">

I tried to fix using `params` object as suggested in the documentation, but the error persists.

```javascript
    token: {
      url: "https://api.instagram.com/oauth/access_token",
      params: {
        client_id: options.clientId,
        client_secret: options.clientSecret,
      },
    }
```

Is this request GET or POST? When I use fetch + POST without these two data, Instagram API returns an error informing the lack of these data instead of just Bad Request.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
