### PR TITLE
fix: assert on `options.jwt.secret`

### DIFF
--- a/src/core/lib/assert.ts
+++ b/src/core/lib/assert.ts
@@ -34,7 +34,7 @@ export function assertConfig(
     )
   }
 
-  if (!options.secret) {
+  if (!options.secret && !options.jwt?.secret) {
     if (process.env.NODE_ENV === "production") {
       return new MissingSecret("Please define a `secret` in production.")
     } else {


### PR DESCRIPTION
The config assertions did only check the top-level `secret` option, but currently, we allow `jwt.secret` as well. That option could just go away in the future.

Fixes #3560

**UPDATE**:

On hold. See https://github.com/nextauthjs/next-auth/issues/3560#issuecomment-1004470473

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
