### PR TITLE
Allow Specifying full oidc-client Issuer Metadata without Discovery

### DIFF
--- a/src/core/lib/oauth/client.ts
+++ b/src/core/lib/oauth/client.ts
@@ -1,4 +1,4 @@
-import { Issuer, Client, custom } from "openid-client"
+import { Client, custom, Issuer, IssuerMetadata } from "openid-client"
 import { InternalOptions } from "src/lib/types"
 
 /**
@@ -19,15 +19,20 @@ export async function openidClient(
   if (provider.wellKnown) {
     issuer = await Issuer.discover(provider.wellKnown)
   } else {
+    // issuer can either be the full oidc-client issuer metadata, or just
+    // the URI of the issuer
+    const metadata: IssuerMetadata = typeof provider.issuer === "object" ?
+      { ...provider.issuer } : { issuer: provider.issuer as string }
+
     issuer = new Issuer({
-      issuer: provider.issuer as string,
+      ...metadata,
       authorization_endpoint:
         // @ts-expect-error
         provider.authorization?.url ?? provider.authorization,
       // @ts-expect-error
       token_endpoint: provider.token?.url ?? provider.token,
       // @ts-expect-error
-      userinfo_endpoint: provider.userinfo?.url ?? provider.userinfo,
+      userinfo_endpoint: provider.userinfo?.url ?? provider.userinfo
     })
   }
 

--- a/src/providers/oauth.ts
+++ b/src/providers/oauth.ts
@@ -21,8 +21,6 @@ type ChecksType = "pkce" | "state" | "both" | "none"
 
 export type OAuthChecks = OpenIDCallbackChecks | OAuthCallbackChecks
 
-type PartialIssuer = Partial<Pick<IssuerMetadata, "jwks_endpoint" | "issuer">>
-
 type UrlParams = Record<string, unknown>
 
 type EndpointRequest<C, R, P> = (
@@ -89,7 +87,7 @@ export type UserinfoEndpointHandler = EndpointHandler<
   Profile
 >
 
-export interface OAuthConfig<P> extends CommonProviderOptions, PartialIssuer {
+export interface OAuthConfig<P> extends CommonProviderOptions {
   /**
    * OpenID Connect (OIDC) compliant providers can configure
    * this instead of `authorize`/`token`/`userinfo` options
@@ -129,7 +127,10 @@ export interface OAuthConfig<P> extends CommonProviderOptions, PartialIssuer {
   // TODO: only allow for BattleNet
   region?: string
   // TODO: only allow for some
-  issuer?: string
+  /**
+   * Configures the issuer to be used by oidc-client.
+   */
+  issuer?: string|IssuerMetadata
   /** Read more at: https://github.com/panva/node-openid-client/tree/main/docs#customizing-http-requests */
   httpOptions?: HttpOptions
 


### PR DESCRIPTION
## Reasoning 💡

Allow setting the full oidc-client Issuer metadata without using Issuer discovery by making `issuer` `string|IssuerMetadata`. I would argue that `issuer` is completely useless without setting jwks_uri, and the type should probably be migrated to `IssuerMetadata|undefined` fully at some point, potentially making it mutually exclusive with `wellKnown`.

This could be considered a breaking change due to removing the jwks_endpoint property from the Typescript types. However, this property was fully ignored so far.

## Checklist 🧢

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## Affected issues 🎟

Fixes #3567
