### PR TITLE
feat(react): add refetchOnWindowFocus option to SessionProvider

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -379,16 +379,18 @@ export function SessionProvider(props: SessionProviderProps) {
   }, [])
 
   React.useEffect(() => {
+    const { refetchOnWindowFocus = true } = props
     // Listen for when the page is visible, if the user switches tabs
-    // and makes our tab visible again, re-fetch the session.
+    // and makes our tab visible again, re-fetch the session, but only if
+    // this feature is not disabled.
     const visibilityHandler = () => {
-      if (document.visibilityState === "visible")
+      if (refetchOnWindowFocus && document.visibilityState === "visible")
         __NEXTAUTH._getSession({ event: "visibilitychange" })
     }
     document.addEventListener("visibilitychange", visibilityHandler, false)
     return () =>
       document.removeEventListener("visibilitychange", visibilityHandler, false)
-  }, [])
+  }, [props.refetchOnWindowFocus])
 
   React.useEffect(() => {
     const { refetchInterval } = props

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -70,4 +70,9 @@ export interface SessionProviderProps {
    * If set to `0` (default), the session is not polled.
    */
   refetchInterval?: number
+  /**
+   * `SessionProvider` automatically refetches the session when the user switches between windows.
+   * This option activates this behaviour if set to `true` (default).
+   */
+  refetchOnWindowFocus?: boolean
 }


### PR DESCRIPTION
The original feature request (#3450) looks left behind for about a month.

But because you can't control whether to refetch session when you focus on a browser, some issues still occur (like form resetting, duplicated API calls, etc).

So I re-open this PR instead of @filipditrich (almost all of this feature depend on his effort) and handle @balazsorban44 's reviews.

Following descriptions are copies from [here](https://github.com/nextauthjs/next-auth/pull/3450).

----

Adding new option refetchOnWindowFocus to SessionProvider component which disables session refetching in visibilitychange event callback.

## Reasoning 💡

Automatic refetching on tab switching is usefull but it should be controllable by user, since it may be an expensive operation.

## Checklist 🧢

- [x] Documentation
- [ ] ~Tests~
- [x] Ready to be merged

## Affected issues 🎟

Fixes #3405 