### PR TITLE
fix(providers): use `idToken` by default in Slack provider

### DIFF
--- a/src/providers/slack.ts
+++ b/src/providers/slack.ts
@@ -40,6 +40,7 @@ export default function Slack<P extends Record<string, any> = SlackProfile>(
     name: "Slack",
     type: "oauth",
     wellKnown: "https://slack.com/.well-known/openid-configuration",
+    idToken: true,
     authorization: { params: { scope: "openid profile email" } },
     profile(profile) {
       return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

Add `idToken: true` by default to Slack provider config to solve oauth callback error.

<details open>
  <summary>Next-Auth console error</summary>

```
[next-auth][error][OAUTH_CALLBACK_ERROR] 
https://next-auth.js.org/errors#oauth_callback_error id_token detected in the response, you must use client.callback() instead of client.oauthCallback() {
  error: {
    message: 'id_token detected in the response, you must use client.callback() instead of client.oauthCallback()',
    stack: 'RPError: id_token detected in the response, you must use client.callback() instead of client.oauthCallback()\n' +
      '   ...,
    name: 'RPError'
  },
  providerId: 'slack',
  message: 'id_token detected in the response, you must use client.callback() instead of client.oauthCallback()'
}
```
</details>

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->

Fixes the same problem as here: #3383 but for Slack provider.