### PR TITLE
docs: Typo correction for type import

### DIFF
--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -102,7 +102,7 @@ With the above code, you just made sure that only user's with the `admin` role c
 
 ```ts title="pages/admin/_middleware.ts"
 import type { NextRequest } from "next/server"
-import type { JWT } from "next-auth"
+import type { JWT } from "next-auth/jwt"
 
 import { withAuth } from "next-auth/middleware"
 


### PR DESCRIPTION
Fix incorrect JWT type import path.

## Reasoning 💡

The "wrap middleware" example has an incorrect path for the JWT type import.

## Checklist 🧢

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## Affected issues 🎟

