### PR TITLE
add jwks_uri to issuer initialization if wellKnown is not used

### DIFF
--- a/src/core/lib/oauth/client.ts
+++ b/src/core/lib/oauth/client.ts
@@ -28,6 +28,7 @@ export async function openidClient(
       token_endpoint: provider.token?.url ?? provider.token,
       // @ts-expect-error
       userinfo_endpoint: provider.userinfo?.url ?? provider.userinfo,
+      jwks_uri: provider.jwksUri,
     })
   }
 

--- a/src/providers/oauth.ts
+++ b/src/providers/oauth.ts
@@ -130,6 +130,7 @@ export interface OAuthConfig<P> extends CommonProviderOptions, PartialIssuer {
   region?: string
   // TODO: only allow for some
   issuer?: string
+  jwksUri?: string
   /** Read more at: https://github.com/panva/node-openid-client/tree/main/docs#customizing-http-requests */
   httpOptions?: HttpOptions
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

This adds `jwksUri` to OAuthConfig to be used in the `openid-client` Issuer constructor if `wellKnown` is not used.

## Reasoning 💡

* I wanted to customize authorization_endpoint of GoogleProvider.
* To use a customized authorization_endpoint, OAuthConfig's `wellKnown` parameter must be blank and `jwks_uri` must be specified.
  - `openid-client` validates `jwks_uri`'s existence: https://github.com/panva/node-openid-client/blob/v5.1.1/lib/helpers/issuer.js#L22

## Checklist 🧢

I couldn't find which docs / test to be fixed with this change, if this PR doesn't contain enough changes, I'll fix it (or OK to close if this change is not acceptable).

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.


To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

None

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
