### PR TITLE
fix: use `VERCEL_URL` by default for `secureCookie`

### DIFF
--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -70,10 +70,8 @@ export async function getToken<R extends boolean = false>(
 ): Promise<R extends true ? string : JWT | null> {
   const {
     req,
-    secureCookie = !(
-      !process.env.NEXTAUTH_URL ||
-      process.env.NEXTAUTH_URL.startsWith("http://")
-    ),
+    secureCookie = process.env.NEXTAUTH_URL?.startsWith("https://") ??
+      !!process.env.VERCEL_URL,
     cookieName = secureCookie
       ? "__Secure-next-auth.session-token"
       : "next-auth.session-token",


### PR DESCRIPTION
Addresses https://github.com/nextauthjs/next-auth/issues/3037#issuecomment-988899503

Credit to @cathykc who originally created a PR for this at #1672