### PR TITLE
Opt-in for dangerous account linking

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -18,6 +18,7 @@ export interface CommonProviderOptions {
   id: string
   name: string
   type: ProviderType
+  allowDangerousEmailAccountLinking?: boolean
   options?: Record<string, unknown>
 }
 


### PR DESCRIPTION
Hi there, happy new year, it's me over from [that thing](https://github.com/nextauthjs/next-auth/discussions/3125).

I've decided to go down the road of using a next-auth fork internally as we trust our hand-selected set of auth providers to correctly verify email addresses. Now I am curious if you'd consider merging it into upstream as well.

If so, I'd be happy to add docs, tests or whatever else you think is needed for this to be mergeable. Naming is another thing I've been wondering about. Maybe the flag should be called `dangerouslyTrustAccountEmail` instead? Or something else?

## Reasoning 💡
By default account linking can only be done through an active session, to prevent account stealing from low-trust providers. Some next-auth users might trust their chosen providers enough to opt them into more lax account linking.

## Checklist 🧢
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

Thanks for the consideration (and the great work on next-auth!)
