### PR TITLE
docs: callbacks can now be relative

### DIFF
--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -400,7 +400,7 @@ As with the `signIn()` function, you can specify a `callbackUrl` parameter by pa
 
 e.g. `signOut({ callbackUrl: 'http://localhost:3000/foo' })`
 
-The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect-callback). By default it requires the URL to be an absolute URL at the same host name, or a relative url starting with a slash. If it does not match it will redirect to the homepage. You can define your own [redirect callback](/configuration/callbacks#redirect-callback) to allow other URLs.
+The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect-callback). By default, it requires the URL to be an absolute URL at the same host name, or you can also supply a relative URL starting with a slash. If it does not match it will redirect to the homepage. You can define your own [redirect callback](/configuration/callbacks#redirect-callback) to allow other URLs.
 
 ### Using the `redirect: false` option
 

--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -312,11 +312,11 @@ You can specify a different `callbackUrl` by specifying it as the second argumen
 
 e.g.
 
-- `signIn(null, { callbackUrl: 'http://localhost:3000/foo' })`
-- `signIn('google', { callbackUrl: 'http://localhost:3000/foo' })`
+- `signIn(null, { callbackUrl: '/foo' })`
+- `signIn('google', { callbackUrl: 'http://localhost:3000/bar' })`
 - `signIn('email', { email, callbackUrl: 'http://localhost:3000/foo' })`
 
-The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect-callback). By default it requires the URL to be an absolute URL at the same host name, or else it will redirect to the homepage. You can define your own [redirect callback](/configuration/callbacks#redirect-callback) to allow other URLs, including supporting relative URLs.
+The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect-callback). By default it requires the URL to be an absolute URL at the same host name, or a relative url starting with a slash. If it does not match it will redirect to the homepage. You can define your own [redirect callback](/configuration/callbacks#redirect-callback) to allow other URLs.
 
 ### Using the `redirect: false` option
 
@@ -400,7 +400,7 @@ As with the `signIn()` function, you can specify a `callbackUrl` parameter by pa
 
 e.g. `signOut({ callbackUrl: 'http://localhost:3000/foo' })`
 
-The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect-callback). By default this means it must be an absolute URL at the same host name (or else it will default to the homepage); you can define your own custom [redirect callback](/configuration/callbacks#redirect-callback) to allow other URLs, including supporting relative URLs.
+The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect-callback). By default it requires the URL to be an absolute URL at the same host name, or a relative url starting with a slash. If it does not match it will redirect to the homepage. You can define your own [redirect callback](/configuration/callbacks#redirect-callback) to allow other URLs.
 
 ### Using the `redirect: false` option
 


### PR DESCRIPTION
Since v4 callbacks can now be relative.

## Reasoning 💡

Updating docs for v4


## Checklist 🧢

- [x] Documentation
- ~[ ] Tests~
- [x] Ready to be merged


[Preview url](https://next-auth-git-fork-reconbot-reconbot-callbacks-nextauthjs.vercel.app/getting-started/client#redirects-to-sign-in-page-when-clicked)