### PR TITLE
Make getToken also support Basic HTTP Auth.

### DIFF
--- a/packages/next-auth/src/jwt/index.ts
+++ b/packages/next-auth/src/jwt/index.ts
@@ -90,7 +90,7 @@ export async function getToken<R extends boolean = false>(
 
   let token = sessionStore.value
 
-  if (!token && req.headers.authorization?.split(" ")[0] === "Bearer") {
+  if (!token && req.headers.authorization?.split(" ")[0] === "Bearer" || "Basic") {
     const urlEncodedToken = req.headers.authorization.split(" ")[1]
     token = decodeURIComponent(urlEncodedToken)
   }

--- a/packages/next-auth/src/jwt/index.ts
+++ b/packages/next-auth/src/jwt/index.ts
@@ -89,10 +89,10 @@ export async function getToken<R extends boolean = false>(
   )
 
   let token = sessionStore.value
-
-  if (!token && req.headers.authorization?.split(" ")[0] === "Bearer" || "Basic") {
-    const urlEncodedToken = req.headers.authorization.split(" ")[1]
-    token = decodeURIComponent(urlEncodedToken)
+  const authHeaderType = req.headers.authorization?.split(" ")[0]
+  if (!token && authHeaderType === "Bearer" || "Basic") {
+    const secret = req.headers.authorization.split(" ")[1]
+    token = authHeaderType === "Bearer" ? decodeURIComponent(secret) : atob(secret)
   }
 
   // @ts-expect-error

--- a/packages/next-auth/src/jwt/index.ts
+++ b/packages/next-auth/src/jwt/index.ts
@@ -92,7 +92,8 @@ export async function getToken<R extends boolean = false>(
   const authHeaderType = req.headers.authorization?.split(" ")[0]
   if (!token && authHeaderType === "Bearer" || "Basic") {
     const secret = req.headers.authorization.split(" ")[1]
-    token = authHeaderType === "Bearer" ? decodeURIComponent(secret) : atob(secret)
+    token = authHeaderType === "Basic" ? atob(secret) : secret
+    token = decodeURIComponent(secret)
   }
 
   // @ts-expect-error


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡
Hey there! ✋🏻 I think it would be really nice to also support HTTP Basic Auth by passing the session token. It basically searches for either "Bearer or "Basic" instead of just supporting Bearer token. 

I think this doesn't add much code to support in the future and is a nice extra way to support auth besides cookies and Bearer token!
👍🏻 

```
curl "http://localhost:3000/api/jwt" \
  -u 'eyJ....Session token Here'

```

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~- [ ] Documentation~
~- [ ] Tests~
- [x] Ready to be merged
