### PR TITLE
docs: fix typo in custom pages docs for `signin` page URL error param

### DIFF
--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -51,7 +51,7 @@ The following errors are passed as error query parameters to the default or over
 - **SessionRequired**: The content of this page requires you to be signed in at all times. See [useSession](/getting-started/client#require-session) for configuration.
 - **Default**: Catch all, will apply, if none of the above matched
 
-Example: `/auth/error?error=Default`
+Example: `/auth/signin?error=Default`
 
 ## Theming
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

Currently I think the example URL for errors being sent to the sign in page is wrong in the context of the other examples given on [this page](https://next-auth.js.org/configuration/pages#sign-in-page). 

It gives the example URL and error param with a path of `auth/error` however, the sign in errors are indeed sent to the `auth/signin` page.

![image](https://user-images.githubusercontent.com/15039843/163837771-fad4758a-31eb-4ee5-8cfe-a53050b3be0a.png)

I've suggested what I think is the correct example URL given the documentation page context (creating a custom `auth/signin` page as detailed above this typo!)

<!-- What changes are being made? What feature/bug is being fixed here? -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

None found

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
