### PR TITLE
feat(oauth): Improve support for non-web clients such as react native

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -176,7 +176,16 @@ export async function NextAuthHandler<
             options,
           })
           if (signin.cookies) cookies.push(...signin.cookies)
-          return { ...signin, cookies }
+
+          if (req.body?.redirect === false) {
+            return {
+              headers: [{ key: "Content-Type", value: "application/json" }],
+              body: { redirect: signin.redirect } as any,
+              cookies,
+            }
+          } else { 
+            return { ...signin, cookies }
+          }
         }
 
         return { redirect: `${options.url}/signin?csrf=true`, cookies }


### PR DESCRIPTION
## Reasoning 💡

I have been trying to understand how to extend next auth so that it can be used for react native apps. I think the main change required is to ensure key oauth endpoints optionally support not redirecting and instead return the key information back to the client.

With this change, posting redirect:false to the signon endpoint will now return the redirect url, instead of redirecting to it. This will allow non-web apps, such as those built with react native, to access the codeChallenge, redirectUrl and state, and handle the provider's sign on flow. The app can then call the redirectUrl itself once the provider flow is complete, including the code returned from the provider and the state.

Feedback welcome. I will try and put together an example repo with next auth and react native expo (which also needs a minor change to accept a custom codeChallenge https://github.com/expo/expo/pull/15535). 

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
