### PR TITLE
fix: deduplicate id, return correct updated data

### DIFF
--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -16,8 +16,9 @@
     "access": "public"
   },
   "scripts": {
-    "test:wip": "./tests/test.sh",
-    "build:wip": "tsc"
+    "test": "./tests/test.sh",
+    "test:watch": "./tests/test.sh -w",
+    "build": "tsc"
   },
   "files": ["README.md", "dist"],
   "peerDependencies": {

--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -26,7 +26,7 @@
     "next-auth": "^4.0.1"
   },
   "devDependencies": {
-    "mongodb": "^4.1.1"
+    "mongodb": "^4.4.0"
   },
   "jest": {
     "preset": "adapter-test/jest"

--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -47,7 +47,7 @@ export const format = {
   /** Takes a plain old JavaScript object and turns it into a mongoDB object */
   to<T = Record<string, unknown>>(object: Record<string, any>) {
     const newObject: Record<string, unknown> = {
-      _id: new ObjectId(object.id),
+      _id: _id(object.id),
     }
     for (const key in object) {
       const value = object[key]

--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -155,14 +155,17 @@ export function MongoDBAdapter(
       return from<AdapterSession>(session)
     },
     async updateSession(data) {
-      const { value: session } = await (
+      // @ts-expect-error
+      const { _id, ...session } = to<AdapterSession>(data)
+
+      const result = await (
         await db
       ).S.findOneAndUpdate(
-        { sessionToken: data.sessionToken },
-        { $set: data },
+        { sessionToken: session.sessionToken },
+        { $set: session },
         { returnDocument: "after" }
       )
-      return from<AdapterSession>(session!)
+      return from<AdapterSession>(result.value!)
     },
     async deleteSession(sessionToken) {
       const { value: session } = await (

--- a/yarn.lock
+++ b/yarn.lock
@@ -13329,10 +13329,10 @@ mongodb-connection-string-url@^2.4.1:
     "@types/whatwg-url" "^8.2.1"
     whatwg-url "^11.0.0"
 
-mongodb@^4.1.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.3.1.tgz#e346f76e421ec6f47ddea5c8f5140e6181aaeb94"
-  integrity sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==
+mongodb@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.4.0.tgz#3b14b9701067713d5c9afb6d6e4a86ca7b969824"
+  integrity sha512-1hPhutJj6yxxu0ymwsO0uEimTo+QTh3oQP6YHxmLneBFBOGydYFdnmDDuLiGWimAlMdRN9WuDXY+JGp47aeOwA==
   dependencies:
     bson "^4.6.1"
     denque "^2.0.1"


### PR DESCRIPTION
## Reasoning 💡

Tests and builds haven't been run on the MongoDB Adapter yet, as the test and build scripts were suffixed by `:wip` and Turbo ignored them.

I found a few bugs in the Adapter which is now fixed.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Closes #4066
