### PR TITLE
fix(providers): add optional chaining to avoid nullish reference errors

### DIFF
--- a/packages/next-auth/src/providers/kakao.ts
+++ b/packages/next-auth/src/providers/kakao.ts
@@ -82,9 +82,9 @@ export default function Kakao<P extends Record<string, any> = KakaoProfile>(
     profile(profile) {
       return {
         id: profile.id,
-        name: profile.kakao_account?.profile.nickname,
+        name: profile.kakao_account?.profile?.nickname,
         email: profile.kakao_account?.email,
-        image: profile.kakao_account?.profile.profile_image_url,
+        image: profile.kakao_account?.profile?.profile_image_url,
       }
     },
     options,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

Hello, I encountered an error while using the Kakao provider.
If you don't select your nickname and profile image in Kakao settings, an 'undefined' error occurs because the profile object is not provided.

Please refer to the picture below.
<img width="963" alt="Kakao developers" src="https://user-images.githubusercontent.com/37607373/162628049-155850b8-c590-4b51-88c6-a31923dcc172.png">
<img width="436" alt="undefined error" src="https://user-images.githubusercontent.com/37607373/162628051-a30bc3d4-302c-4234-87e5-2ac28d5dc0ab.png">

As you can see in line 40 of the code, the profile is an optional property.
So I changed to get a nickname or profile image only if there is a profile object.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~- [ ] Documentation~
~- [ ] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
