### PR TITLE
Fix: (Azure AD) Check for valid profile picture response before converting to base64

### DIFF
--- a/src/providers/azure-ad.ts
+++ b/src/providers/azure-ad.ts
@@ -28,7 +28,7 @@ export default function AzureAD<P extends Record<string, any> = AzureADProfile>(
     wellKnown: `https://login.microsoftonline.com/${tenant}/v2.0/.well-known/openid-configuration`,
     authorization: {
       params: {
-        scope: "User.Read",
+        scope: "openid profile email",
       },
     },
     async profile(profile, tokens) {

--- a/src/providers/azure-ad.ts
+++ b/src/providers/azure-ad.ts
@@ -36,7 +36,7 @@ export default function AzureAD<P extends Record<string, any> = AzureADProfile>(
         id: profile.sub,
         name: profile.name,
         email: profile.email,
-        image: "",
+        image: null,
       };
 
       // https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#examples

--- a/src/providers/azure-ad.ts
+++ b/src/providers/azure-ad.ts
@@ -32,6 +32,13 @@ export default function AzureAD<P extends Record<string, any> = AzureADProfile>(
       },
     },
     async profile(profile, tokens) {
+      const profileObject = {
+        id: profile.sub,
+        name: profile.name,
+        email: profile.email,
+        image: "",
+      };
+
       // https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#examples
       const profilePicture = await fetch(
         `https://graph.microsoft.com/v1.0/me/photos/${profilePhotoSize}x${profilePhotoSize}/$value`,
@@ -41,14 +48,14 @@ export default function AzureAD<P extends Record<string, any> = AzureADProfile>(
           },
         }
       )
-      const pictureBuffer = await profilePicture.arrayBuffer()
-      const pictureBase64 = Buffer.from(pictureBuffer).toString("base64")
-      return {
-        id: profile.sub,
-        name: profile.name,
-        email: profile.email,
-        image: `data:image/jpeg;base64, ${pictureBase64}`,
+
+      if (profilePicture.ok) {
+        const pictureBuffer = await profilePicture.arrayBuffer();
+        const pictureBase64 = Buffer.from(pictureBuffer).toString("base64");
+        profileObject.image = `data:image/jpeg;base64, ${pictureBase64}`;
       }
+
+      return profileObject;
     },
     options,
   }

--- a/src/providers/azure-ad.ts
+++ b/src/providers/azure-ad.ts
@@ -32,13 +32,6 @@ export default function AzureAD<P extends Record<string, any> = AzureADProfile>(
       },
     },
     async profile(profile, tokens) {
-      const profileObject = {
-        id: profile.sub,
-        name: profile.name,
-        email: profile.email,
-        image: null,
-      };
-
       // https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#examples
       const profilePicture = await fetch(
         `https://graph.microsoft.com/v1.0/me/photos/${profilePhotoSize}x${profilePhotoSize}/$value`,
@@ -49,13 +42,23 @@ export default function AzureAD<P extends Record<string, any> = AzureADProfile>(
         }
       )
 
+      // Confirm that profile photo was returned
       if (profilePicture.ok) {
-        const pictureBuffer = await profilePicture.arrayBuffer();
-        const pictureBase64 = Buffer.from(pictureBuffer).toString("base64");
-        profileObject.image = `data:image/jpeg;base64, ${pictureBase64}`;
+        const pictureBuffer = await profilePicture.arrayBuffer()
+        const pictureBase64 = Buffer.from(pictureBuffer).toString("base64")
+        return {
+          id: profile.sub,
+          name: profile.name,
+          email: profile.email,
+          image: `data:image/jpeg;base64, ${pictureBase64}`,
+        }
+      } else {
+        return {
+          id: profile.sub,
+          name: profile.name,
+          email: profile.email,
+        }
       }
-
-      return profileObject;
     },
     options,
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡
Currently, the `profile()` function for Azure AD takes a response from the Microsoft Graph API and converts it to base64 for profile pictures. Unfortunately, this has caused bugs for my project because it doesn't make sure that the response from Microsoft is valid before converting. Users without a photo set on their account will not recieve a valid response, but an invalid "image" will still be returned.

This PR adds a small check to the profile photo response to make sure the HTTP-status is 200-299. If the status is outside of that range, the profile image is left as an empty string.
<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] ~Documentation~
- [ ] ~Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟
None
<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
