### PR TITLE
fix(docs): pin @upstash/redis version to 0.2.1

### DIFF
--- a/docs/docs/adapters/upstash-redis.md
+++ b/docs/docs/adapters/upstash-redis.md
@@ -8,8 +8,10 @@ title: Upstash Redis
 To use this Adapter, you need to install `@upstash/redis` and `@next-auth/upstash-redis-adapter` package:
 
 ```bash npm2yarn
-npm install @upstash/redis @next-auth/upstash-redis-adapter
+npm install @upstash/redis@0.2.1 @next-auth/upstash-redis-adapter
 ```
+Please make sure to use `@usptash/redis` version `0.2.1`. Later versions are incompatible right now.
+Progress is tracked [here](https://github.com/nextauthjs/next-auth/issues/4183)
 
 Configure your NextAuth.js to use the Upstash Redis Adapter:
 

--- a/packages/adapter-upstash-redis/README.md
+++ b/packages/adapter-upstash-redis/README.md
@@ -21,8 +21,10 @@ This is the Upstash Redis adapter for [`next-auth`](https://next-auth.js.org). T
 1. Install `next-auth` and `@next-auth/upstash-redis-adapter` as well as `@upstash/redis` via NPM.
 
 ```js
-npm install next-auth @next-auth/upstash-redis-adapter @upstash/redis
+npm install next-auth @next-auth/upstash-redis-adapter @upstash/redis@0.2.1
 ```
+Please make sure to use `@usptash/redis` version `0.2.1`. Later versions are incompatible right now.
+Progress is tracked [here](https://github.com/nextauthjs/next-auth/issues/4183)
 
 2. Add the follwing code to your `pages/api/[...nextauth].js` next-auth configuration object.
 

--- a/packages/adapter-upstash-redis/package.json
+++ b/packages/adapter-upstash-redis/package.json
@@ -30,11 +30,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@upstash/redis": "^0.2.1",
+    "@upstash/redis": "0.2.1",
     "next-auth": "^4.0.1"
   },
   "devDependencies": {
-    "@upstash/redis": "^0.2.1",
+    "@upstash/redis": "0.2.1",
     "dotenv": "^10.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,7 +3637,7 @@
   dependencies:
     "@lezer/common" "^0.15.0"
 
-"@mdx-js/mdx@1.6.22", "@mdx-js/mdx@^1.6.21":
+"@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
   integrity sha512-AMxuLxPz2j5/6TpF/XSdKpQP1NlG0z11dFOlq+2IP/lSgl11GY8ji6S/rgsViN/L0BDvHvUMruRb7ub+24LUYA==
@@ -5059,7 +5059,7 @@
     "@typescript-eslint/types" "5.10.2"
     eslint-visitor-keys "^3.0.0"
 
-"@upstash/redis@^0.2.1":
+"@upstash/redis@0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@upstash/redis/-/redis-0.2.1.tgz#ace56d27e69e766066c33d0a9ddc0d9286e76b8c"
   integrity sha512-Qxpa81oCy68x5nXlkMKEQL32mEO6tUvYj0sIVNNuYLohYrdWpKZC0vGLLwKl/6HU1FoRiaD1Vdq177ZF4RyoSw==
@@ -11404,17 +11404,17 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+intersection-observer@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
+  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
+
 invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
-
-intersection-observer@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
-  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
 
 ip-regex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Until we migrate to v1 there might be people installing the latest
version of @upstash/redis and then encountering errors.
With this they will at least get a warning.

This is obsolete and should be updated once
https://github.com/nextauthjs/next-auth/issues/4183 is resolved.
