### PR TITLE
fix(fetch): fix fetch credentials default value for old browsers

### DIFF
--- a/packages/next-auth/src/client/_utils.ts
+++ b/packages/next-auth/src/client/_utils.ts
@@ -39,7 +39,10 @@ export async function fetchData<T = any>(
     const options = req?.headers.cookie
       ? { headers: { cookie: req.headers.cookie } }
       : {}
-    const res = await fetch(`${apiBaseUrl(__NEXTAUTH)}/${path}`, options)
+    const res = await fetch(`${apiBaseUrl(__NEXTAUTH)}/${path}`, {
+      ...options,
+      credentials: "same-origin",
+    })
     const data = await res.json()
     if (!res.ok) throw data
     return Object.keys(data).length > 0 ? data : null // Return null if data empty


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Old browsers use a version of fetch that [does not send the cookies alongside the request](https://caniuse.com/mdn-api_request_credentials_default_same-origin) if you don't specify `credentials: 'same-origin'`.

If you try a basic next-auth project in one of these old browsers, you'll have a weird behaviour, no error or warning, and will not be able to login.

I think next-auth code is expecting the defaut value of [Request.credentials](https://developer.mozilla.org/fr/docs/Web/API/Request/credentials) to always be `same-origin` but it is set to `omit` before chrome 72 and firefox 61. 


<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged


