### PR TITLE
chore: fixes `404` error, when visiting the options link

### DIFF
--- a/docs/docs/providers/discord.md
+++ b/docs/docs/providers/discord.md
@@ -15,7 +15,7 @@ https://discord.com/developers/applications
 
 The **Discord Provider** comes with a set of default options:
 
-- [Discord Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/discord.js)
+- [Discord Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/discord.ts)
 
 You can override any of the options to suit your own use case.
 


### PR DESCRIPTION
## Reasoning 💡
I wanted to fix the `404` error in the documentation.

## Checklist 🧢
- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟
Documentation points to discord options, however, the current link leads to a `404 page`

*Edited to match your formats*
