### PR TITLE
fix(middleware): handle no argument case

### DIFF
--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -75,7 +75,10 @@ async function handleMiddleware(
       `\nhttps://next-auth.js.org/errors#no_secret`
     )
 
-    return NextResponse.redirect(`${errorPage}?error=Configuration`)
+    const errorUrl = new URL(errorPage, req.nextUrl.host)
+    errorUrl.searchParams.append("error", "Configuration")
+
+    return NextResponse.redirect(errorUrl)
   }
 
   const token = await getToken({ req: req as any })
@@ -86,10 +89,10 @@ async function handleMiddleware(
   // the user is authorized, let the middleware handle the rest
   if (isAuthorized) return await onSuccess?.(token)
 
-  // the user is not logged in, re-direct to the sign-in page
-  return NextResponse.redirect(
-    `${signInPage}?${new URLSearchParams({ callbackUrl: req.url })}`
-  )
+  // the user is not logged in, redirect to the sign-in page
+  const signInUrl = new URL(signInPage, req.nextUrl.host)
+  signInUrl.searchParams.append("callbackUrl", req.url)
+  return NextResponse.redirect(signInUrl)
 }
 
 export type WithAuthArgs =

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -75,7 +75,7 @@ async function handleMiddleware(
       `\nhttps://next-auth.js.org/errors#no_secret`
     )
 
-    const errorUrl = new URL(errorPage, req.nextUrl.host)
+    const errorUrl = new URL(errorPage, req.nextUrl.origin)
     errorUrl.searchParams.append("error", "Configuration")
 
     return NextResponse.redirect(errorUrl)
@@ -90,7 +90,7 @@ async function handleMiddleware(
   if (isAuthorized) return await onSuccess?.(token)
 
   // the user is not logged in, redirect to the sign-in page
-  const signInUrl = new URL(signInPage, req.nextUrl.host)
+  const signInUrl = new URL(signInPage, req.nextUrl.origin)
   signInUrl.searchParams.append("callbackUrl", req.url)
   return NextResponse.redirect(signInUrl)
 }

--- a/src/next/middleware.ts
+++ b/src/next/middleware.ts
@@ -75,9 +75,7 @@ async function handleMiddleware(
       `\nhttps://next-auth.js.org/errors#no_secret`
     )
 
-    return {
-      redirect: NextResponse.redirect(`${errorPage}?error=Configuration`),
-    }
+    return NextResponse.redirect(`${errorPage}?error=Configuration`)
   }
 
   const token = await getToken({ req: req as any })
@@ -101,6 +99,7 @@ export type WithAuthArgs =
   | [NextMiddleware]
   | [NextMiddleware, NextAuthMiddlewareOptions]
   | [NextAuthMiddlewareOptions]
+  | []
 
 /**
  * Middleware that checks if the user is authenticated/authorized.
@@ -118,7 +117,7 @@ export type WithAuthArgs =
  * [Documentation](https://next-auth.js.org/getting-started/middleware)
  */
 export function withAuth(...args: WithAuthArgs) {
-  if (args[0] instanceof NextRequest) {
+  if (!args.length || args[0] instanceof NextRequest) {
     // @ts-expect-error
     return handleMiddleware(...args)
   }


### PR DESCRIPTION
`export { default } from "next-auth/middleware`

and

```js
import withAuth from "next-auth/middleware"
export default withAuth()
```

cases were broken.

Also changed to using absolute URLs when redirecting.

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
