### PR TITLE
fix(signin.tsx): set type of built-in email sign-in input to "email" and add "required" attribute for browser validation

### DIFF
--- a/packages/next-auth/src/core/pages/signin.tsx
+++ b/packages/next-auth/src/core/pages/signin.tsx
@@ -123,7 +123,7 @@ export default function SigninPage(props: SignInServerPageParams) {
                 <input
                   id={`input-email-for-${provider.id}-provider`}
                   autoFocus
-                  type="text"
+                  type="email"
                   name="email"
                   value={email}
                   placeholder="email@example.com"

--- a/packages/next-auth/src/core/pages/signin.tsx
+++ b/packages/next-auth/src/core/pages/signin.tsx
@@ -127,6 +127,7 @@ export default function SigninPage(props: SignInServerPageParams) {
                   name="email"
                   value={email}
                   placeholder="email@example.com"
+                  required
                 />
                 <button type="submit">Sign in with {provider.name}</button>
               </form>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->
Currently, the built-in sign-in page has the wrong type (text) for the input for emails when using
the magic link provider. Because of this, a user can enter whatever value they want in that input and click on the "Sign in with Email". By switching the type to be "email" we can make use of the browser-provided validation and users will be
forced to use properly formed emails addresses in order to sign in.

![image](https://user-images.githubusercontent.com/26367595/162278700-20e61fa7-0a75-41e4-aa98-f8db1c810ccc.png)

![image](https://user-images.githubusercontent.com/26367595/162278801-2875523d-025b-40fe-8556-76e163b1e3e2.png)

Additionally, the built-in sign-in page doesn't have the required attribute for the input for emails when using the magic link provider. Because of this, a user is able to submit the form without entering a value. By adding the "required" attribute we can make use of the browser-provided validation and users will be forced to provide a value in order to sign in.
## Checklist 🧢

<!-- Feel free to cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
