### PR TITLE
feat(react): custom fetch options

### DIFF
--- a/packages/next-auth/src/client/__tests__/client-provider.test.js
+++ b/packages/next-auth/src/client/__tests__/client-provider.test.js
@@ -155,6 +155,33 @@ test("allows to customize the URL for session fetching", async () => {
   })
 })
 
+test("allows to customize headers for session fetching", async () => {
+  server.use(
+    rest.get(`/api/auth/session`, (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(mockSession))
+    )
+  )
+
+  const fetchOptions = {
+    headers: {
+      'X-Foo-Bar': 'hello'
+    }
+  }
+
+  render(<ProviderFlow session={mockSession} fetchOptions={fetchOptions} />)
+
+  // there's an existing session so it should not try to fetch a new one
+  expect(fetchSpy).not.toHaveBeenCalled()
+
+  // force a session refetch across all clients...
+  getSession()
+
+  return waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy.mock.calls[0][1].headers).toMatchObject({'X-Foo-Bar': 'hello'})
+  })
+})
+
 function ProviderFlow(props) {
   return (
     <SessionProvider {...props}>

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -295,9 +295,10 @@ export async function signOut<R extends boolean = true>(
  * [Documentation](https://next-auth.js.org/getting-started/client#sessionprovider)
  */
 export function SessionProvider(props: SessionProviderProps) {
-  const { children, basePath } = props
+  const { children, basePath, fetchOptions } = props
 
   if (basePath) __NEXTAUTH.basePath = basePath
+  if (fetchOptions) __NEXTAUTH.fetchOptions = fetchOptions
 
   /**
    * If session was `null`, there was an attempt to fetch it,

--- a/packages/next-auth/src/react/types.ts
+++ b/packages/next-auth/src/react/types.ts
@@ -65,6 +65,7 @@ export interface SessionProviderProps {
   session?: Session | null
   baseUrl?: string
   basePath?: string
+  fetchOptions?: RequestInit
   /**
    * A time interval (in seconds) after which the session will be re-fetched.
    * If set to `0` (default), the session is not polled.


### PR DESCRIPTION
Introducing the ability to customize options passed to [fetchData](https://github.com/nextauthjs/next-auth/blob/4824f8c02ad1b0799f4c15eea9c86e93fc5c72fc/src/client/_utils.ts#L32) by passing `fetchOptions` as a prop to `SessionProvider`

## Reasoning 💡

Primarily to facilitate setting `"credentials": "include"` in a case where a single next-auth server is serving multiple Next sites.

## Checklist 🧢

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

https://github.com/nextauthjs/next-auth/issues/2414