### PR TITLE
Updated port number in BoxyHQ SAML docs

### DIFF
--- a/docs/docs/providers/boxyhq-saml.md
+++ b/docs/docs/providers/boxyhq-saml.md
@@ -30,7 +30,7 @@ import BoxyHQSAMLProvider from "next-auth/providers/boxyhq-saml"
 ...
 providers: [
   BoxyHQSAMLProvider({
-    issuer: "http://localhost:5000",
+    issuer: "http://localhost:5225",
     clientId: "dummy", // The dummy here is necessary since we'll pass tenant and product custom attributes in the client code
     clientSecret: "dummy", // The dummy here is necessary since we'll pass tenant and product custom attributes in the client code
   })


### PR DESCRIPTION
## Reasoning 💡

Minor change in documentation for BoxyHQ SAML. Default port 5000 was changed to port 5225 because 5000 is blocked by MacOS AirPlay.

## Checklist 🧢

- [x] Documentation
- [x] Ready to be merged

## Affected issues 🎟

n/a
