### PR TITLE
docs: add google oauth URI examples

### DIFF
--- a/docs/docs/providers/google.md
+++ b/docs/docs/providers/google.md
@@ -13,8 +13,8 @@ https://console.developers.google.com/apis/credentials
 
 The "Authorized redirect URIs" used when creating the credentials must include your full domain and end in the callback path. For example;
 
-- `https://example.com/api/auth/callback/google`
-- For development `http://localhost:3000/api/auth/callback/google`
+- For production: `https://{YOUR_DOMAIN}/api/auth/callback/google`
+- For development: `http://localhost:3000/api/auth/callback/google`
 
 ## Options
 

--- a/docs/docs/providers/google.md
+++ b/docs/docs/providers/google.md
@@ -11,6 +11,11 @@ https://developers.google.com/identity/protocols/oauth2
 
 https://console.developers.google.com/apis/credentials
 
+The "Authorized redirect URIs" used when creating the credentials must include your full domain and end in the callback path. For example;
+
+- `https://example.com/api/auth/callback/google`
+- For development `http://localhost:3000/api/auth/callback/google`
+
 ## Options
 
 The **Google Provider** comes with a set of default options:


### PR DESCRIPTION
## Reasoning 💡

Adding some examples to make it easier to create oauth examples for google.

## Checklist 🧢

- [ ] Documentation
- ~[ ] Tests~
- [x] Ready to be merged


[Preview Url](https://next-auth-git-fork-reconbot-reconbot-google-callback-nextauthjs.vercel.app/providers/google)