### PR TITLE
fix: only warn when using Twitter + OAuth 2.0

### DIFF
--- a/packages/next-auth/src/core/lib/assert.ts
+++ b/packages/next-auth/src/core/lib/assert.ts
@@ -47,12 +47,13 @@ export function assertConfig(
   if (!req.host) return "NEXTAUTH_URL"
 
   let hasCredentials, hasEmail
-  let hasTwitterProvider
+  let hasTwitterOAuth2
 
   for (const provider of options.providers) {
     if (provider.type === "credentials") hasCredentials = true
     else if (provider.type === "email") hasEmail = true
-    else if (provider.id === "twitter") hasTwitterProvider = true
+    else if (provider.id === "twitter" && provider.version === "2.0")
+      hasTwitterOAuth2 = true
   }
 
   if (hasCredentials) {
@@ -80,7 +81,7 @@ export function assertConfig(
     return new MissingAdapter("E-mail login requires an adapter.")
   }
 
-  if (!twitterWarned && hasTwitterProvider) {
+  if (!twitterWarned && hasTwitterOAuth2) {
     twitterWarned = true
     return "TWITTER_OAUTH_2_BETA"
   }


### PR DESCRIPTION
@TheoBr reported this to me, thank you. We should only show the warning if the user opts into Twitter + OAuth 2.0, as their implementation is still somewhat subject to change.

In a future release, we can swap this warning to encourage people to use OAuth 2.0, so after that we can finally drop support for OAuth 1.0 support together with a 5-year-old 130kb dependency, decreasing the install size by ~40%! 

- https://packagephobia.com/result?p=oauth
- https://packagephobia.com/result?p=next-auth

I would like to entertain the idea that once we get the green light from Twitter to advertise their OAuth 2 over OAuth 1, we just bump to v5 and only require the user to install the `oauth` dependency only if they use Twitter 1.

The code is already pretty safe and would not block other users to decrease their bundle size.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
