### PR TITLE
docs: fix providers overview page link in readme.md

### DIFF
--- a/packages/next-auth/README.md
+++ b/packages/next-auth/README.md
@@ -55,7 +55,7 @@ See [next-auth.js.org](https://next-auth.js.org) for more information and docume
 ### Flexible and easy to use
 
 - Designed to work with any OAuth service, it supports OAuth 1.0, 1.0A and 2.0
-- Built-in support for [many popular sign-in services](https://next-auth.js.org/providers/overview)
+- Built-in support for [many popular sign-in services](https://next-auth.js.org/providers)
 - Supports email / passwordless authentication
 - Supports stateless authentication with any backend (Active Directory, LDAP, etc)
 - Supports both JSON Web Tokens and database sessions


### PR DESCRIPTION
## Reasoning 💡

- Previous https://next-auth.js.org/providers/overview link no longer works
- New working link is https://next-auth.js.org/providers

## Checklist 🧢

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
