### PR TITLE
feat(react): add `disableRefetchOnRefocus` option to SessionProvider

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -380,9 +380,10 @@ export function SessionProvider(props: SessionProviderProps) {
 
   React.useEffect(() => {
     // Listen for when the page is visible, if the user switches tabs
-    // and makes our tab visible again, re-fetch the session.
+    // and makes our tab visible again, re-fetch the session, but only if
+    // this feature is not disabled.
     const visibilityHandler = () => {
-      if (document.visibilityState === "visible")
+      if (!props.disableRefetchOnRefocus && document.visibilityState === "visible")
         __NEXTAUTH._getSession({ event: "visibilitychange" })
     }
     document.addEventListener("visibilitychange", visibilityHandler, false)

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -70,4 +70,9 @@ export interface SessionProviderProps {
    * If set to `0` (default), the session is not polled.
    */
   refetchInterval?: number
+  /**
+   * SessionProvider automatically refetches the session when the user switches between tabs.
+   * This option disables this behaviour if set to `true`.
+   */
+  disableRefetchOnRefocus?: boolean
 }


### PR DESCRIPTION
Adding new option `disableRefetchOnRefocus` to SessionProvider component which disables session refetching in `visibilitychange` event callback.

## Reasoning 💡

Automatic refetching on tab switching is usefull but it should be controllable by user, since it may be an expensive operation.

## Checklist 🧢

- [x] Documentation
- [ ] ~Tests~
- [x] Ready to be merged

## Affected issues 🎟

Fixes #3405
