### PR TITLE
feat(mikro-orm): simplify mikro-orm configuration

### DIFF
--- a/docs/docs/adapters/mikro-orm.md
+++ b/docs/docs/adapters/mikro-orm.md
@@ -6,7 +6,7 @@ title: MikroORM
 To use this Adapter, you need to install Mikro ORM, the driver that suits your database, and the separate `@next-auth/mikro-orm-adapter` package:
 
 ```bash npm2yarn
-npm install next-auth @next-auth/mikro-orm-adapter @mikro-orm/core@latest @mikro-orm/[YOUR DRIVER]@latest
+npm install next-auth @next-auth/mikro-orm-adapter @mikro-orm/core @mikro-orm/[YOUR DRIVER]
 ```
 
 Configure NextAuth.js to use the MikroORM Adapter:

--- a/docs/docs/adapters/mikro-orm.md
+++ b/docs/docs/adapters/mikro-orm.md
@@ -6,7 +6,7 @@ title: MikroORM
 To use this Adapter, you need to install Mikro ORM, the driver that suits your database, and the separate `@next-auth/mikro-orm-adapter` package:
 
 ```bash npm2yarn
-npm install next-auth @next-auth/mikro-orm-adapter @mikro-orm/core@next @mikro-orm/[YOUR DRIVER]@next
+npm install next-auth @next-auth/mikro-orm-adapter @mikro-orm/core@latest @mikro-orm/[YOUR DRIVER]@latest
 ```
 
 Configure NextAuth.js to use the MikroORM Adapter:
@@ -31,7 +31,7 @@ export default NextAuth({
 
 ### Passing custom entities
 
-The MikroORM adapter ships with its own set of entities. If you'd like to override them, you can optionally pass them to the adapter.
+The MikroORM adapter ships with its own set of entities. If you'd like to extend them, you can optionally pass them to the adapter.
 
 > This schema is adapted for use in MikroORM and based upon our main [schema](/adapters/models)
 

--- a/packages/adapter-mikro-orm/README.md
+++ b/packages/adapter-mikro-orm/README.md
@@ -35,7 +35,6 @@ This is the MikroORM Adapter for [`next-auth`](https://next-auth.js.org). This p
    export default NextAuth({
       // https://next-auth.js.org/configuration/providers
       providers: [],
-      // optionally pass extended models as { entities: { } }
       adapter: MikroOrmAdapter({
          dbName: "./db.sqlite",
          type: "sqlite",

--- a/packages/adapter-mikro-orm/README.md
+++ b/packages/adapter-mikro-orm/README.md
@@ -41,6 +41,8 @@ This is the MikroORM Adapter for [`next-auth`](https://next-auth.js.org). This p
          type: "sqlite",
          debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
          ...
+      }, {
+         // pass extended models as { entities: { } } if needed
       }),
       ...
    });

--- a/packages/adapter-mikro-orm/package.json
+++ b/packages/adapter-mikro-orm/package.json
@@ -32,12 +32,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
+    "@mikro-orm/core": "^5.0.2",
     "next-auth": "^4.0.1"
   },
   "devDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/sqlite": "^5.0.0"
+    "@mikro-orm/core": "^5.0.2",
+    "@mikro-orm/sqlite": "^5.0.2"
   },
   "jest": {
     "preset": "adapter-test/jest"

--- a/packages/adapter-mikro-orm/src/index.ts
+++ b/packages/adapter-mikro-orm/src/index.ts
@@ -1,55 +1,66 @@
-import type { Options } from "@mikro-orm/core"
+import type {
+  AnyEntity,
+  EntityClass,
+  EntityClassGroup,
+  EntitySchema,
+  Options as ORMOptions,
+} from "@mikro-orm/core"
 import { MikroORM, wrap } from "@mikro-orm/core"
 import * as defaultEntities from "./entities"
 
 import type { Adapter } from "next-auth/adapters"
-import { isPromise } from "util/types"
 
 export * as defaultEntities from "./entities"
 
 /**
- * The MikroORM adapter accepts a MikroORM instance or configuration and returns a NextAuth adapter.
- * @param ormConnection can either be an instance promise or a MikroORM connection configuration (https://mikro-orm.io/docs/next/configuration#driver)
- * @param options entities in the options object will be passed to the MikroORM init function as entities
+ * The MikroORM adapter accepts a MikroORM configuration and returns a NextAuth adapter.
+ * @param ormConnection a MikroORM connection configuration (https://mikro-orm.io/docs/next/configuration#driver)
+ * @param options entities in the options object will be passed to the MikroORM init function as entities. Has to be provided if overridden!
  * @returns
  */
 export function MikroOrmAdapter(
-  ormConnection: Promise<MikroORM> | Options,
+  ormOptions: ORMOptions,
   options?: {
     entities?: Partial<typeof defaultEntities>
   }
 ): Adapter {
-  const {
-    User: UserModel,
-    Account: AccountModel,
-    Session: SessionModel,
-    VerificationToken: VerificationTokenModel,
-  } = { ...defaultEntities, ...options?.entities }
+  const UserModel = options?.entities?.User ?? defaultEntities.User
+  const AccountModel = options?.entities?.Account ?? defaultEntities.Account
+  const SessionModel = options?.entities?.Session ?? defaultEntities.Session
+  const VerificationTokenModel =
+    options?.entities?.VerificationToken ?? defaultEntities.VerificationToken
+
+  let _orm: MikroORM
 
   const getEM = async () => {
-    if (!isPromise(ormConnection)) {
-      if (typeof ormConnection.entities === "string")
-        throw new Error("You have to pass class entities to MikroORM.init")
-
+    if (!_orm) {
       // filter out default entities from the passed entities
-      const connectionEntities = ormConnection.entities?.filter((e) => {
-        if (typeof e !== "string" && "name" in e && typeof e.name === "string")
-          return !["User", "Account", "Session", "VerificationToken"].includes(
-            e.name
+      const optionsEntities =
+        ormOptions.entities?.filter((e) => {
+          if (
+            typeof e !== "string" &&
+            "name" in e &&
+            typeof e.name === "string"
           )
-        return true
-      })
+            return ![
+              "User",
+              "Account",
+              "Session",
+              "VerificationToken",
+            ].includes(e.name)
+          return true
+        }) ?? []
       // add the (un-)enhanced entities to the connection
-      ormConnection.entities = [
-        ...(connectionEntities ?? []),
+      ormOptions.entities = [
+        ...optionsEntities,
         UserModel,
         AccountModel,
         SessionModel,
         VerificationTokenModel,
       ]
-      ormConnection = MikroORM.init(ormConnection)
+      _orm = await MikroORM.init(ormOptions)
     }
-    return await ormConnection.then((orm) => orm.em.fork())
+    return _orm.em.fork()
   }
 
   return {

--- a/packages/adapter-mikro-orm/src/index.ts
+++ b/packages/adapter-mikro-orm/src/index.ts
@@ -1,8 +1,10 @@
 import type {
   AnyEntity,
+  Connection,
   EntityClass,
   EntityClassGroup,
   EntitySchema,
+  IDatabaseDriver,
   Options as ORMOptions,
 } from "@mikro-orm/core"
 import { MikroORM, wrap } from "@mikro-orm/core"
@@ -18,8 +20,8 @@ export * as defaultEntities from "./entities"
  * @param options entities in the options object will be passed to the MikroORM init function as entities. Has to be provided if overridden!
  * @returns
  */
-export function MikroOrmAdapter(
-  ormOptions: ORMOptions,
+export function MikroOrmAdapter<D extends IDatabaseDriver<Connection> = IDatabaseDriver<Connection>>(
+  ormOptions: ORMOptions<D>,
   options?: {
     entities?: Partial<typeof defaultEntities>
   }

--- a/packages/adapter-mikro-orm/tests/index.test.ts
+++ b/packages/adapter-mikro-orm/tests/index.test.ts
@@ -1,4 +1,6 @@
 import type { Options } from "@mikro-orm/core"
+import type { SqliteDriver } from "@mikro-orm/sqlite"
+
 import { MikroORM, wrap } from "@mikro-orm/core"
 import { runBasicTests } from "adapter-test"
 import { MikroOrmAdapter, defaultEntities } from "../src"
@@ -14,7 +16,7 @@ const entities = [
   VeryImportantEntity,
 ]
 
-const config: Options = {
+const config: Options<SqliteDriver> = {
   dbName: "./db.sqlite",
   type: "sqlite",
   entities,

--- a/packages/adapter-mikro-orm/tests/index.test.ts
+++ b/packages/adapter-mikro-orm/tests/index.test.ts
@@ -1,3 +1,4 @@
+import type { Options } from "@mikro-orm/core"
 import { MikroORM, wrap } from "@mikro-orm/core"
 import { runBasicTests } from "adapter-test"
 import { MikroOrmAdapter, defaultEntities } from "../src"
@@ -13,34 +14,22 @@ const entities = [
   VeryImportantEntity,
 ]
 
+const config: Options = {
+  dbName: "./db.sqlite",
+  type: "sqlite",
+  entities,
+  debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
+}
+
 async function getORM() {
   if (_init) return _init
 
-  _init = await MikroORM.init({
-    dbName: "./db.sqlite",
-    type: "sqlite",
-    entities,
-    debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
-  })
+  _init = await MikroORM.init(config)
   return _init
 }
 
 runBasicTests({
-  adapter: MikroOrmAdapter(
-    {
-      dbName: "./db.sqlite",
-      type: "sqlite",
-      entities: [
-        defaultEntities.User,
-        defaultEntities.Account,
-        defaultEntities.Session,
-        defaultEntities.VerificationToken,
-        VeryImportantEntity,
-      ],
-      debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
-    },
-    { entities: { User } }
-  ),
+  adapter: MikroOrmAdapter(config, { entities: { User } }),
   db: {
     async connect() {
       const orm = await getORM()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,12 +3277,11 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@mikro-orm/core@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@mikro-orm/core/-/core-5.0.0.tgz#4a463d68a11f1e2a36737fad73155dcf0563a428"
-  integrity sha512-zJ1e3OiCbmFtQ6MxDxESB9VJ/GkAoa8hB62aqsXANOEGzFeYLSzxenE6hA/Z/LUQ/b2F3VnAbKfL8If3s7m0fQ==
+"@mikro-orm/core@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/core/-/core-5.0.2.tgz#6a671686e1f7c9457b328d7800aa60eaab0ab917"
+  integrity sha512-cWCOOzOIhnhl2QmVpf2xoiZNhVn4Ak15nCZPT8wlD0aJe9K45MpWuIoDEJCet8l2tPwBWSWN0CO1zHdATOmaxQ==
   dependencies:
-    clone "2.1.2"
     dotenv "16.0.0"
     escaya "0.0.61"
     fs-extra "10.0.0"
@@ -3290,21 +3289,21 @@
     mikro-orm "^5.0.0"
     reflect-metadata "0.1.13"
 
-"@mikro-orm/knex@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@mikro-orm/knex/-/knex-5.0.0.tgz#586f9452c65952c7230d9e75d99178934773b1a5"
-  integrity sha512-EuMt0KPsqfpTktWC+VeCuG3thbMX3Z8bf+XOg1GY+hm2aHf2849MfZ6voqwQnYtQeQnIYyZuWJo4ZbghoF+9PQ==
+"@mikro-orm/knex@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/knex/-/knex-5.0.2.tgz#6a197900089bb7cbd9098cea78d0bc2aa3543d64"
+  integrity sha512-C1uq5qNctpFgBZ630UlCO6xML/TwfAWo7VYGBQPxW1Zg/13XHc0Y22GZg0xT0tzsA/lw9U6GlZ2wVHMqYnm4CQ==
   dependencies:
     fs-extra "10.0.0"
-    knex "1.0.1"
+    knex "1.0.3"
     sqlstring "2.3.2"
 
-"@mikro-orm/sqlite@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@mikro-orm/sqlite/-/sqlite-5.0.0.tgz#cd6b81d1a2c4295289294d18f8be8d55c2969baa"
-  integrity sha512-65tQ7W4pdAFH7lvDHiVYGl0rjmYI8kDWu5hpt3MQvLRSTpg7RLiFAmusiOXF0k/NOCAzYAx+UvuLd8U+evCcKA==
+"@mikro-orm/sqlite@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/sqlite/-/sqlite-5.0.2.tgz#36c8346027a10f5cc041f5ab1fb73749cbe01aab"
+  integrity sha512-FOKDgd64E4TsWEnkixnSyQy0pev+dE8Wo+purhllobkpkRLuN8iU5O5uniwGzddooCVawNE5S52w6loTSeni2A==
   dependencies:
-    "@mikro-orm/knex" "^5.0.0"
+    "@mikro-orm/knex" "^5.0.2"
     "@vscode/sqlite3" "5.0.7"
     fs-extra "10.0.0"
     sqlstring-sqlite "0.1.1"
@@ -6415,11 +6414,6 @@ clone-response@^1.0.2:
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
-
-clone@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 clone@^1.0.2:
   version "1.0.4"
@@ -12326,10 +12320,10 @@ klona@^2.0.5:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-knex@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-1.0.1.tgz#0916dc2b79375cd15bfbf0d70bf3c5ef5f411a33"
-  integrity sha512-pusgMo74lEbUxmri+YfWV8x/LJacP/2KcemTCKH7WnXFYz5RoMi+8WM4OJ05b0glfF+aWB4nkFsxsXxJ8qioLQ==
+knex@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-1.0.3.tgz#a5f97aa98e5e036cfd0209a90d53b2a411280e84"
+  integrity sha512-rY1T7cgTQGHAUD9TshMka37bd+SEK+koPXXvZQEIoE8yjJ/E8ShsenaAmr3oaNNzqXuKD/SC0qlYtp7Js8tAXA==
   dependencies:
     colorette "2.0.16"
     commander "^8.3.0"


### PR DESCRIPTION
## Reasoning 💡

Wanted to clean up the mikro-orm adapter configuration a bit, so it now just accepts a mikro-orm config and no longer a initialized connection (which has not been documented anyway). In addition removed modern node16 methods for downwards compatibility (came up in #3816)

## Checklist 🧢

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

closes https://github.com/nextauthjs/next-auth/issues/3816