### PR TITLE
[discussion] Add support for anonymous sessions

### DIFF
--- a/src/jwt/types.ts
+++ b/src/jwt/types.ts
@@ -45,6 +45,14 @@ export interface JWTOptions {
   encode: (params: JWTEncodeParams) => Awaitable<string>
   /** Override this method to control the NextAuth.js issued JWT decoding. */
   decode: (params: JWTDecodeParams) => Awaitable<JWT | null>
+  /**
+   * When enabled, generate a JWT when the session is first established. By default
+   * this will only happen on sign in.
+   * 
+   * For example e-commerce style sites where anonymous tokens are generated on the
+   * first visit and then upgraded to logged in tokens on sign in.
+   */
+   anonymousSessions?: boolean
 }
 
 export type Secret = string | Buffer


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Some sites, especially e-commerce, use anonymous tokens to support actions for users that are not logged in. These are then exchanged when the user logs in. See #568 for discussion.

At the moment, NextAuth has no notion of an anonymous session. As part of a poc for adopting the library, I've had a look at the smallest possible change to add it. Whilst we can obtain these tokens outside of the library, it simplifies the design of the poc quite a bit.

<!-- What changes are being made? What feature/bug is being fixed here? -->

I have modified the `session` API route to invoke the `jwt` callback if no session cookie is already present. In this case, `token` will be empty and `user`, `profile` etc undefined. The callback can then modify the token, in our case adding an anonymous access token.

I've added an `anonymousSession` setting under `jwt` to opt in, as this changes behaviour.

This PR is not ready to merge but I'd like to raise it early and start a discussion about whether this feature is right for NextAuth generally and if this is the right way to implement it. I'm more than happy to take on any additional work to refine the implementation :)

I've already got a few questions:

- Is it OK to generate a token on the `GET session` API route?
  - I'm slightly worried about CSRF implications with the current design funnelling it through the existing JWT callback
  - In our case the worst an attacker could do is generate a new anonymous token but that's specific to our callback
  - Perhaps there should be an additional `anonSession` API route that the client calls, passing a CSRF token?
- Should the anon token callback be separate for clarity?
  - We could potentially avoid the setting entirely and only set the anonymous session if the callback is defined

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #568

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
