### PR TITLE
NOT READY FOR REVIEW - WIP HACK to break free of NEXTAUTH_URL using http header

### DIFF
--- a/app/pages/protected-ssr.js
+++ b/app/pages/protected-ssr.js
@@ -30,7 +30,8 @@ export async function getServerSideProps(context) {
   let content = null
 
   if (session) {
-    const hostname = process.env.NEXTAUTH_URL || "http://localhost:3000"
+    if (!process.env.NEXTAUTH_URL) throw new Error('getServerSideProps does not have NEXTAUTH_URL')
+    const hostname = process.env.NEXTAUTH_URL
     const options = { headers: { cookie: context.req.headers.cookie } }
     const res = await fetch(`${hostname}/api/examples/protected`, options)
     const json = await res.json()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlas-ui/next-auth",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Authentication for Next.js",
   "homepage": "https://next-auth.js.org",
   "repository": "https://github.com/nextauthjs/next-auth.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlas-ui/next-auth",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Authentication for Next.js",
   "homepage": "https://next-auth.js.org",
   "repository": "https://github.com/nextauthjs/next-auth.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "0.0.0-semantically-released",
+  "version": "4.1.3",
   "description": "Authentication for Next.js",
   "homepage": "https://next-auth.js.org",
   "repository": "https://github.com/nextauthjs/next-auth.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "next-auth",
-  "version": "4.1.3",
+  "name": "@atlas-ui/next-auth",
+  "version": "4.1.2",
   "description": "Authentication for Next.js",
   "homepage": "https://next-auth.js.org",
   "repository": "https://github.com/nextauthjs/next-auth.git",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -69,6 +69,10 @@ export async function NextAuthHandler<
 
   const { action, providerId, error, method = "GET" } = req
 
+  if (!req.host) {
+    throw new Error('req.host is undefined')
+  }
+
   const { options, cookies } = await init({
     userOptions,
     action,

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -13,7 +13,7 @@ import { createCallbackUrl } from "./lib/callback-url"
 import { IncomingRequest } from "."
 
 interface InitParams {
-  host?: string
+  host: string
   userOptions: NextAuthOptions
   providerId?: string
   action: InternalOptions["action"]

--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -71,7 +71,7 @@ export async function getToken<R extends boolean = false>(
   const {
     req,
     secureCookie = process.env.NEXTAUTH_URL?.startsWith("https://") ??
-      !!process.env.VERCEL,
+      !!(process.env.NEXTAUTH_TRUST_X_FORWARDED_HOST || process.env.VERCEL),
     cookieName = secureCookie
       ? "__Secure-next-auth.session-token"
       : "next-auth.session-token",

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -82,7 +82,7 @@ export default _logger
 /** Serializes client-side log messages and sends them to the server */
 export function proxyLogger(
   logger: LoggerInstance = _logger,
-  basePath?: string
+  basePath: string
 ): LoggerInstance {
   try {
     if (typeof window === "undefined") {

--- a/src/lib/parse-url.ts
+++ b/src/lib/parse-url.ts
@@ -11,23 +11,26 @@ export interface InternalUrl {
   toString: () => string
 }
 
-export default function parseUrl(url?: string): InternalUrl {
-  const defaultUrl = new URL("http://localhost:3000/api/auth")
+export default function parseUrl(nextauthUrl: string): InternalUrl {
+  const defaultPathname = "/api/auth"
 
-  if (url && !url.startsWith("http")) {
-    url = `https://${url}`
-  }
+  const httpUrl = nextauthUrl.startsWith("http") ? nextauthUrl : (
+    nextauthUrl.startsWith("localhost:")
+      // probably don't want https on localhost:
+      ? `http://${nextauthUrl}`
+      : `https://${nextauthUrl}`
+  )
 
-  const _url = new URL(url ?? defaultUrl)
-  const path = (_url.pathname === "/" ? defaultUrl.pathname : _url.pathname)
+  const urlObj = new URL(httpUrl)
+  const path = (urlObj.pathname === "/" ? defaultPathname : urlObj.pathname)
     // Remove trailing slash
     .replace(/\/$/, "")
 
-  const base = `${_url.origin}${path}`
+  const base = `${urlObj.origin}${path}`
 
   return {
-    origin: _url.origin,
-    host: _url.host,
+    origin: urlObj.origin,
+    host: urlObj.host,
     path,
     base,
     toString: () => base,

--- a/src/next/utils.ts
+++ b/src/next/utils.ts
@@ -17,7 +17,7 @@ export function setCookie(res, cookie: Cookie) {
 /** Extract the host from the environment */
 export function detectHost(forwardedHost: any) {
   // If we detect a Vercel environment, we can trust the host
-  if (process.env.VERCEL) return forwardedHost
+  if (process.env.NEXTAUTH_TRUST_X_FORWARDED_HOST || process.env.VERCEL) return forwardedHost
   // If `NEXTAUTH_URL` is `undefined` we fall back to "http://localhost:3000"
   return process.env.NEXTAUTH_URL
 }

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -48,6 +48,8 @@ export * from "./types"
 //    variable and defaults to 'http://localhost:3000'.
 let __basePath: undefined | string = undefined
 const __NEXTAUTH: NextAuthClientConfig = {
+  // TODO: create api get something like `getForwardedHost`
+  // TODO: if process.env.NEXTAUTH_URL is undefined
   baseOrigin: (nextauthUrl) => parseUrl(nextauthUrl).origin,
   basePath(nextauthUrl?: string): string {
     if (__basePath) {

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -46,17 +46,26 @@ export * from "./types"
 //    relative URLs are valid in that context and so defaults to empty.
 // 2. When invoked server side the value is picked up from an environment
 //    variable and defaults to 'http://localhost:3000'.
+let __basePath: undefined | string = undefined
 const __NEXTAUTH: NextAuthClientConfig = {
-  baseUrl: parseUrl(process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL).origin,
-  basePath: parseUrl(process.env.NEXTAUTH_URL).path,
-  baseUrlServer: parseUrl(
-    process.env.NEXTAUTH_URL_INTERNAL ??
-      process.env.NEXTAUTH_URL ??
-      process.env.VERCEL_URL
-  ).origin,
-  basePathServer: parseUrl(
-    process.env.NEXTAUTH_URL_INTERNAL ?? process.env.NEXTAUTH_URL
-  ).path,
+  baseOrigin: (nextauthUrl) => parseUrl(nextauthUrl).origin,
+  basePath(nextauthUrl?: string): string {
+    if (__basePath) {
+      console.log('using set __basePath:', __basePath)
+      return __basePath
+    }
+    if (!nextauthUrl) nextauthUrl = 'nextauth_url.basePath' // "nextauth_url.basePath" will be discarded by parseUrl. TODO: cleanup
+    return parseUrl(nextauthUrl).path // will always be '/api/path'
+  },
+  setBasePath: (basePath) => { __basePath = basePath },
+  // TODO: change to optional? when preparing PR for github?
+  baseOriginServer: (nextauthUrl) => parseUrl(nextauthUrl).origin,
+  basePathServer(nextauthUrl?: string): string {
+    if (!nextauthUrl) nextauthUrl = 'nextauth_url.basePathServer' // "nextauth_url.basePathServer" will be discarded by parseUrl. TODO: cleanup
+    return parseUrl(
+      nextauthUrl
+    ).path
+  },
   _lastSync: 0,
   _session: undefined,
   _getSession: () => {},
@@ -64,7 +73,7 @@ const __NEXTAUTH: NextAuthClientConfig = {
 
 const broadcast = BroadcastChannel()
 
-const logger = proxyLogger(_logger, __NEXTAUTH.basePath)
+const logger = proxyLogger(_logger, __NEXTAUTH.basePath())
 
 export type SessionContextValue<R extends boolean = false> = R extends true
   ?
@@ -182,7 +191,8 @@ export async function signIn<
   P extends RedirectableProviderType ? SignInResponse | undefined : undefined
 > {
   const { callbackUrl = window.location.href, redirect = true } = options ?? {}
-
+  throw new Error("this signIn method is not used by devinrhode2's company")
+  // @ts-expect-error - remove when `throw` is removed.
   const baseUrl = apiBaseUrl(__NEXTAUTH)
   const providers = await getProviders()
 
@@ -190,15 +200,16 @@ export async function signIn<
     window.location.href = `${baseUrl}/error`
     return
   }
-
+  // @ts-expect-error - remove when `throw` is removed.
   if (!provider || !(provider in providers)) {
     window.location.href = `${baseUrl}/signin?${new URLSearchParams({
       callbackUrl,
     })}`
     return
   }
-
+  // @ts-expect-error - remove when `throw` is removed.
   const isCredentials = providers[provider].type === "credentials"
+  // @ts-expect-error - remove when `throw` is removed.
   const isEmail = providers[provider].type === "email"
   const isSupportingReturn = isCredentials || isEmail
 
@@ -256,6 +267,8 @@ export async function signOut<R extends boolean = true>(
   options?: SignOutParams<R>
 ): Promise<R extends true ? undefined : SignOutResponse> {
   const { callbackUrl = window.location.href } = options ?? {}
+  throw new Error('signout not yet supported')
+  // @ts-expect-error
   const baseUrl = apiBaseUrl(__NEXTAUTH)
   const fetchOptions = {
     method: "post",
@@ -297,7 +310,7 @@ export async function signOut<R extends boolean = true>(
 export function SessionProvider(props: SessionProviderProps) {
   const { children, basePath } = props
 
-  if (basePath) __NEXTAUTH.basePath = basePath
+  if (basePath) __NEXTAUTH.setBasePath(basePath)
 
   /**
    * If session was `null`, there was an attempt to fetch it,


### PR DESCRIPTION
We need to support multiple domain names pointing to the same next.js server (multi-tenancy). Other parts of our infrastructure will pass an `X-Forwarded-Host` header to this next.js server, which we need to use in place of the NEXTAUTH_URL.

This is just a hack to get working for our use case.
I noticed the `version:pr` npm script might actually publish this PR as a package, which is what I am trying to do by opening this PR. If it doesn't publish a package, then I will close and re-open later once this is ready for review

<sub>I tried using `patch-package` but was getting this `Can't find lockfile entry for next-auth` error :/</sub>

## Checklist 🧢

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## Related issues 🎟

#600 