### PR TITLE
chore(docs): fixed broken link

### DIFF
--- a/docs/docs/configuration/providers/oauth.md
+++ b/docs/docs/configuration/providers/oauth.md
@@ -5,7 +5,7 @@ title: OAuth
 
 Authentication Providers in **NextAuth.js** are OAuth definitions that allow your users to sign in with their favorite preexisting logins. You can use any of our many predefined providers, or write your own custom OAuth configuration.
 
-- [Using a built-in OAuth Provider](#oauth-providers) (e.g Github, Twitter, Google, etc...)
+- [Using a built-in OAuth Provider](#built-in-providers) (e.g Github, Twitter, Google, etc...)
 - [Using a custom OAuth Provider](#using-a-custom-provider)
 
 :::note


### PR DESCRIPTION


## Reasoning 💡

The link to the Oauth provider section on the page was broken.

## Checklist 🧢

- [ ] ~Documentation~
- [ ] ~Tests~
- [x] Ready to be merged
