### PR TITLE
fix: ensure Prisma/MongoDB integration

### DIFF
--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@next-auth/fauna-adapter": "^1.0.1",
     "@next-auth/prisma-adapter": "^1.0.1",
-    "@prisma/client": "^3.7.0",
+    "@prisma/client": "^3.10.0",
     "fake-smtp-server": "^0.8.0",
     "faunadb": "^4.4.1",
     "next": "^12.1.0",
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "prisma": "^3.7.0"
+    "prisma": "^3.10.0"
   }
 }

--- a/docs/docs/adapters/prisma.md
+++ b/docs/docs/adapters/prisma.md
@@ -68,8 +68,6 @@ model Account {
   scope              String?
   id_token           String?  @db.Text
   session_state      String?
-  oauth_token_secret String?
-  oauth_token        String?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -133,6 +131,16 @@ To configure your database to use the new schema (i.e. create tables and columns
 npx prisma migrate dev
 ```
 
+### MongoDB
+
+Prisma supports MongoDB, and so does NextAuth.js. Following the instructions of the [Prisma documentation](https://www.prisma.io/docs/concepts/database-connectors/mongodb)on the MongoDB connector, the only thing you have to change is making sure that the `id` field is mapped correctly:
+
+```prisma
+id  String  @id @default(auto()) @map("_id") @db.ObjectId
+```
+
+Everything else should be the same.
+
 ## Naming Conventions
 
 If mixed snake_case and camelCase column names is an issue for you and/or your underlying database system, we recommend using Prisma's `@Map()`([Prisma Docs](https://www.prisma.io/docs/concepts/components/prisma-schema/names-in-underlying-database)) feature to change the field names. This won't affect NextAuth.js, but will allow you to customize the column names to whichever naming convention you wish.
@@ -153,8 +161,6 @@ model Account {
   scope              String?
   id_token           String? @db.Text
   session_state      String?
-  oauth_token_secret String?
-  oauth_token        String?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/docs/docs/adapters/prisma.md
+++ b/docs/docs/adapters/prisma.md
@@ -133,7 +133,7 @@ npx prisma migrate dev
 
 ### MongoDB
 
-Prisma supports MongoDB, and so does NextAuth.js. Following the instructions of the [Prisma documentation](https://www.prisma.io/docs/concepts/database-connectors/mongodb)on the MongoDB connector, the only thing you have to change is making sure that the `id` fields are mapped correctly:
+Prisma supports MongoDB, and so does NextAuth.js. Following the instructions of the [Prisma documentation](https://www.prisma.io/docs/concepts/database-connectors/mongodb) on the MongoDB connector, the only thing you have to change is making sure that the `id` fields are mapped correctly:
 
 ```prisma
 id  String  @id @default(auto()) @map("_id") @db.ObjectId
@@ -143,7 +143,7 @@ Everything else should be the same.
 
 ## Naming Conventions
 
-If mixed snake_case and camelCase column names is an issue for you and/or your underlying database system, we recommend using Prisma's `@Map()`([Prisma Docs](https://www.prisma.io/docs/concepts/components/prisma-schema/names-in-underlying-database)) feature to change the field names. This won't affect NextAuth.js, but will allow you to customize the column names to whichever naming convention you wish.
+If mixed snake_case and camelCase column names is an issue for you and/or your underlying database system, we recommend using Prisma's `@map()`([see the documentation here](https://www.prisma.io/docs/concepts/components/prisma-schema/names-in-underlying-database)) feature to change the field names. This won't affect NextAuth.js, but will allow you to customize the column names to whichever naming convention you wish.
 
 For example, moving to `snake_case` and plural table names.
 

--- a/docs/docs/adapters/prisma.md
+++ b/docs/docs/adapters/prisma.md
@@ -133,7 +133,7 @@ npx prisma migrate dev
 
 ### MongoDB
 
-Prisma supports MongoDB, and so does NextAuth.js. Following the instructions of the [Prisma documentation](https://www.prisma.io/docs/concepts/database-connectors/mongodb)on the MongoDB connector, the only thing you have to change is making sure that the `id` field is mapped correctly:
+Prisma supports MongoDB, and so does NextAuth.js. Following the instructions of the [Prisma documentation](https://www.prisma.io/docs/concepts/database-connectors/mongodb)on the MongoDB connector, the only thing you have to change is making sure that the `id` fields are mapped correctly:
 
 ```prisma
 id  String  @id @default(auto()) @map("_id") @db.ObjectId

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -19,10 +19,10 @@
     "clean": "rm -rf ./prisma/migrations && rm ./prisma/dev.db*",
     "init:default": "prisma migrate dev --name init --skip-seed",
     "init:custom": "prisma migrate dev --name init-custom --schema ./prisma/custom.prisma",
-    "test": "yarn init:default && jest ./tests/*.test.ts",
-    "test:default": "yarn init:default && jest ./tests/**/*.test.ts",
-    "test:custom": "yarn init:custom && CUSTOM_MODEL=1 jest ./tests/**/*.test.ts",
-    "test:wip": "yarn test:default && yarn test:custom",
+    "test:default": "yarn init:default && jest",
+    "test:custom": "yarn init:custom && CUSTOM_MODEL=1 jest",
+    "test:mongodb": "./tests/mongodb.test.sh",
+    "test": "yarn test:default && yarn test:custom && yarn test:mongodb",
     "build": "prisma generate && tsc",
     "studio": "prisma studio"
   },
@@ -32,8 +32,8 @@
     "next-auth": "^4.0.1"
   },
   "devDependencies": {
-    "@prisma/client": "^3.0.2",
-    "prisma": "^3.0.2"
+    "@prisma/client": "^3.10.0",
+    "prisma": "^3.10.0"
   },
   "jest": {
     "preset": "adapter-test/jest"

--- a/packages/adapter-prisma/prisma/mongodb.prisma
+++ b/packages/adapter-prisma/prisma/mongodb.prisma
@@ -1,0 +1,60 @@
+datasource db {
+  provider = "mongodb"
+  url      = "mongodb://localhost:27017/test"
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["mongoDb"]
+}
+
+model Account {
+  id                String  @id @default(auto()) @map("_id") @db.ObjectId
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String? @db.String
+  access_token      String? @db.String
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String? @db.String
+  session_state     String?
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+  @@map("accounts")
+}
+
+model Session {
+  id           String   @id @default(auto()) @map("_id") @db.ObjectId
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("sessions")
+}
+
+model User {
+  id            String    @id @default(auto()) @map("_id") @db.ObjectId
+  name          String?
+  email         String?   @unique
+  emailVerified DateTime?
+  image         String?
+  accounts      Account[]
+  sessions      Session[]
+
+  @@map("users")
+}
+
+model VerificationToken {
+  id         String   @id @default(auto()) @map("_id") @db.ObjectId
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+  @@map("verification_tokens")
+}

--- a/packages/adapter-prisma/prisma/mongodb.prisma
+++ b/packages/adapter-prisma/prisma/mongodb.prisma
@@ -24,7 +24,6 @@ model Account {
   user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
-  @@map("accounts")
 }
 
 model Session {
@@ -33,8 +32,6 @@ model Session {
   userId       String
   expires      DateTime
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@map("sessions")
 }
 
 model User {
@@ -45,8 +42,6 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
-
-  @@map("users")
 }
 
 model VerificationToken {
@@ -56,5 +51,4 @@ model VerificationToken {
   expires    DateTime
 
   @@unique([identifier, token])
-  @@map("verification_tokens")
 }

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -33,6 +33,7 @@ export function PrismaAdapter(p: PrismaClient): Adapter {
     deleteSession: (sessionToken) =>
       p.session.delete({ where: { sessionToken } }),
     async createVerificationToken(data) {
+      // @ts-ignore
       const { id: _, ...verificationToken } = await p.verificationToken.create({
         data,
       })
@@ -40,6 +41,7 @@ export function PrismaAdapter(p: PrismaClient): Adapter {
     },
     async useVerificationToken(identifier_token) {
       try {
+        // @ts-ignore
         const { id: _, ...verificationToken } =
           await p.verificationToken.delete({ where: { identifier_token } })
         return verificationToken

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -13,7 +13,7 @@ export function PrismaAdapter(p: PrismaClient): Adapter {
       })
       return account?.user ?? null
     },
-    updateUser: (data) => p.user.update({ where: { id: data.id }, data }),
+    updateUser: ({ id, ...data }) => p.user.update({ where: { id }, data }),
     deleteUser: (id) => p.user.delete({ where: { id } }),
     linkAccount: (data) => p.account.create({ data }) as any,
     unlinkAccount: (provider_providerAccountId) =>
@@ -29,13 +29,20 @@ export function PrismaAdapter(p: PrismaClient): Adapter {
     },
     createSession: (data) => p.session.create({ data }),
     updateSession: (data) =>
-      p.session.update({ data, where: { sessionToken: data.sessionToken } }),
+      p.session.update({ where: { sessionToken: data.sessionToken }, data }),
     deleteSession: (sessionToken) =>
       p.session.delete({ where: { sessionToken } }),
-    createVerificationToken: (data) => p.verificationToken.create({ data }),
+    async createVerificationToken(data) {
+      const { id: _, ...verificationToken } = await p.verificationToken.create({
+        data,
+      })
+      return verificationToken
+    },
     async useVerificationToken(identifier_token) {
       try {
-        return await p.verificationToken.delete({ where: { identifier_token } })
+        const { id: _, ...verificationToken } =
+          await p.verificationToken.delete({ where: { identifier_token } })
+        return verificationToken
       } catch (error) {
         // If token already used/deleted, just return null
         // https://www.prisma.io/docs/reference/api-reference/error-reference#p2025

--- a/packages/adapter-prisma/tests/index.test.ts
+++ b/packages/adapter-prisma/tests/index.test.ts
@@ -1,11 +1,18 @@
-import { runBasicTests } from "adapter-test"
+import { randomUUID, runBasicTests } from "adapter-test"
 import { PrismaClient } from "@prisma/client"
 import { PrismaAdapter } from "../src"
 const prisma = new PrismaClient()
+import { ObjectId } from "mongodb"
 
 runBasicTests({
   adapter: PrismaAdapter(prisma),
   db: {
+    id() {
+      if (process.env.CONTAINER_NAME === "next-auth-mongodb-test") {
+        return new ObjectId().toHexString()
+      }
+      return randomUUID()
+    },
     connect: async () => {
       await Promise.all([
         prisma.user.deleteMany({}),
@@ -23,16 +30,19 @@ runBasicTests({
       ])
       await prisma.$disconnect()
     },
-    verificationToken: (identifier_token) =>
-      prisma.verificationToken.findUnique({
-        where: { identifier_token },
-      }),
     user: (id) => prisma.user.findUnique({ where: { id } }),
     account: (provider_providerAccountId) =>
-      prisma.account.findUnique({
-        where: { provider_providerAccountId },
-      }),
+      prisma.account.findUnique({ where: { provider_providerAccountId } }),
     session: (sessionToken) =>
       prisma.session.findUnique({ where: { sessionToken } }),
+    async verificationToken(identifier_token) {
+      const result = await prisma.verificationToken.findUnique({
+        where: { identifier_token },
+      })
+      if (!result) return null
+      // @ts-ignore
+      const { id: _, ...verificationToken } = result
+      return verificationToken
+    },
   },
 })

--- a/packages/adapter-prisma/tests/mongodb.test.sh
+++ b/packages/adapter-prisma/tests/mongodb.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+CONTAINER_NAME=next-auth-mongodb-test
+
+JEST_WATCH=false
+
+# Is the watch flag passed to the script?
+while getopts w flag
+do
+    case "${flag}" in
+        w) JEST_WATCH=true;;
+        *) continue;;
+    esac
+done
+
+# Start db
+docker run -d --rm -p 27017:27017 --name ${CONTAINER_NAME} "prismagraphql/mongo-single-replica:4.4.3-bionic"
+
+yarn prisma generate --schema ./prisma/mongodb.prisma
+
+if $JEST_WATCH; then
+    # Run jest in watch mode
+    npx jest --watch
+    # Only stop the container after jest has been quit
+    docker stop "${CONTAINER_NAME}"
+else
+    # Always stop container, but exit with 1 when tests are failing
+    if CONTAINER_NAME=${CONTAINER_NAME} npx jest;then
+        docker stop ${CONTAINER_NAME}
+    else
+        docker stop ${CONTAINER_NAME} && exit 1
+    fi
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,22 +3439,22 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
-"@prisma/client@^3.0.2", "@prisma/client@^3.7.0":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.9.1.tgz#565c8121f1220637bcab4a1d1f106b8c1334406c"
-  integrity sha512-aLwfXKLvL+loQ0IuPPCXkcq8cXBg1IeoHHa5lqQu3dJHdj45wnislA/Ny4UxRQjD5FXqrfAb8sWtF+jhdmjFTg==
+"@prisma/client@^3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.10.0.tgz#4782fe6f1b0e43c2a11a75ad4bb1098599d1dfb1"
+  integrity sha512-6P4sV7WFuODSfSoSEzCH1qfmWMrCUBk1LIIuTbQf6m1LI/IOpLN4lnqGDmgiBGprEzuWobnGLfe9YsXLn0inrg==
   dependencies:
-    "@prisma/engines-version" "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
+    "@prisma/engines-version" "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86"
 
-"@prisma/engines-version@3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009":
-  version "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009.tgz#ea03ffa723382a526dc6625ce6eae9b6ad984400"
-  integrity sha512-5Dh+qTDhpPR66w6NNAnPs+/W/Qt4r1DSd+qhfPFcDThUK4uxoZKGlPb2IYQn5LL+18aIGnmteDf7BnVMmvBNSQ==
+"@prisma/engines-version@3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86":
+  version "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86.tgz#82750856fa637dd89b8f095d2dcc6ac0631231c6"
+  integrity sha512-cVYs5gyQH/qyut24hUvDznCfPrWiNMKNfPb9WmEoiU6ihlkscIbCfkmuKTtspVLWRdl0LqjYEC7vfnPv17HWhw==
 
-"@prisma/engines@3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009":
-  version "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009.tgz#e5c345cdedb7be83d11c1e0c5ab61d866b411256"
-  integrity sha512-qM+uJbkelB21bnK44gYE049YTHIjHysOuj0mj5U2gDGyNLfmiazlggzFPCgEjgme4U5YB2tYs6Z5Hq08Kl8pjA==
+"@prisma/engines@3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86":
+  version "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86.tgz#2964113729a78b8b21e186b5592affd1fde73c16"
+  integrity sha512-LjRssaWu9w2SrXitofnutRIyURI7l0veQYIALz7uY4shygM9nMcK3omXcObRm7TAcw3Z+9ytfK1B+ySOsOesxQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -15276,12 +15276,12 @@ prism-react-renderer@^1.2.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz#392460acf63540960e5e3caa699d851264e99b89"
   integrity sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==
 
-prisma@^3.0.2, prisma@^3.7.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.9.1.tgz#7510a8bf06018a5313b9427b1127ce4750b1ce5c"
-  integrity sha512-IGcJAu5LzlFv+i+NNhOEh1J1xVVttsVdRBxmrMN7eIH+7mRN6L89Hz1npUAiz4jOpNlHC7n9QwaOYZGxTqlwQw==
+prisma@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.10.0.tgz#872d87afbeb1cbcaa77c3d6a63c125e0d704b04d"
+  integrity sha512-dAld12vtwdz9Rz01nOjmnXe+vHana5PSog8t0XGgLemKsUVsaupYpr74AHaS3s78SaTS5s2HOghnJF+jn91ZrA==
   dependencies:
-    "@prisma/engines" "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
+    "@prisma/engines" "3.10.0-50.73e60b76d394f8d37d8ebd1f8918c79029f0db86"
 
 prismjs@^1.23.0:
   version "1.27.0"


### PR DESCRIPTION
Prisma supports MongoDB, and so should we, out of the box. This PR fixes #4030 and adds Prisma+MongoDB tests to ensure we won't regress. I added a brief note in the docs on how one should customize the Prisma schema to work correctly.
