### PR TITLE
Clarify `code_challenge_method` RFC requirement

### DIFF
--- a/docs/docs/errors.md
+++ b/docs/docs/errors.md
@@ -111,9 +111,13 @@ This error occurs when there was no `authorize()` handler defined on the credent
 
 #### PKCE_ERROR
 
-The provider you tried to use failed when setting [PKCE or Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636#section-4.2).
+The provider you tried to use failed when setting [PKCE or Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636#section-4).
 The `code_verifier` is saved in a cookie called (by default) `__Secure-next-auth.pkce.code_verifier` which expires after 15 minutes.
-Check if `cookies.pkceCodeVerifier` is configured correctly. The default `code_challenge_method` is `"S256"`. This is currently not configurable to `"plain"`, as it is not recommended, and in most cases, it is only supported for backward compatibility.
+Check if `cookies.pkceCodeVerifier` is configured correctly.
+
+The default `code_challenge_method` is `"S256"`. This is currently not configurable to `"plain"`, [as per RFC7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2): 
+> If the client is capable of using "S256", it MUST use "S256", as
+  S256" is Mandatory To Implement (MTI) on the server.
 
 ---
 


### PR DESCRIPTION
## Reasoning 💡

[RFC7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2) specifies that clients MUST use the S256 method for code exchange, if able. This clarifies it in the docs, instead of just saying it's "not recommended" or "it's usually only for backwards compatibility".

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [ ] ~Tests~
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
#4459 is related by [this comment](https://github.com/nextauthjs/next-auth/discussions/4459#discussioncomment-2622922).