### PR TITLE
docs: update contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ We're happy to announce we've recently created an [OpenCollective](https://openc
 ## Contributing
 
 We're open to all community contributions! If you'd like to contribute in any way, please first read
-our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/canary/CONTRIBUTING.md).
+our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Reasoning 💡
README.md file from main branch has a contributing guide links, but it links to canary branch.
I confused when init and run this project on the main branch. So I updated the link to main branch.

as-is: https://github.com/nextauthjs/next-auth/blob/canary/CONTRIBUTING.md
to-be: https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md

## Checklist 🧢

- [x] Documentation
- [x] Ready to be merged
