### PR TITLE
Fix inability to use custom decode with middleware

### DIFF
--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -1,6 +1,6 @@
 import type { NextMiddleware, NextFetchEvent } from "next/server"
 import type { Awaitable, NextAuthOptions } from ".."
-import type { JWT } from "../jwt"
+import type { JWT, JWTOptions } from "../jwt"
 
 import { NextResponse, NextRequest } from "next/server"
 
@@ -20,7 +20,8 @@ export interface NextAuthMiddlewareOptions {
    * ---
    * [Documentation](https://next-auth.js.org/configuration/pages)
    */
-  pages?: NextAuthOptions["pages"]
+  pages?: NextAuthOptions["pages"],
+  decode?: JWTOptions["decode"],
   callbacks?: {
     /**
      * Callback that receives the user's JWT payload
@@ -81,7 +82,7 @@ async function handleMiddleware(
     return NextResponse.redirect(errorUrl)
   }
 
-  const token = await getToken({ req: req as any })
+  const token = await getToken({ req: req as any, decode: options?.decode })
 
   const isAuthorized =
     (await options?.callbacks?.authorized?.({ req, token })) ?? !!token


### PR DESCRIPTION
## Reasoning 💡

Thought my custom `encode()` / `decode()` wasn't working at all because the token was always null when checking for authorization in , but it turns out that this bug was affecting me.

I am trying to do this so I can have an unencrypted JWT client-side to query my separate non-nextjs graphql server (hasura).

## Checklist 🧢


- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged


## Affected issues 🎟

Fixes #4181
