### PR TITLE
docs(adapters): add dynamoDB cf ProjectionType

### DIFF
--- a/docs/docs/adapters/dynamodb.md
+++ b/docs/docs/adapters/dynamodb.md
@@ -119,6 +119,8 @@ NextAuthTable:
         KeyType: RANGE
     GlobalSecondaryIndexes:
       - IndexName: GSI1
+        Projection:
+          ProjectionType: ALL
         KeySchema:
           - AttributeName: GSI1PK
             KeyType: HASH


### PR DESCRIPTION
## Reasoning 💡

Hello,
Firstly, a huge thanks for creating and maintaining this awesome project!

I encountered a small error while using the DynamoDB adapter only related to the cloudformation.yaml example. If you choose to declare GlobalSecondaryIndexes then you must also specify ProjectionType to ALL, otherwise, it will default to KEYS_ONLY

Using KEYS_ONLY methods from the adapter that rely on that global index (eg: getUserByAccount) will fail. 

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
