### PR TITLE
update to v4 session objet to strategy: "jwt"

### DIFF
--- a/docs/docs/adapters/dgraph.md
+++ b/docs/docs/adapters/dgraph.md
@@ -229,7 +229,7 @@ further customize the jwt with roles if you want to implement [`RBAC logic`](htt
 import * as jwt from "jsonwebtoken";
 export default NextAuth({
   session: {
-    jwt: true
+    strategy: "jwt"
   },
   jwt: {
     secret: process.env.SECRET,
@@ -237,7 +237,7 @@ export default NextAuth({
       return jwt.sign({...token, userId: token.id}, secret, {
         algorithm: "HS256",
         expiresIn: 30 * 24 * 60 * 60; // 30 days
-      });;
+      });
     },
     decode: async ({ secret, token }) => {
       return jwt.verify(token, secret, { algorithms: ["HS256"] });


### PR DESCRIPTION
I saw in the documentation that v4 now uses
  session: {
    strategy: "jwt"
  },
instead of 
  session: {
    jwt: true
  },

also there was double ;; at the end of the return statement, fixing it

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
