### PR TITLE
docs: Use correct module in examples for augmenting TypeScript Sessio…

### DIFF
--- a/docs/docs/getting-started/typescript.md
+++ b/docs/docs/getting-started/typescript.md
@@ -75,9 +75,9 @@ export default function IndexPage() {
 To extend/augment this type, create a `types/next-auth.d.ts` file in your project:
 
 ```ts title="types/next-auth.d.ts"
-import NextAuth from "next-auth"
+import NextAuth from "next-auth/core/types"
 
-declare module "next-auth" {
+declare module "next-auth/core/types" {
   /**
    * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
    */
@@ -97,9 +97,9 @@ By default, TypeScript will merge new interface properties and overwrite existin
 If you want to keep the default session user properties, you need to add them back into the newly declared interface:
 
 ```ts title="types/next-auth.d.ts"
-import NextAuth, { DefaultSession } from "next-auth"
+import NextAuth, { DefaultSession } from "next-auth/core/types"
 
-declare module "next-auth" {
+declare module "next-auth/core/types" {
   /**
    * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
    */


### PR DESCRIPTION
…n and User types

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

<!-- What changes are being made? What feature/bug is being fixed here? -->

The examples in the documentation for overriding the TypeScript User and Session types did not work as intended. I believe this is due to the incorrect module path provided. The types themselves live inside the `next-auth/core/types` module rather than the `next-auth` module, even though they are being imported in the latter. This change allows TypeScript to correctly detect that the types have been augmented. Tested in TypeScript 4.6.2.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] ~Tests~
- [X] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

Fixes #671

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #671
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
