### PR TITLE
chore: Improve package dependencies cache speed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - name: Init
         uses: actions/checkout@v2
-      - name: Setup Node
-        uses: actions/setup-node@v1
+      - name: Setup Node & Install dependencies
+        uses: actions/setup-node@v2
         with:
           node-version: 16
-      - name: Dependencies
-        uses: bahmutov/npm-install@v1
+          cache: 'yarn'
+        run: yarn --frozen-lockfile
       - name: Build
         run: npm run build
       - name: Run tests
@@ -43,12 +43,12 @@ jobs:
     steps:
       - name: Init
         uses: actions/checkout@v2
-      - name: Setup Node
-        uses: actions/setup-node@v1
+      - name: Setup Node & Install dependencies
+        uses: actions/setup-node@v2
         with:
           node-version: 16
-      - name: Dependencies
-        uses: bahmutov/npm-install@v1
+          cache: 'yarn'
+        run: yarn --frozen-lockfile
       - name: Publish to npm and GitHub
         run: |
           cd packages/next-auth
@@ -65,12 +65,12 @@ jobs:
     steps:
       - name: Init
         uses: actions/checkout@v2
-      - name: Setup Node
-        uses: actions/setup-node@v1
+      - name: Setup Node & Install dependencies
+        uses: actions/setup-node@v2
         with:
           node-version: 16
-      - name: Dependencies
-        uses: bahmutov/npm-install@v1
+          cache: 'yarn'
+        run: yarn --frozen-lockfile
       - name: Determine version
         uses: ./.github/version-pr
         id: determine-version


### PR DESCRIPTION
## Reasoning 💡

Improve caching for installing dependencies on CI. Even though there are cache hits when installing dependencies with `bahmutov/npm-install@v1`, it took ~100s to do the operation.

This PR gives `setup-node@v2` a try. It also provides caching when installing dependencies and uses `https://github.com/actions/cache` under the hood.
<img width="1500" alt="Screen Shot 2022-02-09 at 14 08 11" src="https://user-images.githubusercontent.com/31528554/153139432-6fac3233-2342-4e21-8902-c2b18dc1799e.png">


## Checklist 🧢

- ~[ ] Documentation~
- ~[ ] Tests~
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

