### PR TITLE
Setting the http options befor discover the .wellKnown endpoint 

### DIFF
--- a/src/core/lib/oauth/client.ts
+++ b/src/core/lib/oauth/client.ts
@@ -12,7 +12,9 @@ export async function openidClient(
   options: InternalOptions<"oauth">
 ): Promise<Client> {
   const provider = options.provider
-
+  
+  if (provider.httpOptions) custom.setHttpOptionsDefaults(provider.httpOptions)
+  
   let issuer: Issuer
   if (provider.wellKnown) {
     issuer = await Issuer.discover(provider.wellKnown)
@@ -44,7 +46,7 @@ export async function openidClient(
   // and https://github.com/nextauthjs/next-auth/issues/3067
   client[custom.clock_tolerance] = 10
 
-  if (provider.httpOptions) custom.setHttpOptionsDefaults(provider.httpOptions)
+  //if (provider.httpOptions) custom.setHttpOptionsDefaults(provider.httpOptions)
 
   return client
 }

--- a/src/core/lib/oauth/client.ts
+++ b/src/core/lib/oauth/client.ts
@@ -46,7 +46,5 @@ export async function openidClient(
   // and https://github.com/nextauthjs/next-auth/issues/3067
   client[custom.clock_tolerance] = 10
 
-  //if (provider.httpOptions) custom.setHttpOptionsDefaults(provider.httpOptions)
-
   return client
 }


### PR DESCRIPTION
Set custom.setHttpOptionsDefaults before Issuer.discover(.wellKnown). This allow discover the .wellKnown endpoint behind a proxy

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Proxy settings was not setted on discovering the .wellKnown Endpoint

The http settings are set by the with this change before the discover



<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Yes

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
