### PR TITLE
Fixes secure schema auth rule syntax error in the dgraph documentation

### DIFF
--- a/docs/docs/adapters/dgraph.md
+++ b/docs/docs/adapters/dgraph.md
@@ -100,10 +100,10 @@ by next-auth. The main form of access control used in Dgraph is via `@auth` dire
 ```graphql
 type Account
   @auth(
-    delete: { rule: "{$nextAuth { eq: true } }" }
-    add: { rule: "{$nextAuth { eq: true } }" }
-    query: { rule: "{$nextAuth { eq: true } }" }
-    update: { rule: "{$nextAuth { eq: true } }" }
+    delete: { rule: "{$nextAuth: { eq: true } }" }
+    add: { rule: "{$nextAuth: { eq: true } }" }
+    query: { rule: "{$nextAuth: { eq: true } }" }
+    update: { rule: "{$nextAuth: { eq: true } }" }
   ) {
   id: ID
   type: String
@@ -122,10 +122,10 @@ type Account
 }
 type Session
   @auth(
-    delete: { rule: "{$nextAuth { eq: true } }" }
-    add: { rule: "{$nextAuth { eq: true } }" }
-    query: { rule: "{$nextAuth { eq: true } }" }
-    update: { rule: "{$nextAuth { eq: true } }" }
+    delete: { rule: "{$nextAuth: { eq: true } }" }
+    add: { rule: "{$nextAuth: { eq: true } }" }
+    query: { rule: "{$nextAuth: { eq: true } }" }
+    update: { rule: "{$nextAuth: { eq: true } }" }
   ) {
   id: ID
   expires: DateTime
@@ -141,11 +141,11 @@ type User
           query ($userId: String!) {queryUser(filter: { id: { eq: $userId } } ) {id}}
           """
         }
-        { rule: "{$nextAuth { eq: true } }" }
+        { rule: "{$nextAuth: { eq: true } }" }
       ]
     }
-    delete: { rule: "{$nextAuth { eq: true } }" }
-    add: { rule: "{$nextAuth { eq: true } }" }
+    delete: { rule: "{$nextAuth: { eq: true } }" }
+    add: { rule: "{$nextAuth: { eq: true } }" }
     update: {
       or: [
         {
@@ -153,7 +153,7 @@ type User
           query ($userId: String!) {queryUser(filter: { id: { eq: $userId } } ) {id}}
           """
         }
-        { rule: "{$nextAuth { eq: true } }" }
+        { rule: "{$nextAuth: { eq: true } }" }
       ]
     }
   ) {
@@ -168,10 +168,10 @@ type User
 
 type VerificationToken
   @auth(
-    delete: { rule: "{$nextAuth { eq: true } }" }
-    add: { rule: "{$nextAuth { eq: true } }" }
-    query: { rule: "{$nextAuth { eq: true } }" }
-    update: { rule: "{$nextAuth { eq: true } }" }
+    delete: { rule: "{$nextAuth: { eq: true } }" }
+    add: { rule: "{$nextAuth: { eq: true } }" }
+    query: { rule: "{$nextAuth: { eq: true } }" }
+    update: { rule: "{$nextAuth: { eq: true } }" }
   ) {
   id: ID
   identifier: String @search(by: [hash])


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

The secure schema for the dgraph adapter example has an invalid rule syntax error in it.

I've updated the documentation to a valid dgraph schema definition. 

The `{ rule: "{$nextAuth { eq: true } }" }` rule was simply missing a `:` i.e. `{ rule: "{$nextAuth: { eq: true } }" }`

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
