### PR TITLE
[TypeORM adapter] Widen refresh_token type to permit null

### DIFF
--- a/docs/docs/adapters/typeorm.md
+++ b/docs/docs/adapters/typeorm.md
@@ -116,7 +116,7 @@ export class AccountEntity {
   providerAccountId!: string
 
   @Column({ type: "varchar", nullable: true })
-  refresh_token!: string
+  refresh_token!: string | null
 
   @Column({ type: "varchar", nullable: true })
   access_token!: string | null

--- a/packages/adapter-typeorm-legacy/src/entities.ts
+++ b/packages/adapter-typeorm-legacy/src/entities.ts
@@ -60,7 +60,7 @@ export class AccountEntity {
   providerAccountId!: string
 
   @Column({ type: "varchar", nullable: true })
-  refresh_token!: string
+  refresh_token!: string | null
 
   @Column({ type: "varchar", nullable: true })
   access_token!: string | null

--- a/packages/adapter-typeorm-legacy/tests/custom-entities.ts
+++ b/packages/adapter-typeorm-legacy/tests/custom-entities.ts
@@ -66,7 +66,7 @@ export class AccountEntity {
   providerAccountId!: string
 
   @Column({ type: "varchar", nullable: true })
-  refresh_token!: string
+  refresh_token!: string | null
 
   @Column({ type: "varchar", nullable: true })
   access_token!: string | null


### PR DESCRIPTION
This updates `refresh_token` in the TypeORM adapter's default entities (and associated tests and docs) to be `string |
null` rather than `string`. The field was already nullable in the database, so this only affects the TypeScript type, not anything in the database.

Because the type is being widened, not narrowed, this should also be fully backwards-compatible, since pre-existing custom entities of type `string` will be substitutable for the new default type of `string | null`. I've verified this locally by running the [sqlite] tests with `refresh_token` in `custom-entities.ts` set to both `string` *and* `string | null`, and it typechecks and passes in both cases.

## Reasoning 💡

The existing type of `refresh_token` here, `string`, does not allow for the possibility of `NULL`, but the database field itself is nullable, so it should. See #4055 for more details on rationale.

## Checklist 🧢

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged


## Affected issues 🎟

Fixes #4055 - see that ticket for more details on the user-facing impact.
