### PR TITLE
feat(middleware): add option to ignore specified paths

### DIFF
--- a/apps/example-nextjs/pages/admin/_middleware.ts
+++ b/apps/example-nextjs/pages/admin/_middleware.ts
@@ -1,8 +1,11 @@
-import { withAuth } from "next-auth/middleware"
+import { withAuth } from "next-auth/middleware";
 
 // More on how NextAuth.js middleware works: https://next-auth.js.org/configuration/nextjs#middleware
 export default withAuth({
   callbacks: {
     authorized: ({ token }) => token?.userRole === "admin",
   },
+  ignored: {
+    paths: ["/admin/ignored"]
+  }
 })

--- a/apps/example-nextjs/pages/admin/_middleware.ts
+++ b/apps/example-nextjs/pages/admin/_middleware.ts
@@ -1,4 +1,4 @@
-import { withAuth } from "next-auth/middleware";
+import { withAuth } from "next-auth/middleware"
 
 // More on how NextAuth.js middleware works: https://next-auth.js.org/configuration/nextjs#middleware
 export default withAuth({

--- a/apps/example-nextjs/pages/admin/ignored.tsx
+++ b/apps/example-nextjs/pages/admin/ignored.tsx
@@ -1,4 +1,4 @@
-import Layout from "../../components/layout";
+import Layout from "../../components/layout"
 
 export default function Page() {
   return (

--- a/apps/example-nextjs/pages/admin/ignored.tsx
+++ b/apps/example-nextjs/pages/admin/ignored.tsx
@@ -1,0 +1,17 @@
+import Layout from "../../components/layout";
+
+export default function Page() {
+  return (
+    <Layout>
+      <h1>This page is ignored by Middleware</h1>
+      <p>Anybody is able to see this page.</p>
+      <p>
+        To learn more about the NextAuth middleware see&nbsp;
+        <a href="https://docs-git-misc-docs-nextauthjs.vercel.app/configuration/nextjs#middleware">
+          the docs
+        </a>
+        .
+      </p>
+    </Layout>
+  )
+}

--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -67,6 +67,25 @@ See the documentation for the [pages option](/configuration/pages) for more info
 
 ---
 
+### `ignored`
+
+- **Required**: _No_
+
+#### Description
+
+Exclude specific paths or roots from middleware.
+
+#### Example (default value)
+
+```js
+ignored: {
+  roots: ["/api"], // Any pages beginning with `/api` will be excluded from middleware. 
+  paths: ["/terms", "/folder/page"] // Any pages equal to the given paths will be excluded from middleware. 
+}
+```
+
+---
+
 ### Examples
 
 `withAuth` is very flexible, there are multiple ways to use it.

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -2,10 +2,10 @@ import type { NextMiddleware, NextFetchEvent } from "next/server"
 import type { Awaitable, NextAuthOptions } from ".."
 import type { JWT } from "../jwt"
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server"
 
-import { getToken } from "../jwt";
-import parseUrl from "../lib/parse-url";
+import { getToken } from "../jwt"
+import parseUrl from "../lib/parse-url"
 
 type AuthorizedCallback = (params: {
   token: JWT | null
@@ -31,9 +31,6 @@ export interface NextAuthMiddlewareOptions {
   ignored: {
     /**
    * The root of paths to ignore, such as `/api`. This would exclude all paths starting with `/api`.
-   * 
-   * ---
-   * [Documentation](https://next-auth.js.org/getting-started/nextjs/middleware#ignored-pages)
    */
     roots: string[]
     /**


### PR DESCRIPTION
## Reasoning 💡

This PR simply adds another option to middleware allowing people to specify path's to be ignored. Doing this allows paths that do not require middleware to not have to wait for any backend checks to see if the user is authenticated, nor does any custom middleware that isnt used on said pages have to be ran.

**Before**
![jm25j 1](https://user-images.githubusercontent.com/35779365/161370346-4396d063-dd50-452f-83ce-ef5fb23e57ea.png)

**After**
![anr47 1](https://user-images.githubusercontent.com/35779365/161370341-dd0d6207-ffd0-48fe-a487-fc635895dc09.png)

## Checklist 🧢

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

This is my first pull request in this repository, hopefully I did everything correctly :pray: