### PR TITLE
feat(middleware): introduce `withAuth` Next.js method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ node_modules
 /index.d.ts
 /index.js
 /next
+/middleware.d.ts
+/middleware.js
 
 # Development app
 app/src/css

--- a/app/components/header.js
+++ b/app/components/header.js
@@ -103,6 +103,11 @@ export default function Header() {
               <a>Email</a>
             </Link>
           </li>
+          <li className={styles.navItem}>
+            <Link href="/middleware-protected">
+              <a>Middleware protected</a>
+            </Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "@prisma/client": "^3.7.0",
     "fake-smtp-server": "^0.8.0",
     "faunadb": "^4.4.1",
-    "next": "^12.0.7",
+    "next": "^12.0.8",
     "nodemailer": "^6.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/app/pages/middleware-protected/_middleware.js
+++ b/app/pages/middleware-protected/_middleware.js
@@ -15,7 +15,6 @@ export { default } from "next-auth/middleware"
 
 // export function middleware(req, ev) {
 //   return withAuth(req, {
-//     secret: process.env.NEXTAUTH_SECRET,
 //     callbacks: {
 //       authorized: ({ token }) => !!token,
 //     },
@@ -32,7 +31,6 @@ export { default } from "next-auth/middleware"
 //     return undefined // NOTE: `NextMiddleware` should allow returning `void`
 //   },
 //   {
-//     secret: process.env.NEXTAUTH_SECRET,
 //     callbacks: {
 //       authorized: ({ token }) => token.name === "Balázs Orbán",
 //     }
@@ -40,7 +38,6 @@ export { default } from "next-auth/middleware"
 // )
 
 // export default withAuth({
-//   secret: process.env.NEXTAUTH_SECRET,
 //   callbacks: {
 //     authorized: ({ token }) => !!token,
 //   },

--- a/app/pages/middleware-protected/_middleware.js
+++ b/app/pages/middleware-protected/_middleware.js
@@ -1,0 +1,1 @@
+export { withAuth as default } from "next-auth/next/middleware"

--- a/app/pages/middleware-protected/_middleware.js
+++ b/app/pages/middleware-protected/_middleware.js
@@ -1,1 +1,41 @@
-export { default } from "next-auth/next/middleware"
+export { default } from "next-auth/middleware"
+
+// Other ways to use this middleware
+
+// import withAuth from "next-auth/middleware"
+// import { withAuth } from "next-auth/middleware"
+
+// export function middleware(req, ev) {
+//   return withAuth(req)
+// }
+
+// export function middleware(req, ev) {
+//   return withAuth(req, ev)
+// }
+
+// export function middleware(req, ev) {
+//   return withAuth(req, {
+//     secret: process.env.NEXTAUTH_SECRET,
+//     authorized: ({ token }) => !!token,
+//   })
+// }
+
+// export default withAuth(function middleware(req, ev) {
+//   console.log(req.token)
+// })
+
+// export default withAuth(
+//   function middleware(req, ev) {
+//     console.log(req, ev)
+//     return undefined // NOTE: `NextMiddleware` should allow returning `void`
+//   },
+//   {
+//     secret: process.env.NEXTAUTH_SECRET,
+//     authorized: ({ token }) => token.name === "Balázs Orbán",
+//   }
+// )
+
+// export default withAuth({
+//   secret: process.env.NEXTAUTH_SECRET,
+//   authorized: ({ token }) => !!token,
+// })

--- a/app/pages/middleware-protected/_middleware.js
+++ b/app/pages/middleware-protected/_middleware.js
@@ -22,7 +22,7 @@ export { default } from "next-auth/middleware"
 // }
 
 // export default withAuth(function middleware(req, ev) {
-//   console.log(req.token)
+//   console.log(req.nextauth.token)
 // })
 
 // export default withAuth(

--- a/app/pages/middleware-protected/_middleware.js
+++ b/app/pages/middleware-protected/_middleware.js
@@ -16,7 +16,9 @@ export { default } from "next-auth/middleware"
 // export function middleware(req, ev) {
 //   return withAuth(req, {
 //     secret: process.env.NEXTAUTH_SECRET,
-//     authorized: ({ token }) => !!token,
+//     callbacks: {
+//       authorized: ({ token }) => !!token,
+//     },
 //   })
 // }
 
@@ -31,11 +33,15 @@ export { default } from "next-auth/middleware"
 //   },
 //   {
 //     secret: process.env.NEXTAUTH_SECRET,
-//     authorized: ({ token }) => token.name === "Balázs Orbán",
+//     callbacks: {
+//       authorized: ({ token }) => token.name === "Balázs Orbán",
+//     }
 //   }
 // )
 
 // export default withAuth({
 //   secret: process.env.NEXTAUTH_SECRET,
-//   authorized: ({ token }) => !!token,
+//   callbacks: {
+//     authorized: ({ token }) => !!token,
+//   },
 // })

--- a/app/pages/middleware-protected/_middleware.js
+++ b/app/pages/middleware-protected/_middleware.js
@@ -1,1 +1,1 @@
-export { withAuth as default } from "next-auth/next/middleware"
+export { default } from "next-auth/next/middleware"

--- a/app/pages/middleware-protected/index.js
+++ b/app/pages/middleware-protected/index.js
@@ -1,0 +1,9 @@
+import Layout from "components/layout"
+
+export default function Page() {
+  return (
+    <Layout>
+      <h1>Page protected by Middleware</h1>
+    </Layout>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "./react": "./react/index.js",
     "./core": "./core/index.js",
     "./next": "./next/index.js",
-    "./next/middleware": "./next/middleware.js",
+    "./middleware": "./middleware.js",
     "./client/_utils": "./client/_utils.js",
     "./providers/*": "./providers/*.js"
   },
   "scripts": {
     "build": "npm run build:js && npm run build:css",
-    "clean": "rm -rf client css lib providers core jwt react next index.d.ts index.js adapters.d.ts",
+    "clean": "rm -rf client css lib providers core jwt react next index.d.ts index.js adapters.d.ts middleware.d.ts",
     "build:js": "npm run clean && npm run generate-providers && tsc && babel --config-file ./config/babel.config.js src --out-dir . --extensions \".tsx,.ts,.js,.jsx\"",
     "build:css": "postcss --config config/postcss.config.js src/**/*.css --base src --dir . && node config/wrap-css.js",
     "dev:setup": "npm i && npm run generate-providers && npm run build:css && cd app && npm i",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "build": "npm run build:js && npm run build:css",
-    "clean": "rm -rf client css lib providers core jwt react next index.d.ts index.js adapters.d.ts middleware.d.ts",
+    "clean": "rm -rf client css lib providers core jwt react next index.d.ts index.js adapters.d.ts middleware.d.ts middleware.js",
     "build:js": "npm run clean && npm run generate-providers && tsc && babel --config-file ./config/babel.config.js src --out-dir . --extensions \".tsx,.ts,.js,.jsx\"",
     "build:css": "postcss --config config/postcss.config.js src/**/*.css --base src --dir . && node config/wrap-css.js",
     "dev:setup": "npm i && npm run generate-providers && npm run build:css && cd app && npm i",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
     "core",
     "index.d.ts",
     "index.js",
-    "adapters.d.ts"
+    "adapters.d.ts",
+    "middleware.d.ts",
+    "middleware.js"
   ],
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "./react": "./react/index.js",
     "./core": "./core/index.js",
     "./next": "./next/index.js",
+    "./next/middleware": "./next/middleware.js",
     "./client/_utils": "./client/_utils.js",
     "./providers/*": "./providers/*.js"
   },

--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -42,7 +42,7 @@ export async function decode({
 
 export interface GetTokenParams<R extends boolean = false> {
   /** The request containing the JWT either in the cookies or in the `Authorization` header. */
-  req: NextApiRequest
+  req: NextApiRequest | Pick<NextApiRequest, "cookies" | "headers">
   /**
    * Use secure prefix for cookie name, unless URL in `NEXTAUTH_URL` is http://
    * or not set (e.g. development or test instance) case use unprefixed name

--- a/src/lib/parse-url.ts
+++ b/src/lib/parse-url.ts
@@ -11,6 +11,7 @@ export interface InternalUrl {
   toString: () => string
 }
 
+/** Returns an `URL` like object to make requests/redirects from server-side */
 export default function parseUrl(url?: string): InternalUrl {
   const defaultUrl = new URL("http://localhost:3000/api/auth")
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,2 @@
+export { default } from "./next/middleware"
+export * from "./next/middleware"

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -1,0 +1,97 @@
+import type { NextRequest } from "next/server"
+import type { Awaitable, NextAuthOptions } from ".."
+import type { JWT } from "../jwt"
+
+import { NextResponse } from "next/server"
+import { getToken } from "../jwt"
+
+export interface NextAuthMiddlewareOptions {
+  /**
+   * The secret used to create the session.
+   * @note Must match as `secret` in `NextAuth`.
+   * @default process.env.NEXTAUTH_SECRET
+   *
+   * ---
+   * [Documentation](https://next-auth.js.org/configuration/options#secret)
+   */
+  secret?: string
+  /**
+   * Where to redirect the user in case of an error if they weren't logged in.
+   * Similar to `pages` in `NextAuth`.
+   *
+   * ---
+   * [Documentation](https://next-auth.js.org/configuration/pages)
+   */
+  pages?: NextAuthOptions["pages"]
+  /**
+   * Callback that receives the user's JWT payload
+   * and returns `true` to allow the user to continue.
+   *
+   * If it returns `false`, the user is redirected to the sign-in page instead
+   *
+   * The default is to let the user continue if they have a valid JWT (basic authentication).
+   *
+   * How to restrict a page and all of it's subpages for admins-only:
+   * @example
+   *
+   * ```js
+   * // `pages/admin/_middleware.js`
+   * import { withAuth } from "next-auth/next/middleware"
+   *
+   * export default withAuth({
+   *   authorized: ({ token }) => token?.user.isAdmin
+   * })
+   * ```
+   */
+  authorized: (options: {
+    token: JWT | null
+    req: NextRequest
+  }) => Awaitable<boolean>
+}
+
+/**
+ * Middleware that checks if the user is authenticated/authorized.
+ * If if they aren't, they will be redirected to the login page.
+ * Otherwise, continue.
+ *
+ * @example
+ *
+ * ```js
+ * // `pages/_middleware.js`
+ * export { withAuth as default } from "next-auth/next/middleware"
+ * ```
+ *
+ * ---
+ * [Documentation](https://next-auth.js.org/getting-started/middleware)
+ */
+export function withAuth(options?: NextAuthMiddlewareOptions) {
+  const secret = options?.secret ?? process.env.NEXTAUTH_SECRET
+  if (!secret) {
+    const code = "NO_SECRET"
+    console.error(
+      `[next-auth][error][${code}]`,
+      `\nhttps://next-auth.js.org/errors#${code.toLowerCase()}`
+    )
+    return NextResponse.redirect(
+      options?.pages?.error ?? "/api/auth/error?error=Configuration"
+    )
+  }
+
+  return async function middleware(req: NextRequest) {
+    const token = await getToken({
+      req: {
+        headers: req.headers as any,
+        cookies: req.cookies,
+      },
+      secret,
+    })
+
+    const isAuthorized = options?.authorized
+      ? options?.authorized?.({ token, req })
+      : !!token
+
+    if (isAuthorized) return
+
+    return NextResponse.redirect(options?.pages?.signIn ?? "/api/auth/signin")
+  }
+}

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -14,15 +14,6 @@ type AuthorizedCallback = (params: {
 
 export interface NextAuthMiddlewareOptions {
   /**
-   * The secret used to create the session.
-   * @note Must match as `secret` in `NextAuth`.
-   * @default process.env.NEXTAUTH_SECRET
-   *
-   * ---
-   * [Documentation](https://next-auth.js.org/configuration/options#secret)
-   */
-  secret?: NextAuthOptions["secret"]
-  /**
    * Where to redirect the user in case of an error if they weren't logged in.
    * Similar to `pages` in `NextAuth`.
    *
@@ -46,10 +37,12 @@ export interface NextAuthMiddlewareOptions {
      *
      * ```js
      * // `pages/admin/_middleware.js`
-     * import { withAuth } from "next-auth/next/middleware"
+     * import { withAuth } from "next-auth/middleware"
      *
      * export default withAuth({
-     *   authorized: ({ token }) => token?.user.isAdmin
+     *   callbacks: {
+     *     authorized: ({ token }) => token?.user.isAdmin
+     *   }
      * })
      * ```
      *
@@ -76,7 +69,7 @@ async function handleMiddleware(
     return
   }
 
-  const secret = options?.secret ?? process.env.NEXTAUTH_SECRET
+  const secret = process.env.NEXTAUTH_SECRET
   if (!secret) {
     console.error(
       `[next-auth][error][NO_SECRET]`,

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -122,3 +122,5 @@ export async function withAuth(
     )
   }
 }
+
+export default withAuth

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -136,7 +136,7 @@ export function withAuth(...args: WithAuthArgs) {
     const options = args[1] as NextAuthMiddlewareOptions | undefined
     return async (...args: Parameters<NextMiddleware>) =>
       await handleMiddleware(args[0], options, async (token) => {
-        ;(args[0] as any).token = token
+        ;(args[0] as any).nextauth = { token }
         return await middleware(...args)
       })
   }

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -78,10 +78,12 @@ export async function withAuth(
       )
       return NextResponse.redirect("/api/auth/error?error=Configuration")
     }
+    const req = args[0]
+    if (await getToken({ req: req as any, secret })) return
 
-    if (await getToken({ req: args[0] as any, secret })) return
-
-    return NextResponse.redirect("/api/auth/signin")
+    return NextResponse.redirect(
+      `/api/auth/signin?${new URLSearchParams({ callbackUrl: req.url })}`
+    )
   }
 
   const options = args[0]
@@ -114,6 +116,9 @@ export async function withAuth(
 
     if (isAuthorized) return
 
-    return NextResponse.redirect(pages.signIn ?? "/api/auth/signin")
+    const redirectUrl = pages.signIn ?? "/api/auth/signin"
+    return NextResponse.redirect(
+      `${redirectUrl}?${new URLSearchParams({ callbackUrl: req.url })}`
+    )
   }
 }

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -69,8 +69,7 @@ async function handleMiddleware(
     return
   }
 
-  const secret = process.env.NEXTAUTH_SECRET
-  if (!secret) {
+  if (!process.env.NEXTAUTH_SECRET) {
     console.error(
       `[next-auth][error][NO_SECRET]`,
       `\nhttps://next-auth.js.org/errors#no_secret`
@@ -81,11 +80,11 @@ async function handleMiddleware(
     }
   }
 
-  const token = await getToken({ req: req as any, secret })
+  const token = await getToken({ req: req as any })
 
-  const authorized: AuthorizedCallback =
-    options?.callbacks?.authorized ?? (({ token }) => !!token)
-  const isAuthorized = await authorized({ req, token })
+  const isAuthorized =
+    (await options?.callbacks?.authorized?.({ req, token })) ?? !!token
+
   // the user is authorized, let the middleware handle the rest
   if (isAuthorized) return await onSuccess?.(token)
 

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -79,15 +79,7 @@ export async function withAuth(
       return NextResponse.redirect("/api/auth/error?error=Configuration")
     }
 
-    const req = args[0]
-    const token = await getToken({
-      req: {
-        headers: req.headers as any,
-        cookies: req.cookies,
-      },
-      secret,
-    })
-    if (token) return
+    if (await getToken({ req: args[0] as any, secret })) return
 
     return NextResponse.redirect("/api/auth/signin")
   }
@@ -114,13 +106,7 @@ export async function withAuth(
       )
     }
 
-    const token = await getToken({
-      req: {
-        headers: req.headers as any,
-        cookies: req.cookies,
-      },
-      secret,
-    })
+    const token = await getToken({ req: req as any, secret })
 
     const isAuthorized = options?.authorized
       ? options?.authorized?.({ token, req })

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -61,17 +61,15 @@ export type WithAuthArgs =
 /** Check if `secret` has been declared  */
 function initConfig(
   req: NextRequest,
-  options?: NextAuthMiddlewareOptions | NextFetchEvent
+  optionsOrEv?: NextAuthMiddlewareOptions | NextFetchEvent
 ) {
-  // @ts-expect-error
+  const options = optionsOrEv as NextAuthMiddlewareOptions // This is relatively safe as we don't share properties with NextFetchEvent
   const signInPage = options?.pages?.signIn ?? "/api/auth/signin"
-  // @ts-expect-error
   const errorPage = options?.pages?.error ?? "/api/auth/error"
 
   // Avoid infinite redirect loop
   if ([signInPage, errorPage].includes(req.nextUrl.pathname)) return
 
-  // @ts-expect-error
   const secret = options?.secret ?? process.env.NEXTAUTH_SECRET
   // Continue only if the secret is specified
   if (secret)
@@ -80,8 +78,7 @@ function initConfig(
       options,
       secret,
       signInPage,
-      // @ts-expect-error
-      authorized: options?.authorized || (({ token }) => token),
+      authorized: options?.authorized ?? (({ token }) => token),
     }
 
   console.error(

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -116,7 +116,9 @@ function initConfig(
 export function withAuth(...args: WithAuthArgs) {
   if (args[0] instanceof NextRequest) {
     const config = initConfig(args[0], args[1])
-    if (!config || config.redirect) return config?.redirect
+    if (!config) return
+    if (config.redirect) return config.redirect
+
     const { req, secret, signInPage, authorized } = config
 
     return getToken({ req: req as any, secret }).then(async (token) => {
@@ -133,7 +135,9 @@ export function withAuth(...args: WithAuthArgs) {
     const options = args[1] as NextAuthMiddlewareOptions | undefined
     return async (...args: Parameters<NextMiddleware>) => {
       const config = initConfig(args[0], options)
-      if (!config || config.redirect) return config?.redirect
+      if (!config) return
+      if (config.redirect) return config.redirect
+
       const { req, secret, signInPage, authorized } = config
 
       const token = await getToken({ req: req as any, secret })
@@ -152,7 +156,8 @@ export function withAuth(...args: WithAuthArgs) {
   const options = args[0]
   return async (...args: Parameters<NextMiddleware>) => {
     const config = initConfig(args[0], options)
-    if (!config || config.redirect) return config?.redirect
+    if (!config) return
+    if (config.redirect) return config.redirect
 
     const { req, secret, signInPage, authorized } = config
 


### PR DESCRIPTION
This is currently an idea :bulb: but it fixes #3037

To test it out, see https://github.com/nextauthjs/next-auth/pull/3657#issuecomment-1014990129

Useful resources:
- https://nextjs.org/docs/middleware#execution-order

## Usage examples

### Authentication only

You allow any logged-in user to access a page

```js
// pages/_middleware.js

export { default } from "next-auth/middleware"
```

### Authorization

Certain conditions must be met for the user to continue, for example, to restrict an admin dashboard, you can do:

```js
// pages/admin/_middleware.js
import { withAuth } from "next-auth/middleware"

export default withAuth({
  callbacks: {
    authorized: ({ token }) => token?.user.isAdmin
  }
})
```

See the source code for the proposed API.

Suggestion: We could detect if `NEXTAUTH_SECRET` is present, sparing the user to fill an extra configuration field. (NOTE: This could be done in `NextAuth` in `pages/api/auth/[...nextauth]` as well)

Open for feedback.

- [ ] Docs https://github.com/nextauthjs/docs/pull/218
- [ ] Update [Live Demo](https://next-auth-example.vercel.app/)