### PR TITLE
fix: display inline errors when using custom error page.

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -135,15 +135,6 @@ export async function NextAuthHandler<
         }
         return render.verifyRequest()
       case "error":
-        if (pages.error) {
-          return {
-            redirect: `${pages.error}${
-              pages.error.includes("?") ? "&" : "?"
-            }error=${error}`,
-            cookies,
-          }
-        }
-
         // These error messages are displayed in line on the sign in page
         if (
           [
@@ -160,6 +151,15 @@ export async function NextAuthHandler<
           ].includes(error as string)
         ) {
           return { redirect: `${options.url}/signin?error=${error}`, cookies }
+        }
+
+        if (pages.error) {
+          return {
+            redirect: `${pages.error}${
+              pages.error.includes("?") ? "&" : "?"
+            }error=${error}`,
+            cookies,
+          }
         }
 
         return render.error({ error: error as ErrorType })

--- a/src/core/pages/signin.tsx
+++ b/src/core/pages/signin.tsx
@@ -48,7 +48,7 @@ export default function SigninPage(props: SignInServerPageParams) {
     Callback: "Try signing in with a different account.",
     OAuthAccountNotLinked:
       "To confirm your identity, sign in with the same account you used originally.",
-    EmailSignin: "Check your email inbox.",
+    EmailSignin: "The e-mail could not be sent.",
     CredentialsSignin:
       "Sign in failed. Check the details you provided are correct.",
     SessionRequired: "Please sign in to access this page.",


### PR DESCRIPTION
## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->
- Move code handles inline sign-in errors before page errors. This should allow showing inline sign-in errors instead of redirecting to the custom error page, if users define one.
- Change email error. 

## Checklist 🧢

<!-- Feel free to cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- ~~[ ] Documentation~~
- [ ] Tests: Should I write a test for this?
- [x] Ready to be merged: If no tests are required, think it is ready to be merged.

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

- Fixes #3341 