### PR TITLE
feat(providers): add support to Twitter OAuth 2.0

### DIFF
--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,9 @@ import EmailProvider from "next-auth/providers/email"
 import GitHubProvider from "next-auth/providers/github"
 import Auth0Provider from "next-auth/providers/auth0"
 import KeycloakProvider from "next-auth/providers/keycloak"
-import TwitterProvider from "next-auth/providers/twitter"
+import TwitterProvider, {
+  TwitterLegacy as TwitterLegacyProvider,
+} from "next-auth/providers/twitter"
 import CredentialsProvider from "next-auth/providers/credentials"
 import IDS4Provider from "next-auth/providers/identity-server4"
 import Twitch from "next-auth/providers/twitch"
@@ -71,11 +73,17 @@ export const authOptions: NextAuthOptions = {
       },
     }),
     // OAuth 1
+    // TwitterLegacyProvider({
+    //   clientId: process.env.TWITTER_LEGACY_ID,
+    //   clientSecret: process.env.TWITTER_LEGACY_SECRET,
+    // }),
+    // OAuth 2 / OIDC
     TwitterProvider({
+      // Opt-in to the new Twitter API for now. Should be default in the future.
+      version: "2.0",
       clientId: process.env.TWITTER_ID,
       clientSecret: process.env.TWITTER_SECRET,
     }),
-    // OAuth 2 / OIDC
     GitHubProvider({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
@@ -179,7 +187,7 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   secret: process.env.SECRET,
-  debug: true,
+  debug: false,
   theme: {
     colorScheme: "auto",
     logo: "https://next-auth.js.org/img/logo/logo-sm.png",

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -187,7 +187,7 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   secret: process.env.SECRET,
-  debug: false,
+  debug: true,
   theme: {
     colorScheme: "auto",
     logo: "https://next-auth.js.org/img/logo/logo-sm.png",

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -123,6 +123,9 @@ export function TwitterLegacy<
   }
 }
 
+/**
+ * [Documentation](https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me)
+ */
 export interface TwitterProfile {
   data: {
     id: string

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -180,17 +180,11 @@ export default function Twitter<
     type: "oauth",
     authorization: {
       url: "https://twitter.com/i/oauth2/authorize",
-      // tweet.read should probably not be necessary for the default userinfo endpoint.
-      // We only need the following by default: name, id, image and email.
       params: { scope: "users.read tweet.read offline.access" },
     },
     token: {
       url: "https://api.twitter.com/2/oauth2/token",
-
-      // TODO: Get rid of the `request` method, if possible.
-      // client_id should be optional when authenticating a confidential client
-      // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1
-      // https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
+      // TODO: Remove this
       async request({ client, params, checks, provider }) {
         const response = await client.oauthCallback(
           provider.callbackUrl,
@@ -205,12 +199,11 @@ export default function Twitter<
       url: "https://api.twitter.com/2/users/me",
       params: { "user.fields": "profile_image_url" },
     },
-
     profile({ data }) {
       return {
         id: data.id,
         name: data.name,
-        // TODO: Figure out how to get user's e-mail
+        // NOTE: E-mail is currently unsupported by OAuth 2 Twitter.
         email: null,
         image: data.profile_image_url,
       }

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -181,7 +181,7 @@ export default function Twitter<
     authorization: {
       url: "https://twitter.com/i/oauth2/authorize",
       // tweet.read should probably not be necessary for the default userinfo endpoint.
-      // We only need info this info: name, id, image and email.
+      // We only need the following by default: name, id, image and email.
       params: { scope: "users.read tweet.read offline.access" },
     },
     token: {
@@ -207,8 +207,6 @@ export default function Twitter<
     },
 
     profile({ data }) {
-      console.log(data)
-
       return {
         id: data.id,
         name: data.name,

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -166,49 +166,54 @@ export interface TwitterProfile {
   }
 }
 
+let warned = false
 export default function Twitter<
   P extends Record<string, any> = TwitterLegacyProfile | TwitterProfile
 >(options: OAuthUserConfig<P>): OAuthConfig<P> {
-  if (!options.version || options.version === "1.0A") {
-    console.warn("Using Twitter with OAuth 1.0. OAuth 2.0 is recommended.")
-    return TwitterLegacy(options)
-  }
-  return {
-    id: "twitter",
-    name: "Twitter",
-    version: "2.0",
-    type: "oauth",
-    authorization: {
-      url: "https://twitter.com/i/oauth2/authorize",
-      params: { scope: "users.read tweet.read offline.access" },
-    },
-    token: {
-      url: "https://api.twitter.com/2/oauth2/token",
-      // TODO: Remove this
-      async request({ client, params, checks, provider }) {
-        const response = await client.oauthCallback(
-          provider.callbackUrl,
-          params,
-          checks,
-          { exchangeBody: { client_id: options.clientId } }
-        )
-        return { tokens: response }
+  if (!warned && options.version === "2.0") {
+    warned = true
+    console.warn(
+      "Opted-in to Twitter OAuth 2.0. See the docs https://next-auth.js.org/providers/twitter#oauth-2"
+    )
+    return {
+      id: "twitter",
+      name: "Twitter",
+      version: "2.0",
+      type: "oauth",
+      authorization: {
+        url: "https://twitter.com/i/oauth2/authorize",
+        params: { scope: "users.read tweet.read offline.access" },
       },
-    },
-    userinfo: {
-      url: "https://api.twitter.com/2/users/me",
-      params: { "user.fields": "profile_image_url" },
-    },
-    profile({ data }) {
-      return {
-        id: data.id,
-        name: data.name,
-        // NOTE: E-mail is currently unsupported by OAuth 2 Twitter.
-        email: null,
-        image: data.profile_image_url,
-      }
-    },
-    checks: ["pkce", "state"],
-    options,
+      token: {
+        url: "https://api.twitter.com/2/oauth2/token",
+        // TODO: Remove this
+        async request({ client, params, checks, provider }) {
+          const response = await client.oauthCallback(
+            provider.callbackUrl,
+            params,
+            checks,
+            { exchangeBody: { client_id: options.clientId } }
+          )
+          return { tokens: response }
+        },
+      },
+      userinfo: {
+        url: "https://api.twitter.com/2/users/me",
+        params: { "user.fields": "profile_image_url" },
+      },
+      profile({ data }) {
+        return {
+          id: data.id,
+          name: data.name,
+          // NOTE: E-mail is currently unsupported by OAuth 2 Twitter.
+          email: null,
+          image: data.profile_image_url,
+        }
+      },
+      checks: ["pkce", "state"],
+      options,
+    }
   }
+
+  return TwitterLegacy(options)
 }


### PR DESCRIPTION
Adds support for Twitter OAuth 2.0. 

For now, we want to make it opt-in, since we just released a major (4.0) version.

OAuth 2.0 should be the default in the future. Depending on the length of the deprecation phase of OAuth 1.0A at Twitter, we can keep the legacy implementation and make it opt-in by installing [`oauth`](https://www.npmjs.com/package/oauth) but dropping it for anyone else.

Todo:

- [x] Docs https://github.com/nextauthjs/docs/pull/193
~- [ ] Add warnings when using legacy (try to push people against the new version)~ (still a bit early)
- [x] finalize API

Fixes #3367