### PR TITLE
chore: add example syncing

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,5 @@
+nextauthjs/next-auth-example-sync-test@main:
+  - .github/FUNDING.yml
+  - source: apps/example
+      dest: .
+      deleteOrphaned: true

--- a/.github/workflows/sync-example.yml
+++ b/.github/workflows/sync-example.yml
@@ -1,0 +1,16 @@
+name: Sync Example Repository
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.SYNC_EXAMPLE_PAT }}


### PR DESCRIPTION
Partially solves #3650. We would like to manage all code from the same repository. This makes it possible to manage the example template repository https://github.com/nextauthjs/next-auth-example and keep it in sync.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
