### PR TITLE
docs: remove error event in config options

### DIFF
--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -285,7 +285,6 @@ events: {
   async updateUser(message) { /* user updated - e.g. their email was verified */ },
   async linkAccount(message) { /* account (e.g. Twitter) linked to a user */ },
   async session(message) { /* session is active */ },
-  async error(message) { /* error in authentication flow */ }
 }
 ```
 


### PR DESCRIPTION

## Reasoning 💡

Remove `event.error` in docs 

## Checklist 🧢

- [x] Documentation
- ~~[ ] Tests~~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #4404 
