### PR TITLE
fix(providers): token url option added for Keycloak

### DIFF
--- a/src/providers/keycloak.ts
+++ b/src/providers/keycloak.ts
@@ -31,6 +31,7 @@ export default function Keycloak<
     id: "keycloak",
     name: "Keycloak",
     wellKnown: `${options.issuer}/.well-known/openid-configuration`,
+    token: `${options.token}/protocol/openid-connect/token`,
     type: "oauth",
     authorization: { params: { scope: "openid email profile" } },
     checks: ["pkce", "state"],


### PR DESCRIPTION
A token url option added to get access_token for Keycloak Provider

## Reasoning 💡

Keycloak Provider now has a token option to specify access_token url

## Checklist 🧢
- [ x] Documentation
- [ x] Tests
- [ x] Ready to be merged