### PR TITLE
fix(jwt): use authorization header as fallback

### DIFF
--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -88,7 +88,13 @@ export async function getToken<R extends boolean = false>(
     logger
   )
 
-  const token = sessionStore.value
+  let token = sessionStore.value
+
+  if (!token && req.headers.authorization?.split(" ")[0] === "Bearer") {
+    const urlEncodedToken = req.headers.authorization.split(" ")[1]
+    token = decodeURIComponent(urlEncodedToken)
+  }
+
   // @ts-expect-error
   if (!token) return null
 


### PR DESCRIPTION
## Reasoning 💡

As explained in #3452, a bug was introduced in #3101 that removed the fallback behavior of `getToken` for `Authorization Bearer <JWT>` headers. This PR restores the relevant lines removed while retaining the chunking behavior for large cookies that #3101 added.

## Checklist 🧢

- [x] Documentation
- [ ] ~Tests~
- [x] Ready to be merged

## Affected issues 🎟

Fixes #3452
