### PR TITLE
feat(docs): Fauna Adapter setup commands split into two sections

### DIFF
--- a/packages/docs/docs/adapters/fauna.md
+++ b/packages/docs/docs/adapters/fauna.md
@@ -51,7 +51,6 @@ CreateCollection({ name: "sessions" })
 CreateCollection({ name: "users" })
 CreateCollection({ name: "verification_tokens" })
 ```
-
 ```javascript
 CreateIndex({
   name: "account_by_provider_and_provider_account_id",

--- a/packages/docs/docs/adapters/fauna.md
+++ b/packages/docs/docs/adapters/fauna.md
@@ -50,6 +50,9 @@ CreateCollection({ name: "accounts" })
 CreateCollection({ name: "sessions" })
 CreateCollection({ name: "users" })
 CreateCollection({ name: "verification_tokens" })
+```
+
+```javascript
 CreateIndex({
   name: "account_by_provider_and_provider_account_id",
   source: Collection("accounts"),


### PR DESCRIPTION
## Reasoning 💡

Make commands for setup with Fauna adapter displayed in docs so newcomers are less likely to encounter an error in Fauna Console.

## Checklist 🧢

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

Closes [#3858](https://github.com/nextauthjs/next-auth/issues/3858)


## Comments
I think splitting into two code blocks will do the trick. Especially since snippets have `Copy` button, which will likely dictate how commands are being put into Fauna.