### PR TITLE
fix: add idToken true default to Okta provider (#3383)

### DIFF
--- a/src/providers/okta.ts
+++ b/src/providers/okta.ts
@@ -43,6 +43,7 @@ export default function Okta<P extends Record<string, any> = OktaProfile>(
     type: "oauth",
     wellKnown: `${options.issuer}/.well-known/openid-configuration`,
     authorization: { params: { scope: "openid email profile" } },
+    idToken: true,
     profile(profile) {
       return {
         id: profile.sub,


### PR DESCRIPTION
## Reasoning 💡

Adds `idToken: true` to the default config Okta provider

## Checklist 🧢

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

Fixes #3383 


