### PR TITLE
docs: fix type in signIn callbackUrl examples

### DIFF
--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -312,7 +312,7 @@ You can specify a different `callbackUrl` by specifying it as the second argumen
 
 e.g.
 
-- `signIn(null, { callbackUrl: 'http://localhost:3000/foo' })`
+- `signIn(undefined, { callbackUrl: 'http://localhost:3000/foo' })`
 - `signIn('google', { callbackUrl: 'http://localhost:3000/foo' })`
 - `signIn('email', { email, callbackUrl: 'http://localhost:3000/foo' })`
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Fix the type in signIn callbackUrl examples to match the typescript.

## Reasoning 💡

Maybe don't merge this but instead expand the type signature to match the project convention. But `null` is not a valid input for `signIn(provider?: LiteralUnion<BuiltInProviderType>,...)`

[Preview Url](https://next-auth-git-fork-reconbot-patch-3-nextauthjs.vercel.app/getting-started/client#specifying-a-callbackurl)

## Checklist 🧢

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- ~[ ] Tests~
- [x] Ready to be merged

