### PR TITLE
Fix `encodeURIComponent(callbackUrl)` for custom signIn page

### DIFF
--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -107,8 +107,8 @@ export async function NextAuthHandler<
         if (pages.signIn) {
           let signinUrl = `${pages.signIn}${
             pages.signIn.includes("?") ? "&" : "?"
-          }callbackUrl=${options.callbackUrl}`
-          if (error) signinUrl = `${signinUrl}&error=${error}`
+          }callbackUrl=${encodeURIComponent(options.callbackUrl)}`
+          if (error) signinUrl = `${signinUrl}&error=${encodeURIComponent(error)}`
           return { redirect: signinUrl, cookies }
         }
 


### PR DESCRIPTION
Adds a missing `encodeURIComponent` for the custom signIn page.

Before:
```
http://localhost:3000/?callbackUrl=http://localhost:3000/?a=1&b=2&error=OAuthSignin
```
The `b` param got dropped from the callback.

After :zap::
```
http://localhost:3000/?callbackUrl=http%3A%2F%2Flocalhost%3A3000%2F%3Fa%3D1%26b%3D2&error=OAuthSignin
```