### PR TITLE
feat: added types for sign in errors

### DIFF
--- a/src/core/pages/error.tsx
+++ b/src/core/pages/error.tsx
@@ -1,6 +1,10 @@
 import { Theme } from "../.."
 import { InternalUrl } from "../../lib/parse-url"
 
+/**
+ * The following errors are passed as error query parameters to the default or overridden error page.
+ *
+ * [Documentation](https://next-auth.js.org/configuration/pages#error-page) */
 export type ErrorType =
   | "default"
   | "configuration"

--- a/src/core/pages/error.tsx
+++ b/src/core/pages/error.tsx
@@ -1,10 +1,16 @@
 import { Theme } from "../.."
 import { InternalUrl } from "../../lib/parse-url"
 
+export type ErrorType =
+  | "default"
+  | "configuration"
+  | "accessdenied"
+  | "verification"
+
 export interface ErrorProps {
   url?: InternalUrl
   theme?: Theme
-  error?: string
+  error?: ErrorType
 }
 
 interface ErrorView {
@@ -13,12 +19,6 @@ interface ErrorView {
   message: JSX.Element
   signin?: JSX.Element
 }
-
-export type ErrorType =
-  | "default"
-  | "configuration"
-  | "accessdenied"
-  | "verification"
 
 /** Renders an error page. */
 export default function ErrorPage(props: ErrorProps) {
@@ -87,15 +87,17 @@ export default function ErrorPage(props: ErrorProps) {
     status,
     html: (
       <div className="error">
-      { theme?.brandColor && <style
-        dangerouslySetInnerHTML={{
-          __html: `
+        {theme?.brandColor && (
+          <style
+            dangerouslySetInnerHTML={{
+              __html: `
         :root {
           --brand-color: ${theme?.brandColor}
         }
       `,
-        }}
-      /> }
+            }}
+          />
+        )}
         {theme?.logo && <img src={theme.logo} alt="Logo" className="logo" />}
         <div className="card">
           <h1>{heading}</h1>

--- a/src/core/pages/signin.tsx
+++ b/src/core/pages/signin.tsx
@@ -1,12 +1,25 @@
 import { Theme } from "../.."
 import { InternalProvider } from "../../lib/types"
 
+export type SignInErrorTypes =
+  | "Signin"
+  | "OAuthSignin"
+  | "OAuthCallback"
+  | "OAuthCreateAccount"
+  | "EmailCreateAccount"
+  | "Callback"
+  | "OAuthAccountNotLinked"
+  | "EmailSignin"
+  | "CredentialsSignin"
+  | "SessionRequired"
+  | "default"
+
 export interface SignInServerPageParams {
   csrfToken: string
   providers: InternalProvider[]
   callbackUrl: string
   email: string
-  error: string
+  error: SignInErrorTypes
   theme: Theme
 }
 
@@ -39,7 +52,7 @@ export default function SigninPage(props: SignInServerPageParams) {
     )
   }
 
-  const errors: Record<string, string> = {
+  const errors: Record<SignInErrorTypes, string> = {
     Signin: "Try signing in with a different account.",
     OAuthSignin: "Try signing in with a different account.",
     OAuthCallback: "Try signing in with a different account.",
@@ -59,16 +72,17 @@ export default function SigninPage(props: SignInServerPageParams) {
 
   return (
     <div className="signin">
-      
-      { theme.brandColor && <style
-        dangerouslySetInnerHTML={{
-          __html: `
+      {theme.brandColor && (
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
         :root {
           --brand-color: ${theme.brandColor}
         }
       `,
-        }}
-      /> }
+          }}
+        />
+      )}
       {theme.logo && <img src={theme.logo} alt="Logo" className="logo" />}
       <div className="card">
         {error && (

--- a/src/core/pages/signin.tsx
+++ b/src/core/pages/signin.tsx
@@ -1,6 +1,10 @@
 import { Theme } from "../.."
 import { InternalProvider } from "../../lib/types"
 
+/**
+ * The following errors are passed as error query parameters to the default or overridden sign-in page.
+ *
+ * [Documentation](https://next-auth.js.org/configuration/pages#sign-in-page) */
 export type SignInErrorTypes =
   | "Signin"
   | "OAuthSignin"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

  This PR is intended to add typing for `<SigninPage />` component's `error` property as the following:

<img width="400" alt="Screenshot 2022-01-25 at 21 53 02" src="https://user-images.githubusercontent.com/6870986/151060461-0e98a642-3529-402f-a866-956de1cd569b.png">

After this change it will accept only the giving `string` values. Originally it accepted any `string` value.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #3665 

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #3665 
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
