### PR TITLE
docs: fix OpenCollective link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ export default function App({
 
 ### Support
 
-We're happy to announce we've recently created an [OpenCollective](https://opencollective.org/nextauth) for individuals and companies looking to contribute financially to the project!
+We're happy to announce we've recently created an [OpenCollective](https://opencollective.com/nextauth) for individuals and companies looking to contribute financially to the project!
 
 <!--sponsors start-->
 <table>


### PR DESCRIPTION
Fixes a broken link to opencollective.

## Reasoning 💡

opencollective.org/nextauth does not resolve. The correct link is opencollective.com/nextauth

## Checklist 🧢

- ~[ ] Documentation~
- ~[ ] Tests~
- [x] Ready to be merged

## Affected issues 🎟

This was already fixed once here: https://github.com/nextauthjs/next-auth/pull/3066 but was overwritten.