### PR TITLE
docs: update auth0 and vercel config documentation

### DIFF
--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -18,7 +18,7 @@ If your Next.js application uses a custom base path, specify the route to the AP
 _e.g. `NEXTAUTH_URL=https://example.com/custom-route/api/auth`_
 
 :::note
-We automatically detect when you deploy to [Vercel](https://vercel.com) so you don't have to define this variable.
+Using [Vercel system environment variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) we automatically detect when you deploy to [Vercel](https://vercel.com) so you don't have to define this variable. Make sure **Automatically expose System Environment Variables** is checked in your Project Settings, or to manualy expose a `VERCEL` environment variable.  
 :::
 
 ### NEXTAUTH_SECRET

--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -18,7 +18,7 @@ If your Next.js application uses a custom base path, specify the route to the AP
 _e.g. `NEXTAUTH_URL=https://example.com/custom-route/api/auth`_
 
 :::note
-Using [Vercel system environment variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) we automatically detect when you deploy to [Vercel](https://vercel.com) so you don't have to define this variable. Make sure **Automatically expose System Environment Variables** is checked in your Project Settings, or to manualy expose a `VERCEL` environment variable.  
+Using [System Environment Variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) we automatically detect when you deploy to [Vercel](https://vercel.com) so you don't have to define this variable. Make sure **Automatically expose System Environment Variables** is checked in your Project Settings.
 :::
 
 ### NEXTAUTH_SECRET

--- a/docs/docs/providers/auth0.md
+++ b/docs/docs/providers/auth0.md
@@ -11,10 +11,6 @@ https://auth0.com/docs/api/authentication#authorize-application
 
 https://manage.auth0.com/dashboard
 
-:::tip
-Configure your application in Auth0 as a "Regular Web Application" (not a "Single Page App").
-:::
-
 ## Options
 
 The **Auth0 Provider** comes with a set of default options:


### PR DESCRIPTION
## Reasoning 💡

Hello !

I recently used next-auth with auth0 and struggled with 2 details of your documentation that I would like to fix if you don't mind :)

1. options.md
System env vars are not automatically exposed on vercel projects created prior to novembre 20th 2020 (https://vercel.com/changelog/system-environment-variables-are-now-available-by-default).
This can be confusing for people like me migrating to next-auth, so I thought about giving some details and a link to Vercel doc.

2. auth0.md
I don't think this statement remains true as of today. I managed to have my app working with my auth0 tenant configured as a SPA.
[With the release of spa.js we are now supporting the Authorization Code Flow with Proof Key for Code Exchange (PKCE) 45 for SPAs.](https://community.auth0.com/t/difference-between-spa-regular-web-app-and-even-native-apps/27690/2)

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- ~[ ] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Thanks for everything

Best