### PR TITLE
added trakt provider

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -33,6 +33,9 @@ TWITTER_SECRET=
 LINE_ID=
 LINE_SECRET=
 
+TRAKT_ID=
+TRAKT_SECRET=
+
 # Example configuration for a Gmail account (will need SMTP enabled)
 EMAIL_SERVER=smtps://user@gmail.com:password@smtp.gmail.com:465
 EMAIL_FROM=user@gmail.com

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -28,6 +28,7 @@ import AzureB2C from "next-auth/providers/azure-ad-b2c"
 import OsuProvider from "next-auth/providers/osu"
 import AppleProvider from "next-auth/providers/apple"
 import PatreonProvider from "next-auth/providers/patreon"
+import TraktProvider from "next-auth/providers/trakt"
 
 // import { PrismaAdapter } from "@next-auth/prisma-adapter"
 // import { PrismaClient } from "@prisma/client"
@@ -189,7 +190,11 @@ export const authOptions: NextAuthOptions = {
     PatreonProvider({
       clientId: process.env.PATREON_ID,
       clientSecret: process.env.PATREON_SECRET,
-    })
+    }),
+    TraktProvider({
+      clientId: process.env.TRAKT_ID,
+      clientSecret: process.env.TRAKT_SECRET,
+    }),
   ],
   secret: process.env.SECRET,
   debug: true,

--- a/src/providers/trakt.ts
+++ b/src/providers/trakt.ts
@@ -29,29 +29,18 @@ export default function Trakt<
     token: "https://api.trakt.tv/oauth/token",
 
     userinfo: {
-      // custom data fetcher to compensate for
-      // unique headers required by the trakt api
       async request(context) {
-        if (!context.provider.clientId) {
-          throw new Error("clientId is required")
-        }
-
-        const headers = new Headers()
-        headers.set("Content-Type", "application/json")
-        headers.set("Authorization", `Bearer ${context.tokens.access_token}`)
-        headers.set("trakt-api-version", "2")
-        headers.set("trakt-api-key", context.provider.clientId)
-
         const res = await fetch("https://api.trakt.tv/users/me?extended=full", {
-          headers: headers,
+          headers: {
+            Authorization: `Bearer ${context.tokens.access_token}`,
+            "trakt-api-version": "2"
+            "trakt-api-key": context.provider.clientId as string,
+          },
         })
 
-        if (res.status !== 200) {
-          throw new Error("Expected 200 OK from the userinfo endpoint")
-        }
+        if (res.ok) return await res.json()
 
-        const data = await res.json()
-        return data
+        throw new Error("Expected 200 OK from the userinfo endpoint")
       },
     },
     profile(profile) {

--- a/src/providers/trakt.ts
+++ b/src/providers/trakt.ts
@@ -23,7 +23,7 @@ export default function Trakt<
     name: "Trakt",
     type: "oauth",
     authorization: {
-      url: "https://api.trakt.tv/oauth/authorize",
+      url: "https://trakt.tv/oauth/authorize",
       params: { scope: "" }, // when default, trakt returns auth error
     },
     token: "https://api.trakt.tv/oauth/token",

--- a/src/providers/trakt.ts
+++ b/src/providers/trakt.ts
@@ -1,0 +1,67 @@
+import { OAuthConfig, OAuthUserConfig } from "."
+
+export interface TraktUser {
+  username: string
+  private: boolean
+  name: string
+  vip: boolean
+  vip_ep: boolean
+  ids: { slug: string }
+  joined_at: string
+  location: string | null
+  about: string | null
+  gender: string | null
+  age: number | null
+  images: { avatar: { full: string } }
+}
+
+export default function Trakt<
+  P extends Record<string, any> = TraktUser
+>(options: OAuthUserConfig<P>): OAuthConfig<P> {
+  return {
+    id: "trakt",
+    name: "Trakt",
+    type: "oauth",
+    authorization: {
+      url: "https://api.trakt.tv/oauth/authorize",
+      params: { scope: "" }, // when default, trakt returns auth error
+    },
+    token: "https://api.trakt.tv/oauth/token",
+
+    userinfo: {
+      // custom data fetcher to compensate for
+      // unique headers required by the trakt api
+      async request(context) {
+        if (!context.provider.clientId) {
+          throw new Error("clientId is required")
+        }
+
+        const headers = new Headers()
+        headers.set("Content-Type", "application/json")
+        headers.set("Authorization", `Bearer ${context.tokens.access_token}`)
+        headers.set("trakt-api-version", "2")
+        headers.set("trakt-api-key", context.provider.clientId)
+
+        const res = await fetch("https://api.trakt.tv/users/me?extended=full", {
+          headers: headers,
+        })
+
+        if (res.status !== 200) {
+          throw new Error("Expected 200 OK from the userinfo endpoint")
+        }
+
+        const data = await res.json()
+        return data
+      },
+    },
+    profile(profile) {
+      return {
+        id: profile.ids.slug,
+        name: profile.name,
+        email: null, // trakt does not provide user emails
+        image: profile.images.avatar.full, // trakt does not allow hotlinking
+      }
+    },
+    options,
+  }
+}

--- a/src/providers/trakt.ts
+++ b/src/providers/trakt.ts
@@ -1,4 +1,4 @@
-import { OAuthConfig, OAuthUserConfig } from "."
+import type { OAuthConfig, OAuthUserConfig } from "."
 
 export interface TraktUser {
   username: string

--- a/src/providers/trakt.ts
+++ b/src/providers/trakt.ts
@@ -33,7 +33,7 @@ export default function Trakt<
         const res = await fetch("https://api.trakt.tv/users/me?extended=full", {
           headers: {
             Authorization: `Bearer ${context.tokens.access_token}`,
-            "trakt-api-version": "2"
+            "trakt-api-version": "2",
             "trakt-api-key": context.provider.clientId as string,
           },
         })


### PR DESCRIPTION
Added [Trakt](https://trakt.tv) provider

## Reasoning 💡

I'm making an app that uses the trakt api. So figured adding it as a provider would be helpful.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged


## Proof

![2022_01_31-12_40_06](https://user-images.githubusercontent.com/47277246/151783377-82cde8eb-d58e-4008-9ee8-fefc202c2fea.png)

- Trakt does not provide the user's emails
- The profile image link cannot be hotlinked as seen in the image above. Trakt returns an access forbidden error

This is the first time I'm making a pull request so I hope there aren't any loose ends.