### PR TITLE
fix: pass csrf & callbackUrl cookies in session api

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -92,8 +92,11 @@ export async function NextAuthHandler<
     switch (action) {
       case "providers":
         return (await routes.providers(options.providers)) as any
-      case "session":
-        return (await routes.session({ options, sessionStore })) as any
+      case "session": {
+        const session = await routes.session({ options, sessionStore })
+        if (session.cookies) cookies.push(...session.cookies)
+        return { ...session, cookies } as any
+      }
       case "csrf":
         return {
           headers: [{ key: "Content-Type", value: "application/json" }],


### PR DESCRIPTION
Always set csrf & callbackUrl cookies in session api regardless of current session state.

## Reasoning 💡
My project has a custom login page and I'm using the `useSessioin` hook in client side to check the user's current auth status. If an unauthenticated user goes to the login page (or any page), session api is always called first. Since the current implementation does not set the csrf cookies in session api response, when user tries to login he/she gets redirected back to the login page due to csrf mismatch error. This PR solves the issue. It was working fine in v3, probably got removed somehow.

## Checklist 🧢
- [ ] Documentation (not needed)
- [ ] Tests (not sure if it's needed)
- [x] Ready to be merged