### PR TITLE
chore(docs): Fix API directory

### DIFF
--- a/docs/docs/getting-started/typescript.md
+++ b/docs/docs/getting-started/typescript.md
@@ -47,7 +47,7 @@ This will work in code editors with a strong TypeScript integration like VSCode 
 
 Let's look at `Session`:
 
-```ts title="pages/api/[...nextauth].ts"
+```ts title="pages/api/auth/[...nextauth].ts"
 import NextAuth from "next-auth"
 
 export default NextAuth({


### PR DESCRIPTION
Update the API directory from `pages/api/[...nextauth].ts` to `pages/api/auth/[...nextauth].ts`  so it matches the typescript example.
