### PR TITLE
Add option to customize the handling of routes in order to extend or fully overwrite current behavior

### DIFF
--- a/packages/next-auth/src/core/handle-routes.ts
+++ b/packages/next-auth/src/core/handle-routes.ts
@@ -1,0 +1,164 @@
+import logger from "../lib/logger"
+import * as routes from "./routes"
+import renderPage from "./pages"
+
+import { RoutesHandler } from "./types"
+import type { ErrorType } from "./pages/error"
+
+export const defaultRoutesHandler: RoutesHandler = async ({
+  req,
+  cookies,
+  options,
+  sessionStore,
+  userOptions,
+  error,
+}) => {
+  const { method, action } = req
+  if (method === "GET") {
+    const render = renderPage({ ...options, query: req.query, cookies })
+    const { pages } = options
+    switch (action) {
+      case "providers":
+        return (await routes.providers(options.providers)) as any
+      case "session": {
+        const session = await routes.session({ options, sessionStore })
+        if (session.cookies) cookies.push(...session.cookies)
+        return { ...session, cookies } as any
+      }
+      case "csrf":
+        return {
+          headers: [{ key: "Content-Type", value: "application/json" }],
+          body: { csrfToken: options.csrfToken } as any,
+          cookies,
+        }
+      case "signin":
+        if (pages.signIn) {
+          let signinUrl = `${pages.signIn}${
+            pages.signIn.includes("?") ? "&" : "?"
+          }callbackUrl=${options.callbackUrl}`
+          if (error) signinUrl = `${signinUrl}&error=${error}`
+          return { redirect: signinUrl, cookies }
+        }
+
+        return render.signin()
+      case "signout":
+        if (pages.signOut) return { redirect: pages.signOut, cookies }
+
+        return render.signout()
+      case "callback":
+        if (options.provider) {
+          const callback = await routes.callback({
+            body: req.body,
+            query: req.query,
+            headers: req.headers,
+            cookies: req.cookies,
+            method,
+            options,
+            sessionStore,
+          })
+          if (callback.cookies) cookies.push(...callback.cookies)
+          return { ...callback, cookies }
+        }
+        break
+      case "verify-request":
+        if (pages.verifyRequest) {
+          return { redirect: pages.verifyRequest, cookies }
+        }
+        return render.verifyRequest()
+      case "error":
+        // These error messages are displayed in line on the sign in page
+        if (
+          [
+            "Signin",
+            "OAuthSignin",
+            "OAuthCallback",
+            "OAuthCreateAccount",
+            "EmailCreateAccount",
+            "Callback",
+            "OAuthAccountNotLinked",
+            "EmailSignin",
+            "CredentialsSignin",
+            "SessionRequired",
+          ].includes(error as string)
+        ) {
+          return { redirect: `${options.url}/signin?error=${error}`, cookies }
+        }
+
+        if (pages.error) {
+          return {
+            redirect: `${pages.error}${
+              pages.error.includes("?") ? "&" : "?"
+            }error=${error}`,
+            cookies,
+          }
+        }
+
+        return render.error({ error: error as ErrorType })
+      default:
+    }
+  } else if (method === "POST") {
+    switch (action) {
+      case "signin":
+        // Verified CSRF Token required for all sign in routes
+        if (options.csrfTokenVerified && options.provider) {
+          const signin = await routes.signin({
+            query: req.query,
+            body: req.body,
+            options,
+          })
+          if (signin.cookies) cookies.push(...signin.cookies)
+          return { ...signin, cookies }
+        }
+
+        return { redirect: `${options.url}/signin?csrf=true`, cookies }
+      case "signout":
+        // Verified CSRF Token required for signout
+        if (options.csrfTokenVerified) {
+          const signout = await routes.signout({ options, sessionStore })
+          if (signout.cookies) cookies.push(...signout.cookies)
+          return { ...signout, cookies }
+        }
+        return { redirect: `${options.url}/signout?csrf=true`, cookies }
+      case "callback":
+        if (options.provider) {
+          // Verified CSRF Token required for credentials providers only
+          if (
+            options.provider.type === "credentials" &&
+            !options.csrfTokenVerified
+          ) {
+            return { redirect: `${options.url}/signin?csrf=true`, cookies }
+          }
+
+          const callback = await routes.callback({
+            body: req.body,
+            query: req.query,
+            headers: req.headers,
+            cookies: req.cookies,
+            method,
+            options,
+            sessionStore,
+          })
+          if (callback.cookies) cookies.push(...callback.cookies)
+          return { ...callback, cookies }
+        }
+        break
+      case "_log":
+        if (userOptions.logger) {
+          try {
+            const { code, level, ...metadata } = req.body ?? {}
+            logger[level](code, metadata)
+          } catch (error) {
+            // If logging itself failed...
+            logger.error("LOGGER_ERROR", error as Error)
+          }
+        }
+        return {}
+      default:
+    }
+  }
+
+  return {
+    status: 400,
+    body: `Error: Action ${action} with HTTP ${method} is not supported by NextAuth.js` as any,
+  }
+}

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -1,14 +1,12 @@
 import logger, { setLogger } from "../lib/logger"
-import * as routes from "./routes"
 import renderPage from "./pages"
 import { init } from "./init"
 import { assertConfig } from "./lib/assert"
 import { SessionStore } from "./lib/cookie"
 
-import type { NextAuthOptions } from "./types"
+import { NextAuthOptions } from "./types"
 import type { NextAuthAction } from "../lib/types"
 import type { Cookie } from "./lib/cookie"
-import type { ErrorType } from "./pages/error"
 
 export interface IncomingRequest {
   /** @default "http://localhost:3000" */
@@ -86,151 +84,12 @@ export async function NextAuthHandler<
     options.logger
   )
 
-  if (method === "GET") {
-    const render = renderPage({ ...options, query: req.query, cookies })
-    const { pages } = options
-    switch (action) {
-      case "providers":
-        return (await routes.providers(options.providers)) as any
-      case "session": {
-        const session = await routes.session({ options, sessionStore })
-        if (session.cookies) cookies.push(...session.cookies)
-        return { ...session, cookies } as any
-      }
-      case "csrf":
-        return {
-          headers: [{ key: "Content-Type", value: "application/json" }],
-          body: { csrfToken: options.csrfToken } as any,
-          cookies,
-        }
-      case "signin":
-        if (pages.signIn) {
-          let signinUrl = `${pages.signIn}${
-            pages.signIn.includes("?") ? "&" : "?"
-          }callbackUrl=${options.callbackUrl}`
-          if (error) signinUrl = `${signinUrl}&error=${error}`
-          return { redirect: signinUrl, cookies }
-        }
-
-        return render.signin()
-      case "signout":
-        if (pages.signOut) return { redirect: pages.signOut, cookies }
-
-        return render.signout()
-      case "callback":
-        if (options.provider) {
-          const callback = await routes.callback({
-            body: req.body,
-            query: req.query,
-            headers: req.headers,
-            cookies: req.cookies,
-            method,
-            options,
-            sessionStore,
-          })
-          if (callback.cookies) cookies.push(...callback.cookies)
-          return { ...callback, cookies }
-        }
-        break
-      case "verify-request":
-        if (pages.verifyRequest) {
-          return { redirect: pages.verifyRequest, cookies }
-        }
-        return render.verifyRequest()
-      case "error":
-        // These error messages are displayed in line on the sign in page
-        if (
-          [
-            "Signin",
-            "OAuthSignin",
-            "OAuthCallback",
-            "OAuthCreateAccount",
-            "EmailCreateAccount",
-            "Callback",
-            "OAuthAccountNotLinked",
-            "EmailSignin",
-            "CredentialsSignin",
-            "SessionRequired",
-          ].includes(error as string)
-        ) {
-          return { redirect: `${options.url}/signin?error=${error}`, cookies }
-        }
-
-        if (pages.error) {
-          return {
-            redirect: `${pages.error}${
-              pages.error.includes("?") ? "&" : "?"
-            }error=${error}`,
-            cookies,
-          }
-        }
-
-        return render.error({ error: error as ErrorType })
-      default:
-    }
-  } else if (method === "POST") {
-    switch (action) {
-      case "signin":
-        // Verified CSRF Token required for all sign in routes
-        if (options.csrfTokenVerified && options.provider) {
-          const signin = await routes.signin({
-            query: req.query,
-            body: req.body,
-            options,
-          })
-          if (signin.cookies) cookies.push(...signin.cookies)
-          return { ...signin, cookies }
-        }
-
-        return { redirect: `${options.url}/signin?csrf=true`, cookies }
-      case "signout":
-        // Verified CSRF Token required for signout
-        if (options.csrfTokenVerified) {
-          const signout = await routes.signout({ options, sessionStore })
-          if (signout.cookies) cookies.push(...signout.cookies)
-          return { ...signout, cookies }
-        }
-        return { redirect: `${options.url}/signout?csrf=true`, cookies }
-      case "callback":
-        if (options.provider) {
-          // Verified CSRF Token required for credentials providers only
-          if (
-            options.provider.type === "credentials" &&
-            !options.csrfTokenVerified
-          ) {
-            return { redirect: `${options.url}/signin?csrf=true`, cookies }
-          }
-
-          const callback = await routes.callback({
-            body: req.body,
-            query: req.query,
-            headers: req.headers,
-            cookies: req.cookies,
-            method,
-            options,
-            sessionStore,
-          })
-          if (callback.cookies) cookies.push(...callback.cookies)
-          return { ...callback, cookies }
-        }
-        break
-      case "_log":
-        if (userOptions.logger) {
-          try {
-            const { code, level, ...metadata } = req.body ?? {}
-            logger[level](code, metadata)
-          } catch (error) {
-            // If logging itself failed...
-            logger.error("LOGGER_ERROR", error as Error)
-          }
-        }
-        return {}
-      default:
-    }
-  }
-
-  return {
-    status: 400,
-    body: `Error: Action ${action} with HTTP ${method} is not supported by NextAuth.js` as any,
-  }
+  return options.routesHandler({
+    options,
+    error,
+    cookies,
+    sessionStore,
+    req,
+    userOptions,
+  }) as OutgoingResponse<Body>
 }

--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -11,6 +11,7 @@ import { defaultCallbacks } from "./lib/default-callbacks"
 import { createCSRFToken } from "./lib/csrf-token"
 import { createCallbackUrl } from "./lib/callback-url"
 import { IncomingRequest } from "."
+import { defaultRoutesHandler } from "./handle-routes"
 
 interface InitParams {
   host?: string
@@ -97,10 +98,14 @@ export async function init({
     // Event messages
     events: eventsErrorHandler(userOptions.events ?? {}, logger),
     adapter: adapterErrorHandler(userOptions.adapter, logger),
+
     // Callback functions
     callbacks: { ...defaultCallbacks, ...userOptions.callbacks },
     logger,
     callbackUrl: url.origin,
+
+    // Routes handling
+    routesHandler: userOptions.routesHandler || defaultRoutesHandler,
   }
 
   // Init cookies

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -4,6 +4,9 @@ import type { TokenSetParameters } from "openid-client"
 import type { JWT, JWTOptions } from "../jwt"
 import type { LoggerInstance } from "../lib/logger"
 import type { CookieSerializeOptions } from "cookie"
+import { SessionStore, Cookie } from "./lib/cookie"
+import { InternalOptions } from "../lib/types"
+import { IncomingRequest, OutgoingResponse } from "../core"
 
 export type Awaitable<T> = T | PromiseLike<T>
 
@@ -195,6 +198,19 @@ export interface NextAuthOptions {
    * [Documentation](https://next-auth.js.org/configuration/options#cookies) | [Usage example](https://next-auth.js.org/configuration/options#example)
    */
   cookies?: Partial<CookiesOptions>
+
+  /**
+   * You can override the default route handler by specifying a custom route handler. This allows you
+   * to handle custom types of providers that are not supported by NextAuth.js.
+   *
+   * By default the routes are handles by the defaultRoutesHandler function. You can manually call
+   * this function inside your custom routesHandler by calling `nextAuth.defaultRoutesHandler(...args)`.
+   *
+   * - ⚠ **This is an advanced option.** Advanced options are passed the same way as basic options,
+   * but **may have complex implications** or side effects.
+   * You should **try to avoid using advanced options** unless you are very comfortable using them.
+   */
+  routesHandler?: RoutesHandler
 }
 
 /**
@@ -472,3 +488,16 @@ export interface DefaultUser {
  * [`profile` OAuth provider callback](https://next-auth.js.org/configuration/providers#using-a-custom-provider)
  */
 export interface User extends Record<string, unknown>, DefaultUser {}
+
+export interface RoutesHandlerParams {
+  error?: string
+  cookies: Cookie[]
+  sessionStore: SessionStore
+  req: IncomingRequest
+  userOptions: NextAuthOptions
+  options: InternalOptions
+}
+
+export type RoutesHandler = (
+  p: RoutesHandlerParams
+) => Promise<OutgoingResponse<Body>>

--- a/packages/next-auth/src/index.ts
+++ b/packages/next-auth/src/index.ts
@@ -2,5 +2,6 @@ export * from "./core/types"
 
 export type { IncomingRequest, OutgoingResponse } from "./core"
 
+export * from "./core/handle-routes"
 export * from "./next"
 export { default } from "./next"

--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -9,6 +9,7 @@ import type {
   SessionOptions,
   Theme,
   Awaitable,
+  RoutesHandler,
 } from ".."
 
 import type {
@@ -72,6 +73,7 @@ export interface InternalOptions<T extends ProviderType = any> {
   callbacks: CallbacksOptions
   cookies: CookiesOptions
   callbackUrl: string
+  routesHandler: RoutesHandler
 }
 
 /** @internal */


### PR DESCRIPTION
This PR adds an option to overwrite and extend the default route handling by adding a `routesHandler` prop in the `NextAuthOptions`. By default it uses the current behavior: https://github.com/nextauthjs/next-auth/blob/a72f1b6d21da89b4223542006c865862635c027b/packages/next-auth/src/core/index.ts#L89-L235

However, when a `routesHandler` is configured, one can completely overwrite or extend the above block and re-use the default implementation by calling the default handler function `import { defaultRoutesHandler } from 'auth-next` .

## Reasoning 💡

In its current form there are no ways to extend or change next-auth's routes. Doing this on the framework level (for example in Next itself) is not an option as you would have to re-implement tons of functionality that is called before and after the routes are handled, for example the initialization of the `InternalOptions`:
- https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/init.ts
- https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/index.ts#L49-L88 

The initialization of the session store:
https://github.com/nextauthjs/next-auth/blob/a72f1b6d21da89b4223542006c865862635c027b/packages/next-auth/src/core/index.ts#L83-L87

And all the wrapping done by the next.js implementation for authNextHandler:
https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/next/index.ts#L16-L60

By adding an option for devs to overwrite the handling of routes the core becomes a lot more flexible. It gives devs a way to start exploring more functionalities without having to maintain a fork of next-auth, like we already can with `adapters` and `providers`.

For example, this PR could help people with implementing:
- custom `provider types`
- database session handling for the `credentials`-type 
- more routes where they see fit, for example a  `change e-mail` - function.

## Checklist 🧢

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

If there is interest in this feature I can flesh out the details.

## Affected issues 🎟

This does give people a way to start handling `credentials` differently add possibly add `database`-session support themselves or as part as a different package / plugin:
https://github.com/nextauthjs/next-auth/issues/3729
https://github.com/nextauthjs/next-auth/issues/3970
https://github.com/nextauthjs/next-auth/discussions/3787

This could be a start for allowing custom types:
https://github.com/nextauthjs/next-auth/discussions/3275