### PR TITLE
fix(providers): profile types

### DIFF
--- a/packages/next-auth/src/providers/42-school.ts
+++ b/packages/next-auth/src/providers/42-school.ts
@@ -134,8 +134,7 @@ export interface CampusUser {
   created_at: string
   updated_at: string | null
 }
-
-export interface FortyTwoProfile extends UserData {
+export interface FortyTwoProfile extends UserData, Record<string, any> {
   groups: Array<{ id: string; name: string }>
   cursus_users: CursusUser[]
   projects_users: ProjectUser[]
@@ -153,9 +152,9 @@ export interface FortyTwoProfile extends UserData {
   user: any | null
 }
 
-export default function FortyTwo<
-  P extends Record<string, any> = FortyTwoProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function FortyTwo<P extends FortyTwoProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "42-school",
     name: "42 School",

--- a/packages/next-auth/src/providers/apple.ts
+++ b/packages/next-auth/src/providers/apple.ts
@@ -5,7 +5,7 @@ import { OAuthConfig, OAuthUserConfig } from "."
  * [Retrieve the User's Information from Apple ID Servers
 ](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple#3383773)
  */
-export interface AppleProfile {
+export interface AppleProfile extends Record<string, any> {
   /**
    * The issuer registered claim identifies the principal that issued the identity token.
    * Since Apple generates the token, the value is `https://appleid.apple.com`.
@@ -87,7 +87,7 @@ export interface AppleProfile {
   auth_time: number
 }
 
-export default function Apple<P extends Record<string, any> = AppleProfile>(
+export default function Apple<P extends AppleProfile>(
   options: Omit<OAuthUserConfig<P>, "clientSecret"> & {
     /**
      * Apple requires the client secret to be a JWT. You can generate one using the following script:

--- a/packages/next-auth/src/providers/atlassian.ts
+++ b/packages/next-auth/src/providers/atlassian.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-interface AtlassianProfile {
+interface AtlassianProfile extends Record<string, any> {
   account_id: string
   name: string
   email: string

--- a/packages/next-auth/src/providers/auth0.ts
+++ b/packages/next-auth/src/providers/auth0.ts
@@ -1,13 +1,13 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface Auth0Profile {
+export interface Auth0Profile extends Record<string, any> {
   sub: string
   nickname: string
   email: string
   picture: string
 }
 
-export default function Auth0<P extends Record<string, any> = Auth0Profile>(
+export default function Auth0<P extends Auth0Profile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/authentik.ts
+++ b/packages/next-auth/src/providers/authentik.ts
@@ -1,29 +1,29 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface AuthentikProfile {
-  iss: string,
-  sub: string,
-  aud: string,
-  exp: number,
-  iat: number,
-  auth_time: number,
-  acr: string,
-  c_hash: string,
-  nonce: string,
-  at_hash: string,
-  email: string,
-  email_verified: boolean,
-  name: string,
-  given_name: string,
-  family_name: string,
-  preferred_username: string,
-  nickname: string,
+export interface AuthentikProfile extends Record<string, any> {
+  iss: string
+  sub: string
+  aud: string
+  exp: number
+  iat: number
+  auth_time: number
+  acr: string
+  c_hash: string
+  nonce: string
+  at_hash: string
+  email: string
+  email_verified: boolean
+  name: string
+  given_name: string
+  family_name: string
+  preferred_username: string
+  nickname: string
   groups: string[]
 }
 
-export default function Authentik<
-  P extends Record<string, any> = AuthentikProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function Authentik<P extends AuthentikProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "authentik",
     name: "Authentik",

--- a/packages/next-auth/src/providers/azure-ad-b2c.ts
+++ b/packages/next-auth/src/providers/azure-ad-b2c.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface AzureB2CProfile {
+export interface AzureB2CProfile extends Record<string, any> {
   exp: number
   nbf: number
   ver: string
@@ -17,9 +17,7 @@ export interface AzureB2CProfile {
   tfp: string
 }
 
-export default function AzureADB2C<
-  P extends Record<string, any> = AzureB2CProfile
->(
+export default function AzureADB2C<P extends AzureB2CProfile>(
   options: OAuthUserConfig<P> & {
     primaryUserFlow: string
     tenantId: string

--- a/packages/next-auth/src/providers/azure-ad.ts
+++ b/packages/next-auth/src/providers/azure-ad.ts
@@ -1,13 +1,13 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface AzureADProfile {
+export interface AzureADProfile extends Record<string, any> {
   sub: string
   nicname: string
   email: string
   picture: string
 }
 
-export default function AzureAD<P extends Record<string, any> = AzureADProfile>(
+export default function AzureAD<P extends AzureADProfile>(
   options: OAuthUserConfig<P> & {
     /**
      * https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#examples

--- a/packages/next-auth/src/providers/battlenet.ts
+++ b/packages/next-auth/src/providers/battlenet.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface BattleNetProfile {
+export interface BattleNetProfile extends Record<string, any> {
   sub: string
   battle_tag: string
 }
@@ -10,9 +10,9 @@ export type BattleNetIssuer =
   | "https://www.battlenet.com.cn/oauth"
   | `https://${"us" | "eu" | "kr" | "tw"}.battle.net/oauth`
 
-export default function BattleNet<
-  P extends Record<string, any> = BattleNetProfile
->(options: OAuthUserConfig<P> & { issuer: BattleNetIssuer }): OAuthConfig<P> {
+export default function BattleNet<P extends BattleNetProfile>(
+  options: OAuthUserConfig<P> & { issuer: BattleNetIssuer }
+): OAuthConfig<P> {
   return {
     id: "battlenet",
     name: "Battle.net",

--- a/packages/next-auth/src/providers/boxyhq-saml.ts
+++ b/packages/next-auth/src/providers/boxyhq-saml.ts
@@ -1,15 +1,15 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface BoxyHQSAMLProfile {
+export interface BoxyHQSAMLProfile extends Record<string, any> {
   id: string
   email: string
   firstName?: string
   lastName?: string
 }
 
-export default function SAMLJackson<
-  P extends Record<string, any> = BoxyHQSAMLProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function SAMLJackson<P extends BoxyHQSAMLProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "boxyhq-saml",
     name: "BoxyHQ SAML",

--- a/packages/next-auth/src/providers/cognito.ts
+++ b/packages/next-auth/src/providers/cognito.ts
@@ -1,13 +1,13 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface CognitoProfile {
+export interface CognitoProfile extends Record<string, any> {
   sub: string
   name: string
   email: string
   picture: string
 }
 
-export default function Cognito<P extends Record<string, any> = CognitoProfile>(
+export default function Cognito<P extends CognitoProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/discord.ts
+++ b/packages/next-auth/src/providers/discord.ts
@@ -1,5 +1,26 @@
-/** @type {import(".").OAuthProvider} */
-export default function Discord(options) {
+import type { OAuthConfig, OAuthUserConfig } from "."
+
+export interface DiscordProfile extends Record<string, any> {
+  accent_color: number
+  avatar: string
+  banner: string
+  banner_color: string
+  discriminator: string
+  email: string
+  flags: number
+  id: string
+  image_url: string
+  locale: string
+  mfa_enabled: boolean
+  premium_type: number
+  public_flags: number
+  username: string
+  verified: boolean
+}
+
+export default function Discord<P extends DiscordProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "discord",
     name: "Discord",

--- a/packages/next-auth/src/providers/eveonline.ts
+++ b/packages/next-auth/src/providers/eveonline.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface EVEOnlineProfile {
+export interface EVEOnlineProfile extends Record<string, any> {
   CharacterID: number
   CharacterName: string
   ExpiresOn: string
@@ -10,9 +10,9 @@ export interface EVEOnlineProfile {
   IntellectualProperty: string
 }
 
-export default function EVEOnline<
-  P extends Record<string, any> = EVEOnlineProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function EVEOnline<P extends EVEOnlineProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "eveonline",
     name: "EVE Online",
@@ -27,7 +27,7 @@ export default function EVEOnline<
     idToken: true,
     profile(profile) {
       return {
-        id: profile.CharacterID,
+        id: String(profile.CharacterID),
         name: profile.CharacterName,
         email: null,
         image: `https://image.eveonline.com/Character/${profile.CharacterID}_128.jpg`,

--- a/packages/next-auth/src/providers/facebook.ts
+++ b/packages/next-auth/src/providers/facebook.ts
@@ -1,13 +1,20 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface FacebookProfile {
-  id: string
-  picture: { data: { url: string } }
+interface FacebookPictureData {
+  url: string
 }
 
-export default function Facebook<
-  P extends Record<string, any> = FacebookProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+interface FacebookPicture {
+  data: FacebookPictureData
+}
+export interface FacebookProfile extends Record<string, any> {
+  id: string
+  picture: FacebookPicture
+}
+
+export default function Facebook<P extends FacebookProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "facebook",
     name: "Facebook",

--- a/packages/next-auth/src/providers/fusionauth.ts
+++ b/packages/next-auth/src/providers/fusionauth.ts
@@ -3,7 +3,7 @@ import { OAuthConfig, OAuthUserConfig } from "./oauth"
 /** This is the default openid signature returned from FusionAuth
  * it can be customized using [lambda functions](https://fusionauth.io/docs/v1/tech/lambdas)
  */
-export interface FusionAuthProfile {
+export interface FusionAuthProfile extends Record<string, any> {
   aud: string
   exp: number
   iat: number
@@ -20,9 +20,7 @@ export interface FusionAuthProfile {
   sid: string
 }
 
-export default function FusionAuth<
-  P extends Record<string, any> = FusionAuthProfile
->(
+export default function FusionAuth<P extends FusionAuthProfile>(
   // tenantId only needed if there is more than one tenant configured on the server
   options: OAuthUserConfig<P> & { tenantId?: string }
 ): OAuthConfig<P> {

--- a/packages/next-auth/src/providers/google.ts
+++ b/packages/next-auth/src/providers/google.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface GoogleProfile {
+export interface GoogleProfile extends Record<string, any> {
   aud: string
   azp: string
   email: string
@@ -18,7 +18,7 @@ export interface GoogleProfile {
   sub: string
 }
 
-export default function Google<P extends Record<string, any> = GoogleProfile>(
+export default function Google<P extends GoogleProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/kakao.ts
+++ b/packages/next-auth/src/providers/kakao.ts
@@ -19,7 +19,7 @@ export type AgeRange =
  * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
  * type from : https://gist.github.com/ziponia/cdce1ebd88f979b2a6f3f53416b56a77
  */
-export interface KakaoProfile {
+export interface KakaoProfile extends Record<string, any> {
   id: number
   has_signed_up?: boolean
   connected_at?: DateTime
@@ -66,7 +66,7 @@ export interface KakaoProfile {
   }
 }
 
-export default function Kakao<P extends Record<string, any> = KakaoProfile>(
+export default function Kakao<P extends KakaoProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {
@@ -81,10 +81,10 @@ export default function Kakao<P extends Record<string, any> = KakaoProfile>(
     },
     profile(profile) {
       return {
-        id: profile.id,
-        name: profile.kakao_account?.profile.nickname,
+        id: String(profile.id),
+        name: profile.kakao_account?.profile?.nickname,
         email: profile.kakao_account?.email,
-        image: profile.kakao_account?.profile.profile_image_url,
+        image: profile.kakao_account?.profile?.profile_image_url,
       }
     },
     options,

--- a/packages/next-auth/src/providers/keycloak.ts
+++ b/packages/next-auth/src/providers/keycloak.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface KeycloakProfile {
+export interface KeycloakProfile extends Record<string, any> {
   exp: number
   iat: number
   auth_time: number
@@ -24,9 +24,9 @@ export interface KeycloakProfile {
   user: any
 }
 
-export default function Keycloak<
-  P extends Record<string, any> = KeycloakProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function Keycloak<P extends KeycloakProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "keycloak",
     name: "Keycloak",

--- a/packages/next-auth/src/providers/line.ts
+++ b/packages/next-auth/src/providers/line.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface LineProfile {
+export interface LineProfile extends Record<string, any> {
   iss: string
   sub: string
   aud: string
@@ -12,7 +12,7 @@ export interface LineProfile {
   user: any
 }
 
-export default function LINE<P extends Record<string, any> = LineProfile>(
+export default function LINE<P extends LineProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/linkedin.ts
+++ b/packages/next-auth/src/providers/linkedin.ts
@@ -8,7 +8,7 @@ interface Element {
   identifiers?: Identifier[]
 }
 
-export interface LinkedInProfile {
+export interface LinkedInProfile extends Record<string, any> {
   id: string
   localizedFirstName: string
   localizedLastName: string
@@ -19,9 +19,9 @@ export interface LinkedInProfile {
   }
 }
 
-export default function LinkedIn<
-  P extends Record<string, any> = LinkedInProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function LinkedIn<P extends LinkedInProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "linkedin",
     name: "LinkedIn",

--- a/packages/next-auth/src/providers/naver.ts
+++ b/packages/next-auth/src/providers/naver.ts
@@ -1,7 +1,7 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
 /** https://developers.naver.com/docs/login/profile/profile.md */
-export interface NaverProfile {
+export interface NaverProfile extends Record<string, any> {
   resultcode: string
   message: string
   response: {
@@ -18,7 +18,7 @@ export interface NaverProfile {
   }
 }
 
-export default function Naver<P extends Record<string, any> = NaverProfile>(
+export default function Naver<P extends NaverProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/okta.ts
+++ b/packages/next-auth/src/providers/okta.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface OktaProfile {
+export interface OktaProfile extends Record<string, any> {
   iss: string
   ver: string
   sub: string
@@ -34,7 +34,7 @@ export interface OktaProfile {
   c_hash: string
 }
 
-export default function Okta<P extends Record<string, any> = OktaProfile>(
+export default function Okta<P extends OktaProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/osu.ts
+++ b/packages/next-auth/src/providers/osu.ts
@@ -16,7 +16,7 @@ export interface OsuUserCompact {
   username: string
 }
 
-export interface OsuProfile extends OsuUserCompact {
+export interface OsuProfile extends OsuUserCompact, Record<string, any> {
   discord: string | null
   has_supported: boolean
   interests: string | null
@@ -49,7 +49,7 @@ export interface OsuProfile extends OsuUserCompact {
   is_restricted: boolean
 }
 
-export default function Osu<P extends Record<string, any> = OsuProfile>(
+export default function Osu<P extends OsuProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/patreon.ts
+++ b/packages/next-auth/src/providers/patreon.ts
@@ -1,13 +1,13 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface PatreonProfile {
+export interface PatreonProfile extends Record<string, any> {
   sub: string
   nickname: string
   email: string
   picture: string
 }
 
-export default function Patreon<P extends Record<string, any> = PatreonProfile>(
+export default function Patreon<P extends PatreonProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/pipedrive.ts
+++ b/packages/next-auth/src/providers/pipedrive.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface PipedriveProfile {
+export interface PipedriveProfile extends Record<string, any> {
   success: boolean
   data: {
     id: number
@@ -35,9 +35,9 @@ export interface PipedriveProfile {
   }
 }
 
-export default function Pipedrive<
-  P extends Record<string, any> = PipedriveProfile
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function Pipedrive<P extends PipedriveProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "pipedrive",
     name: "Pipedrive",
@@ -48,7 +48,7 @@ export default function Pipedrive<
     userinfo: "https://api.pipedrive.com/users/me",
     profile: ({ data: profile }) => {
       return {
-        id: profile.id,
+        id: String(profile.id),
         name: profile.name,
         email: profile.email,
         image: profile.icon_url,

--- a/packages/next-auth/src/providers/slack.ts
+++ b/packages/next-auth/src/providers/slack.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface SlackProfile {
+export interface SlackProfile extends Record<string, any> {
   ok: boolean
   sub: string
   "https://slack.com/user_id": string
@@ -32,7 +32,7 @@ export interface SlackProfile {
   "https://slack.com/team_image_default": boolean
 }
 
-export default function Slack<P extends Record<string, any> = SlackProfile>(
+export default function Slack<P extends SlackProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/spotify.ts
+++ b/packages/next-auth/src/providers/spotify.ts
@@ -4,13 +4,13 @@ export interface SpotifyImage {
   url: string
 }
 
-export interface SpotifyProfile {
+export interface SpotifyProfile extends Record<string, any> {
   id: string
   display_name: string
   email: string
   images: SpotifyImage[]
 }
-export default function Spotify<P extends Record<string, any> = SpotifyProfile>(
+export default function Spotify<P extends SpotifyProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/trakt.ts
+++ b/packages/next-auth/src/providers/trakt.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface TraktUser {
+export interface TraktUser extends Record<string, any> {
   username: string
   private: boolean
   name: string
@@ -15,9 +15,9 @@ export interface TraktUser {
   images: { avatar: { full: string } }
 }
 
-export default function Trakt<
-  P extends Record<string, any> = TraktUser
->(options: OAuthUserConfig<P>): OAuthConfig<P> {
+export default function Trakt<P extends TraktUser>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
   return {
     id: "trakt",
     name: "Trakt",

--- a/packages/next-auth/src/providers/twitch.ts
+++ b/packages/next-auth/src/providers/twitch.ts
@@ -1,13 +1,13 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface TwitchProfile {
+export interface TwitchProfile extends Record<string, any> {
   sub: string
   preferred_username: string
   email: string
   picture: string
 }
 
-export default function Twitch<P extends Record<string, any> = TwitchProfile>(
+export default function Twitch<P extends TwitchProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {

--- a/packages/next-auth/src/providers/workos.ts
+++ b/packages/next-auth/src/providers/workos.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface WorkOSProfile {
+export interface WorkOSProfile extends Record<string, any> {
   object: string
   id: string
   organization_id: string
@@ -15,10 +15,11 @@ export interface WorkOSProfile {
     email: string
     lastName: string
     firstName: string
+    picture: string
   }
 }
 
-export default function WorkOS<P extends Record<string, any> = WorkOSProfile>(
+export default function WorkOS<P extends WorkOSProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   const { issuer = "https://api.workos.com/" } = options

--- a/packages/next-auth/src/providers/zoom.ts
+++ b/packages/next-auth/src/providers/zoom.ts
@@ -1,6 +1,6 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
-export interface ZoomProfile {
+export interface ZoomProfile extends Record<string, any> {
   id: string
   first_name: string
   last_name: string
@@ -29,7 +29,7 @@ export interface ZoomProfile {
   status: string
 }
 
-export default function Zoom<P extends Record<string, any> = ZoomProfile>(
+export default function Zoom<P extends ZoomProfile>(
   options: OAuthUserConfig<P>
 ): OAuthConfig<P> {
   return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## Reasoning 💡

When reviewing this PR https://github.com/nextauthjs/next-auth/pull/4170 we noticed that the types in our provider files [were incorrect](https://github.com/nextauthjs/next-auth/pull/4170/files#r828419058).

When declaring the options for the provider profile, we were doing this:
```ts
export default function Discord<P extends Record<string, any> = DiscordProfile>(
```
but **TS** is not able to infer the types correctly as you can see:

<img width="600" alt="Screenshot 2022-03-16 at 21 32 15" src="https://user-images.githubusercontent.com/5938217/158687916-d64b5270-d2fc-4f40-923b-64deedc079b9.png">

However changing it like this:
```ts
interface DiscordProfile extends Record<string, any> {
  // ...
}

export default function Discord<P extends DiscordProfile>(
```

enables TS to pick up the types correctly:

<img width="600" alt="Screenshot 2022-03-16 at 21 32 00" src="https://user-images.githubusercontent.com/5938217/158688248-3f9b1d80-86a5-40b6-8085-0f31582efcc6.png">

I believe both syntaxes are more or less equivalent to what we want to achieve which is typing the profile object of the provider but allowing extra fields for user flexibility.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] ~~Documentation~~
- [ ] ~~Tests~~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

None 
