### PR TITLE
fix(providers): use `idToken` by default in Cognito provider

### DIFF
--- a/src/providers/cognito.ts
+++ b/src/providers/cognito.ts
@@ -15,6 +15,7 @@ export default function Cognito<P extends Record<string, any> = CognitoProfile>(
     name: "Cognito",
     type: "oauth",
     wellKnown: `${options.issuer}/.well-known/openid-configuration`,
+    idToken: true,
     profile(profile) {
       return {
         id: profile.sub,


### PR DESCRIPTION
## Reasoning 💡

Add `idToken: true` by default to Cognito config provider

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes the same problem as here: #3383 but for Amazon Cognito provider.

