### PR TITLE
fix(core): detect Vercel without `NEXTAUTH_URL`

### DIFF
--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -71,7 +71,7 @@ export async function getToken<R extends boolean = false>(
   const {
     req,
     secureCookie = process.env.NEXTAUTH_URL?.startsWith("https://") ??
-      !!process.env.VERCEL_URL,
+      !!process.env.VERCEL,
     cookieName = secureCookie
       ? "__Secure-next-auth.session-token"
       : "next-auth.session-token",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,7 +50,7 @@ export type NextAuthAction =
 export interface InternalOptions<T extends ProviderType = any> {
   providers: InternalProvider[]
   /**
-   * Parsed from `NEXTAUTH_URL` or `VERCEL_URL`.
+   * Parsed from `NEXTAUTH_URL` or `x-forwarded-host` on Vercel.
    * @default "http://localhost:3000/api/auth"
    */
   url: InternalUrl

--- a/src/next/index.ts
+++ b/src/next/index.ts
@@ -21,7 +21,7 @@ async function NextAuthNextHandler(
   const { nextauth, ...query } = req.query
   const handler = await NextAuthHandler({
     req: {
-      host: detectHost(req.headers["x-forwarded-host"] as string),
+      host: detectHost(req.headers["x-forwarded-host"]),
       body: req.body,
       query,
       cookies: req.cookies,
@@ -87,7 +87,7 @@ export async function getServerSession(
   const session = await NextAuthHandler<Session | {}>({
     options,
     req: {
-      host: detectHost(context.req.headers["x-forwarded-host"] as string),
+      host: detectHost(context.req.headers["x-forwarded-host"]),
       action: "session",
       method: "GET",
       cookies: context.req.cookies,

--- a/src/next/index.ts
+++ b/src/next/index.ts
@@ -1,5 +1,5 @@
 import { NextAuthHandler } from "../core"
-import { setCookie } from "./cookie"
+import { setCookie, detectHost } from "./utils"
 
 import type {
   GetServerSidePropsContext,
@@ -21,7 +21,7 @@ async function NextAuthNextHandler(
   const { nextauth, ...query } = req.query
   const handler = await NextAuthHandler({
     req: {
-      host: process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL,
+      host: detectHost(req.headers["x-forwarded-host"] as string),
       body: req.body,
       query,
       cookies: req.cookies,
@@ -87,7 +87,7 @@ export async function getServerSession(
   const session = await NextAuthHandler<Session | {}>({
     options,
     req: {
-      host: process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL,
+      host: detectHost(context.req.headers["x-forwarded-host"] as string),
       action: "session",
       method: "GET",
       cookies: context.req.cookies,
@@ -108,7 +108,7 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       NEXTAUTH_URL?: string
-      VERCEL_URL?: string
+      VERCEL?: "1"
     }
   }
 }

--- a/src/next/utils.ts
+++ b/src/next/utils.ts
@@ -13,3 +13,11 @@ export function setCookie(res, cookie: Cookie) {
   setCookieHeader.push(cookieHeader)
   res.setHeader("Set-Cookie", setCookieHeader)
 }
+
+/** Extract the host from the environment */
+export function detectHost(forwardedHost: string) {
+  // If we detect a Vercel environment, we can trust the host
+  if (process.env.VERCEL === "1") return forwardedHost
+  // If `NEXTAUTH_URL` is `undefined` we fall back to "http://localhost:3000"
+  return process.env.NEXTAUTH_URL
+}

--- a/src/next/utils.ts
+++ b/src/next/utils.ts
@@ -17,7 +17,7 @@ export function setCookie(res, cookie: Cookie) {
 /** Extract the host from the environment */
 export function detectHost(forwardedHost: any) {
   // If we detect a Vercel environment, we can trust the host
-  if (process.env.VERCEL === "1") return forwardedHost
+  if (process.env.VERCEL) return forwardedHost
   // If `NEXTAUTH_URL` is `undefined` we fall back to "http://localhost:3000"
   return process.env.NEXTAUTH_URL
 }

--- a/src/next/utils.ts
+++ b/src/next/utils.ts
@@ -15,7 +15,7 @@ export function setCookie(res, cookie: Cookie) {
 }
 
 /** Extract the host from the environment */
-export function detectHost(forwardedHost: string) {
+export function detectHost(forwardedHost: any) {
   // If we detect a Vercel environment, we can trust the host
   if (process.env.VERCEL === "1") return forwardedHost
   // If `NEXTAUTH_URL` is `undefined` we fall back to "http://localhost:3000"


### PR DESCRIPTION
Fixes #3419

Based on https://github.com/nextauthjs/next-auth/issues/3419#issuecomment-1003004601