### PR TITLE
fix: dropbox provider (#3899)

### DIFF
--- a/packages/next-auth/src/providers/dropbox.js
+++ b/packages/next-auth/src/providers/dropbox.js
@@ -36,7 +36,20 @@ export default function Dropbox(options) {
     authorization:
       "https://www.dropbox.com/oauth2/authorize?token_access_type=offline&scope=account_info.read",
     token: "https://api.dropboxapi.com/oauth2/token",
-    userinfo: "https://api.dropboxapi.com/2/users/get_current_account",
+    userinfo: {
+      request: async (context) => {
+        let res = await fetch(
+          "https://api.dropboxapi.com/2/users/get_current_account",
+          {
+            headers: {
+              Authorization: `Bearer ${context.tokens.access_token}`,
+            },
+            method: "POST",
+          }
+        );
+        return await res.json();
+      },
+    },
     profile(profile) {
       return {
         id: profile.account_id,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

This change should fix the currently broken Dropbox provider. Dropbox userinfo endpoint uses POST, not GET, which causes the 404 error mentioned in issue #3899.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #3899
