### PR TITLE
docs: remove redudant and deprecated session.jwt

### DIFF
--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -47,7 +47,6 @@ export interface NextAuthOptions {
    */
   session?: Partial<SessionOptions>
   /**
-   * JSON Web Tokens can be used for session tokens if enabled with the `session: { jwt: true }` option.
    * JSON Web Tokens are enabled by default if you have not specified a database.
    * By default JSON Web Tokens are signed (JWS) but not encrypted (JWE),
    * as JWT encryption adds additional overhead and comes with some caveats.


### PR DESCRIPTION
... as `session.jwt` has been replaced with `session.strategy: 'jwt'`