### PR TITLE
feat(core): detect `NEXTAUTH_SECRET`

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -7,7 +7,7 @@ NEXTAUTH_URL=http://localhost:3000
 # https://generate-secret.vercel.app/32 to generate a secret.
 # Note: Changing a secret may invalidate existing sessions
 # and/or verification tokens.
-SECRET=secret
+NEXTAUTH_SECRET=secret
 
 AUTH0_ID=
 AUTH0_SECRET=

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -189,9 +189,8 @@ export const authOptions: NextAuthOptions = {
     PatreonProvider({
       clientId: process.env.PATREON_ID,
       clientSecret: process.env.PATREON_SECRET,
-    })
+    }),
   ],
-  secret: process.env.SECRET,
   debug: true,
   theme: {
     colorScheme: "auto",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -27,9 +27,10 @@ export interface NextAuthOptions {
   providers: Provider[]
   /**
    * A random string used to hash tokens, sign cookies and generate cryptographic keys.
-   * If not specified is uses a hash of all configuration options, including Client ID / Secrets for entropy.
-   * The default behavior is volatile, and **it is strongly recommended** you explicitly specify a value
-   * to avoid invalidating end user sessions when configuration changes are deployed.
+   * If not specified, it falls back to `jwt.secret` or `NEXTAUTH_SECRET` from environment vairables.
+   * Otherwise it will use a hash of all configuration options, including Client ID / Secrets for entropy.
+   *
+   * NOTE: The last behavior is extrmely volatile, and will throw an error in production.
    * * **Default value**: `string` (SHA hash of the "options" object)
    * * **Required**: No - **but strongly recommended**!
    *

--- a/src/jwt/types.ts
+++ b/src/jwt/types.ts
@@ -34,7 +34,11 @@ export interface JWTDecodeParams {
 }
 
 export interface JWTOptions {
-  /** The secret used to encode/decode the NextAuth.js issued JWT. */
+  /**
+   * The secret used to encode/decode the NextAuth.js issued JWT.
+   * @deprecated  Set the `NEXTAUTH_SECRET` environment vairable or
+   * use the top-level `secret` option instead
+   */
   secret: string
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.

--- a/src/next/index.ts
+++ b/src/next/index.ts
@@ -19,6 +19,10 @@ async function NextAuthNextHandler(
   options: NextAuthOptions
 ) {
   const { nextauth, ...query } = req.query
+
+  options.secret =
+    options.secret ?? options.jwt?.secret ?? process.env.NEXTAUTH_SECRET
+
   const handler = await NextAuthHandler({
     req: {
       host: detectHost(req.headers["x-forwarded-host"]),


### PR DESCRIPTION
Since v4, we have made providing a secret mandatory in production. The `NextAuth` configuration (in `[...nextauth].js`) required either the top-level `secret` or `jwt.secret` values to be set, otherwise an error is thrown. https://next-auth.js.org/errors#no_secret

To make this configuration easier (which ties in with #3657), we are going to detect if you set a `NEXTAUTH_SECRET` variable automatically, so it is less likely that you end up with the above error.


## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
