### PR TITLE
chore(adapters): Add next-autth as devDependencies for adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "semver": "7.3.5",
     "stream-to-array": "2.3.0",
     "ts-node": "10.5.0",
-    "turbo": "1.1.4",
+    "turbo": "^1.1.6",
     "typescript": "^4.5.2"
   },
   "engines": {

--- a/packages/adapter-dgraph/package.json
+++ b/packages/adapter-dgraph/package.json
@@ -38,6 +38,7 @@
     "@types/jsonwebtoken": "^8.5.5",
     "@types/node-fetch": "^2.5.11",
     "jest": "^27.0.6",
+    "next-auth": "^4.0.1",
     "ts-jest": "^27.0.3"
   },
   "dependencies": {

--- a/packages/adapter-dynamodb/package.json
+++ b/packages/adapter-dynamodb/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.36.1",
     "@aws-sdk/lib-dynamodb": "^3.36.1",
-    "@shelf/jest-dynamodb": "^2.1.0"
+    "@shelf/jest-dynamodb": "^2.1.0",
+    "next-auth": "^4.0.1"
   }
 }

--- a/packages/adapter-fauna/package.json
+++ b/packages/adapter-fauna/package.json
@@ -37,7 +37,8 @@
   },
   "devDependencies": {
     "@fauna-labs/fauna-schema-migrate": "^2.1.3",
-    "faunadb": "^4.3.0"
+    "faunadb": "^4.3.0",
+    "next-auth": "^4.0.1"
   },
   "jest": {
     "preset": "adapter-test/jest"

--- a/packages/adapter-firebase/package.json
+++ b/packages/adapter-firebase/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "firebase": "^8.6.2",
-    "firebase-tools": "^9.11.0"
+    "firebase-tools": "^9.11.0",
+    "next-auth": "^4.0.1"
   }
 }

--- a/packages/adapter-mikro-orm/package.json
+++ b/packages/adapter-mikro-orm/package.json
@@ -37,7 +37,8 @@
   },
   "devDependencies": {
     "@mikro-orm/core": "^5.0.2",
-    "@mikro-orm/sqlite": "^5.0.2"
+    "@mikro-orm/sqlite": "^5.0.2",
+    "next-auth": "^4.0.1"
   },
   "jest": {
     "preset": "adapter-test/jest"

--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -26,7 +26,8 @@
     "next-auth": "^4.0.1"
   },
   "devDependencies": {
-    "mongodb": "^4.4.0"
+    "mongodb": "^4.4.0",
+    "next-auth": "^4.0.1"
   },
   "jest": {
     "preset": "adapter-test/jest"

--- a/packages/adapter-neo4j/package.json
+++ b/packages/adapter-neo4j/package.json
@@ -38,7 +38,8 @@
   },
   "devDependencies": {
     "@types/uuid": "^8.3.3",
-    "neo4j-driver": "^4.4.0"
+    "neo4j-driver": "^4.4.0",
+    "next-auth": "^4.0.1"
   },
   "dependencies": {
     "uuid": "^8.3.2"

--- a/packages/adapter-pouchdb/package.json
+++ b/packages/adapter-pouchdb/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@types/pouchdb": "^6.4.0",
+    "next-auth": "^4.0.1",
     "pouchdb": "^7.2.2",
     "pouchdb-adapter-memory": "^7.2.2",
     "pouchdb-find": "^7.2.2"

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@prisma/client": "^3.10.0",
+    "next-auth": "^4.0.1",
     "prisma": "^3.10.0"
   },
   "jest": {

--- a/packages/adapter-sequelize/package.json
+++ b/packages/adapter-sequelize/package.json
@@ -33,6 +33,7 @@
     "sequelize": "^6.6.5"
   },
   "devDependencies": {
+    "next-auth": "^4.0.1",
     "sequelize": "^6.6.5"
   },
   "jest": {

--- a/packages/adapter-typeorm-legacy/package.json
+++ b/packages/adapter-typeorm-legacy/package.json
@@ -37,6 +37,7 @@
     "sqlite": "tests/sqlite/test.sh"
   },
   "devDependencies": {
+    "next-auth": "^4.0.1",
     "mssql": "^7.2.1",
     "mysql": "^2.18.1",
     "pg": "^8.7.1",

--- a/packages/adapter-upstash-redis/package.json
+++ b/packages/adapter-upstash-redis/package.json
@@ -35,7 +35,8 @@
   },
   "devDependencies": {
     "@upstash/redis": "^1.0.1",
-    "dotenv": "^10.0.0"
+    "dotenv": "^10.0.0",
+    "next-auth": "^4.0.1"
   },
   "dependencies": {
     "uuid": "^8.3.2"

--- a/packages/next-auth/src/core/lib/oauth/client-legacy.ts
+++ b/packages/next-auth/src/core/lib/oauth/client-legacy.ts
@@ -36,6 +36,7 @@ export function oAuth1Client(options: InternalOptions<"oauth">) {
   // Promisify getOAuth1AccessToken()  for OAuth1
   const originalGetOAuth1AccessToken =
     oauth1Client.getOAuthAccessToken.bind(oauth1Client)
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   oauth1Client.getOAuthAccessToken = async (...args: any[]) => {
     return await new Promise((resolve, reject) => {
       originalGetOAuth1AccessToken(
@@ -52,6 +53,7 @@ export function oAuth1Client(options: InternalOptions<"oauth">) {
 
   const originalGetOAuthRequestToken =
     oauth1Client.getOAuthRequestToken.bind(oauth1Client)
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   oauth1Client.getOAuthRequestToken = async (params = {}) => {
     return await new Promise((resolve, reject) => {
       originalGetOAuthRequestToken(

--- a/packages/next-auth/src/lib/logger.ts
+++ b/packages/next-auth/src/lib/logger.ts
@@ -99,7 +99,7 @@ export function proxyLogger(
         }
         ;(metadata as any).client = true
         const url = `${basePath}/_log`
-        const body = new URLSearchParams({ level, code, ...metadata })
+        const body = new URLSearchParams({ level, code, ...(metadata as any) })
         if (navigator.sendBeacon) {
           return navigator.sendBeacon(url, body)
         }

--- a/packages/tsconfig/adapters.json
+++ b/packages/tsconfig/adapters.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",
-    "declaration": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "strict": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13940,7 +13940,7 @@ netmask@^2.0.1:
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
-next-auth@^4.3.1, next-auth@latest:
+next-auth@latest:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.3.1.tgz#94520592d1d1851eb66ca3ad2758637e1df950e1"
   integrity sha512-DBYEPBLq5naIqh/1i2zEHljcA1OXXecKW3NRU1W4s6R3UX3RdLZ2lWlqgBHUiZQ1zdNikFM/bYQxVGyG7bx8oA==
@@ -18356,83 +18356,83 @@ tunnel@0.0.6, tunnel@^0.0.6:
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
-turbo-darwin-64@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.1.4.tgz#cfe3970da9eb2c40e6d39aee06e2a124ef591d0c"
-  integrity sha512-X10dAxqCMXnDjyN4K5mSvhol42kfAcJhI9NS7neIMD25kLcULYFe96Qk1XWEBxgCEBAmkf7UrysYSP+dQMPlGw==
+turbo-darwin-64@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.1.6.tgz#1f493d9fed174e609b65c2f64028d42d095c9bb7"
+  integrity sha512-xzl79T7mPKaIGhMBCAzpTvXkbFNZaMyeOMsNXxVT5dTY+d3FwLFfbqHIoG1dH745TbH6i67bxtt70lKdQa+qdQ==
 
-turbo-darwin-arm64@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.1.4.tgz#565413799f98ff7da170be13396975e834c7d570"
-  integrity sha512-sl5TiMLNqWKvKpQsh6lg2sUXRTVt5lfRqnStVw/E/5BTm/KIBZTNWHmx0hO8/LwDmXenVtpiW7h7BbWewfPqTQ==
+turbo-darwin-arm64@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.1.6.tgz#aa6218492de696e49c1af16bb1d13118aa85a203"
+  integrity sha512-r0D+Kfwcaqec5h9Xa4T/VD6mWZ2LQr+zOEBBL6UA15htgel06B2eXiGdjRiw4i7ieV80tEBEDdz9tSWJBhAL/Q==
 
-turbo-freebsd-64@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.1.4.tgz#ad11411522ea3ffc470a89e33a8e8dae41220dcf"
-  integrity sha512-EKrAzIyVgmeQf0NpAcxYrhFEiBTrjO163dpiiHxwRiRxTYtcWgY+RJiWVQyIeG0yPx1Z+aLXvmPqf6HvC0T3hg==
+turbo-freebsd-64@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.1.6.tgz#9a7b6affb3177f100a2315cdd81c3b2f87180287"
+  integrity sha512-v5MJeRcyeCDF3La40TOub0+/OuGGFuLzlVHb4jYxthESbtLve1H23bDiL+4gCQgPYOsKMOvKQpuoMaKW2gxk7A==
 
-turbo-freebsd-arm64@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.1.4.tgz#bf73cbb4d59244c6486dcf87a758842fed662284"
-  integrity sha512-Vz3NSbc909eZU1DaS54vL1Z022OCG9wnrK7cB2e2ynMMdeYrIxAWnQeGVrYewQHYhwcCs7/6TgZCfhZKnG2nxQ==
+turbo-freebsd-arm64@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.1.6.tgz#e70e94277c7149ba95cbacd826068f46b0346727"
+  integrity sha512-5gm3r+M5f/Idt/pggyCQ+MZSlaUdxUeb/4LtPohhWOoj4PYo1o5kwInaRlckr7uV36E4/npDvz9cDV96Pohejg==
 
-turbo-linux-32@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.1.4.tgz#cc4e02a790a6703535f9fb8144d95d27a6e75437"
-  integrity sha512-sACZPPv0wDpoTu1qRuOP0CYZS6HY8naySg9fTBP4kcRF5dLC4xPQZA46g8AUMkRFoBsyqA08t2whwV8gvYFoUg==
+turbo-linux-32@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.1.6.tgz#02f072f68bb8a71e205f24cee2068ee455fb1cb1"
+  integrity sha512-dLc1Vd/LQP5n3NGLMf+cdaK99sMWvHdDvTUSrSwoYDy5fWFpUm0E12lAxRH3tikX2m7Kfcy2uY5xSJIuq5xzYQ==
 
-turbo-linux-64@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.1.4.tgz#a64834b2abd0be4f4fb7ff0497445bcd005421b1"
-  integrity sha512-VTDSlTiF01P50JcyemWhGC1lx736gQMi3q6eLkGrt0t9HTtkl9FpQEypJDyRKZXTL+60ldriIwhivHmWm9cwQA==
+turbo-linux-64@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.1.6.tgz#5b90ab2aa1e2e0a94f18905871d88656335f0285"
+  integrity sha512-V4rb41yQUA+vPDgXc06oHmKbgrBUbwm09oRtjvmlIQU8zX8qujMPZIun8tGP4NuzErJXGzD3WDgj7VSsO23IIw==
 
-turbo-linux-arm64@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.1.4.tgz#cc1c35896de9a55f67d473165a49d916072d7437"
-  integrity sha512-rMSjwzWg9W8J/JwIBtp0+e8O8MP6Z5U4htMgk88zalhSYhAxGIhOCIQT8KsaKoc71Ee/wG1soeprZvqBf/B84Q==
+turbo-linux-arm64@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.1.6.tgz#f7e738e35b5daa7e5f82f61aa1018a39ad03501f"
+  integrity sha512-QsE7gow3WxWXKwNWJX4DIJys6xc6Up4/icjdTZCZbglPLwuG2UiUzjJ2+beXxVU4EmpQF6NwKubHCtrs8m8/kQ==
 
-turbo-linux-arm@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.1.4.tgz#7c4310dfc7e8e1e42a766f57969e972a23c4c70b"
-  integrity sha512-XDVX6rzRr7AgqQvA4VwPVAHWxxWFI8SgEsNtbXD4sKiEFo9fTWqMvtRJqhx86Z/XHtCJF8VuU3yPS5puItdc9A==
+turbo-linux-arm@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.1.6.tgz#39b29c3f91a5e426fb17f1fe543ed8587b861c7b"
+  integrity sha512-zAaIa0+EhRYYkM51ruB1LCUqyeigK66A+KfXZ3Y9+aiKg7EYbDvuv+ReD4srLPKoIuAxR5dYlk5RVhSKejt2Cw==
 
-turbo-linux-mips64le@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.1.4.tgz#33ce619f2ed6259594a521bf4495f51f0ee8171b"
-  integrity sha512-2VK+R9eUQU1xPJ+tGOsALQ6hsc8W7h9ohIumBYYs++SDazwaMQB7lsusXDasf6smEzD02KyUJuj0OvwzJjqq7Q==
+turbo-linux-mips64le@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.1.6.tgz#b10aab67382984d728e3c2e7239bd4d9a67da9e2"
+  integrity sha512-098DB9daXoI6LRCkuOv1Pqim+H4wXZrFza9Xd7zJIel1WmxEgNsHqWpSH5Jn2J92LbkWl+tfN1+myw4+a4ESfw==
 
-turbo-linux-ppc64le@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.1.4.tgz#fa9e9b5fa5efd2cad7d076ef9060af874019b994"
-  integrity sha512-Ja9eiRxjioO1PV+TxRmTzsNvGGUQDdJnTLsG1YkKldkplecQdUfJRFdWksEZ7dZ+Hv44g4zvskJgUuCYlGckyA==
+turbo-linux-ppc64le@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.1.6.tgz#0fa6bdcf3420ee65b4faa2755fe852390c022a5b"
+  integrity sha512-U5A1mnsGM994h/1VT4FbsV/bb+I0fgvkY5/TTX7MfA9Iwt0SxsNlh+Jgofe1svPz0CKEe6Hl2WQSGHTlBPJb5Q==
 
-turbo-windows-32@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.1.4.tgz#e0762183582e01a21384023199e6b9fb2a883b84"
-  integrity sha512-c8l91hmpsFcmZQJBsDlhLAxfaBl83DXSmDOQoE7YT60vOZZSkfPlNSsHm9tq+4WN54unFfqpNbO7r6z+6R7rfw==
+turbo-windows-32@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.1.6.tgz#724185a8584fa2c14edc4892056f23576aeb0317"
+  integrity sha512-0C+/EI11j8ABtI6O2n+NYL2osDI6moo7YL8pqiWbNrdEGI2KbeCTVQpruUH+GONsMov06pR4BouL9UT2jSpG0g==
 
-turbo-windows-64@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.1.4.tgz#a11e1cc8fc9867066f2863da506179373b39e6bd"
-  integrity sha512-DMitFYd5eIhZ2CyPUeds3JXDB/onXBdA2DEj9cxVXY7q2ZBE4rpoV0Ft/mh15LsQZhwap9ipgddbCn16OGFvzw==
+turbo-windows-64@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.1.6.tgz#3965a5c0c55273de2882e580ca042c6564c43272"
+  integrity sha512-O2kC+7+zuMjFIi6mpU1qz+Bv27TcHkkCczcDNVU29G52pm5lwj7BZ+/gu+EPJSnF5VrgdA6Oru6KVXPRS1q+Cg==
 
-turbo@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.1.4.tgz#c42db7d5b5eaad5714bff7c5babf11ba97a17244"
-  integrity sha512-kz08AV61hJeY9xuL4yQ27G2qks5LMAdvbd36GpcKvrh4Za+m0t+r2ijMjDvATp8uj4i6IlSV0t/G0/OMwkm6HA==
+turbo@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.1.6.tgz#dcae11bbd7a465473bdf416b82caac2b7f94d641"
+  integrity sha512-pZTc6Sb5MtK/X/qhiDSssc8AZWoUoYf14ZqYjvDWg/aEtqgwYorVJqfRcj4XOXOqtVZ3gO/91eXwdyh/q2aQHA==
   optionalDependencies:
-    turbo-darwin-64 "1.1.4"
-    turbo-darwin-arm64 "1.1.4"
-    turbo-freebsd-64 "1.1.4"
-    turbo-freebsd-arm64 "1.1.4"
-    turbo-linux-32 "1.1.4"
-    turbo-linux-64 "1.1.4"
-    turbo-linux-arm "1.1.4"
-    turbo-linux-arm64 "1.1.4"
-    turbo-linux-mips64le "1.1.4"
-    turbo-linux-ppc64le "1.1.4"
-    turbo-windows-32 "1.1.4"
-    turbo-windows-64 "1.1.4"
+    turbo-darwin-64 "1.1.6"
+    turbo-darwin-arm64 "1.1.6"
+    turbo-freebsd-64 "1.1.6"
+    turbo-freebsd-arm64 "1.1.6"
+    turbo-linux-32 "1.1.6"
+    turbo-linux-64 "1.1.6"
+    turbo-linux-arm "1.1.6"
+    turbo-linux-arm64 "1.1.6"
+    turbo-linux-mips64le "1.1.6"
+    turbo-linux-ppc64le "1.1.6"
+    turbo-windows-32 "1.1.6"
+    turbo-windows-64 "1.1.6"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
## Reasoning 💡

- `turborepo` recently made changes so that `peerDependencies` are not getting prioritized in the topological order in their v1.1.6 release. This makes our build fails because adapters are being built in parallel with core `next-auth`. 
- Follow up #4205, this PR improves the codebase by adding `next-auth` as `devDependencies` for all adapter modules. This should help priotizing `next-auth` to being built first.
## Checklist 🧢

- ~[ ] Documentation~
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

