### PR TITLE
chore: separate build commands for core and app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,6 @@ jobs:
         uses: NejcZdovc/comment-pr@v1
         with:
           message: "🎉 Experimental release [published on npm](https://www.npmjs.com/package/next-auth/v/${{ env.VERSION }})!\n\n```sh\nnpm i next-auth@${{ env.VERSION }}\n```\n```sh\nyarn add next-auth@${{ env.VERSION }}\n```"
-
         env:
           VERSION: ${{ steps.determine-version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
         uses: NejcZdovc/comment-pr@v1
         with:
           message: "🎉 Experimental release [published on npm](https://www.npmjs.com/package/next-auth/v/${{ env.VERSION }})!\n\n```sh\nnpm i next-auth@${{ env.VERSION }}\n```\n```sh\nyarn add next-auth@${{ env.VERSION }}\n```"
+
         env:
           VERSION: ${{ steps.determine-version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "repository": "https://github.com/nextauthjs/next-auth.git",
   "scripts": {
-    "build": "turbo run build",
+    "build:app": "turbo run build --scope=next-auth-app --include-dependencies",
+    "build": "turbo run build --scope=next-auth --scope=@next-auth/* --no-deps",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint -- --fix",
     "test": "turbo run test --concurrency=1 --ignore=packages/adapter-pouch/*",

--- a/packages/next-auth/tsconfig.json
+++ b/packages/next-auth/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
+    "emitDeclarationOnly": true,
     "baseUrl": ".",
-    "outDir": ".",
+    "outDir": "."
   },
   "exclude": ["config"]
 }

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "emitDeclarationOnly": true,
     "strictNullChecks": true,
     "target": "es2019",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Reasoning 💡

Separate build command for `next-auth` and `next-auth-app`.

## Checklist 🧢

- ~[ ] Documentation~
- [x] Move `emitDeclarationOnly` to `next-auth` only
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

