### PR TITLE
Reuse previous session in `SessionProvider`

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -303,14 +303,15 @@ export function SessionProvider(props: SessionProviderProps) {
    * If session was `null`, there was an attempt to fetch it,
    * but it failed, but we still treat it as a valid initial value.
    */
-  const hasInitialSession = props.session !== undefined
+  const hasInitialSession =
+    props.session !== undefined || __NEXTAUTH._session !== undefined
 
   /** If session was passed, initialize as already synced */
   __NEXTAUTH._lastSync = hasInitialSession ? now() : 0
 
   const [session, setSession] = React.useState(() => {
-    if (hasInitialSession) __NEXTAUTH._session = props.session
-    return props.session
+    if (props.session !== undefined) __NEXTAUTH._session = props.session
+    return __NEXTAUTH._session
   })
 
   /** If session was passed, initialize as not loading */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

This reuses the previous session from the last mounted `<SessionProvider>`, if present.
With this change, users don't have to add the `<SessionProvider>` to the `_app.js` but can instead add it to individual pages that require authentication.

This reduces bundle size for pages that do not require authentication (e.g. landing pages, documentation) and does not create cookies until the user enters a page that uses the provider.

Technically this was possible before, but if the user went from a non-authenticated page back to a authenticated page, the session would not be loaded.
<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
