### PR TITLE
fix: Replay cache output for `next-auth`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,24 @@
     "build": {
       "dependsOn": ["^build"]
     },
+    "next-auth#build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        "lib/**",
+        "css/**",
+        "jwt/**",
+        "react/**",
+        "next/**",
+        "client/**",
+        "providers/**",
+        "core/**",
+        "index.d.ts",
+        "index.js",
+        "adapters.d.ts",
+        "middleware.d.ts",
+        "middleware.js"
+      ]
+    },
     "test": {
       "dependsOn": ["lint", "build"],
       "outputs": []


### PR DESCRIPTION

## Reasoning 💡

Configure correct output for `next-auth` when replaying cache in the event of output deletion. (The default value for turbo cache output is `dist` and `build`). 

## Checklist 🧢

- ~[ ] Documentation~
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

