### PR TITLE
chore(providers): Add typings for Discord Provider

### DIFF
--- a/packages/next-auth/src/providers/discord.ts
+++ b/packages/next-auth/src/providers/discord.ts
@@ -1,5 +1,26 @@
-/** @type {import(".").OAuthProvider} */
-export default function Discord(options) {
+import type { OAuthConfig, OAuthUserConfig } from "."
+
+export interface DiscordProfile {
+  accent_color: number
+  avatar: string
+  banner: string
+  banner_color: string
+  discriminator: string
+  email: string
+  flags: number
+  id: string
+  image_url: string
+  locale: string
+  mfa_enabled: boolean
+  premium_type: number
+  public_flags: number
+  username: string
+  verified: boolean
+}
+
+export default function Discord<P extends DiscordProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "discord",
     name: "Discord",

--- a/packages/next-auth/src/providers/discord.ts
+++ b/packages/next-auth/src/providers/discord.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface DiscordProfile {
+export interface DiscordProfile extends Record<string, any> {
   accent_color: number
   avatar: string
   banner: string


### PR DESCRIPTION
## Reasoning 💡
The current Discord provider is not TypeScript compatible out-of-the-box and requires developers to declare their own typing and interface. This change does the following:

1. Renames `providers/discord.js` to `providers/discord.ts`.
2. Creates, implements, and exports a `DiscordProfile` interface.
3. Updates the `Discord()` provider to support `OAuthUserConfig` and `OAuthConfig`.

**Note:** These changes were modeled off of `providers/twitch.ts`.

## Checklist 🧢

- ~[ ] Documentation~
- ~[ ] Tests~
- [x] Ready to be merged

This is ready to be merged as it does not introduce breaking changes or API changes and is backwards compatible with the latest stable version. This has been tested by launching the `dev` app, updating the `.env.local` with Discord API credentials, and testing Discord login inside the test rig.

## Affected issues 🎟

None.
