### PR TITLE
Allow for React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
   },
   "peerDependencies": {
     "nodemailer": "^6.6.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0-0",
+    "react-dom": "^17.0.2 || ^18.0.0-0",
   },
   "peerDependenciesMeta": {
     "nodemailer": {


### PR DESCRIPTION
Avoid peer dependency warning when using React 18.

Copied from https://github.com/vercel/next.js/blob/eba64c29a4acd4bd1dfc469c3aec3fd37c6bc372/packages/next/package.json#L83-L84

## Reasoning 💡

React 18 is a release candidate and has been used in production by Facebook for a very long time.

## Checklist 🧢

I don't think any of the below is needed. It should just work.


- [ ] ~Documentation~
- [ ] ~Tests~
- [x] Ready to be merged


## Affected issues 🎟


n/a