### PR TITLE
remove auth from keycloack url

### DIFF
--- a/docs/docs/providers/keycloak.md
+++ b/docs/docs/providers/keycloak.md
@@ -37,5 +37,5 @@ providers: [
 ```
 
 :::note
-`issuer` should include the realm – e.g. `https://my-keycloak-domain.com/auth/realms/My_Realm`
+`issuer` should include the realm – e.g. `https://my-keycloak-domain.com/realms/My_Realm`
 :::


### PR DESCRIPTION
in keycloak 17.0+ , There's a change in endpoints as per the official documentation (https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_users_resource) .
so the new url well be https://my-keycloak-domain.com/realms/My_Realm

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
