### PR TITLE
feat: better out-of-the-box `id_token` detection

### DIFF
--- a/src/core/lib/oauth/callback.ts
+++ b/src/core/lib/oauth/callback.ts
@@ -1,10 +1,11 @@
-import { CallbackParamsType, TokenSet } from "openid-client"
+import { TokenSet } from "openid-client"
 import { openidClient } from "./client"
 import { oAuth1Client } from "./client-legacy"
 import { useState } from "./state-handler"
 import { usePKCECodeVerifier } from "./pkce-handler"
 import { OAuthCallbackError } from "../../errors"
 
+import type { CallbackParamsType } from "openid-client"
 import type { Account, LoggerInstance, Profile } from "../../.."
 import type { OAuthChecks, OAuthConfig } from "../../../providers"
 import type { InternalOptions } from "../../../lib/types"

--- a/src/core/lib/providers.ts
+++ b/src/core/lib/providers.ts
@@ -45,17 +45,17 @@ function normalizeProvider(provider?: Provider) {
       typeof value === "string"
     ) {
       const url = new URL(value)
-      ;(acc as any)[key] = {
+      acc[key] = {
         url: `${url.origin}${url.pathname}`,
         params: Object.fromEntries(url.searchParams ?? []),
       }
     } else {
-      acc[key as keyof InternalProvider] = value
+      acc[key] = value
     }
 
     return acc
     // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter, @typescript-eslint/consistent-type-assertions
-  }, {} as InternalProvider)
+  }, {} as any)
 
   if (normalized.type === "oauth" && !normalized.version?.startsWith("1.")) {
     // If provider has as an "openid-configuration" well-known endpoint

--- a/src/core/lib/providers.ts
+++ b/src/core/lib/providers.ts
@@ -57,18 +57,17 @@ function normalizeProvider(provider?: Provider) {
     // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter, @typescript-eslint/consistent-type-assertions
   }, {} as InternalProvider)
 
-  if (provider.type === "oauth" && !provider.version?.startsWith("1.")) {
+  if (normalized.type === "oauth" && !normalized.version?.startsWith("1.")) {
     // If provider has as an "openid-configuration" well-known endpoint
     // or an "openid" scope request, it will also likely be able to receive an `id_token`
-    ;(normalized as any).idToken = Boolean(
-      (normalized as any).idToken ??
-        (normalized as any).wellKnown?.includes("openid-configuration") ??
-        (normalized as any).token?.params?.scope?.includes("openid")
+    normalized.idToken = Boolean(
+      normalized.idToken ??
+        normalized.wellKnown?.includes("openid-configuration") ??
+        // @ts-expect-error
+        normalized.authorization?.params?.scope?.includes("openid")
     )
 
-    if (!provider.checks) {
-      ;(normalized as any).checks = ["state"]
-    }
+    if (!normalized.checks) normalized.checks = ["state"]
   }
   return normalized
 }


### PR DESCRIPTION
Many of our providers can (and do) return `id_token`s and we should make a better job at detecting it.

Good indicators are:

1. well-known endpoint with `openid` in the url
2. `openid` scope request

In these cases, if the user did not define a top-level `idToken` property, we should check these cases.

Fixes #3502