### PR TITLE
Cleanup global `__NEXTAUTH` state after unmount

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -359,6 +359,12 @@ export function SessionProvider(props: SessionProviderProps) {
     }
 
     __NEXTAUTH._getSession()
+
+    return () => {
+      __NEXTAUTH._lastSync = 0
+      __NEXTAUTH._session = undefined
+      __NEXTAUTH._getSession = () => {}
+    }
   }, [])
 
   React.useEffect(() => {


### PR DESCRIPTION
Re-mounting the component was not reloading the session because the global `__NEXTAUTH` was not cleaned up on unmount.

## Reasoning 💡

https://github.com/nextauthjs/next-auth/pull/4252#issuecomment-1082390355

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- ~[] Documentation~
- ~[] Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Note: If using `reactStrictMode: true` and using React 18 (https://github.com/vercel/next.js/issues/35822) you will see two `api/auth/session` requests during `next dev`
