### PR TITLE
Fixes first login attempt on custom credentials signIn page

### DIFF
--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -105,7 +105,8 @@ There is another, more fully styled example signin page available [here](https:/
 If you create a custom sign in form for email sign in, you will need to submit both fields for the **email** address and **csrfToken** from **/api/auth/csrf** in a POST request to **/api/auth/signin/email**.
 
 ```jsx title="pages/auth/email-signin.js"
-import { getCsrfToken } from "next-auth/react"
+import { getServerCsrfToken } from "next-auth/next"
+import { authOptions } from "../api/auth/[...nextauth]"
 
 export default function SignIn({ csrfToken }) {
   return (
@@ -121,7 +122,7 @@ export default function SignIn({ csrfToken }) {
 }
 
 export async function getServerSideProps(context) {
-  const csrfToken = await getCsrfToken(context)
+  const csrfToken = await getServerCsrfToken(context, authOptions)
   return {
     props: { csrfToken },
   }
@@ -139,7 +140,8 @@ signIn("email", { email: "jsmith@example.com" })
 If you create a sign in form for credentials based authentication, you will need to pass a **csrfToken** from **/api/auth/csrf** in a POST request to **/api/auth/callback/credentials**.
 
 ```jsx title="pages/auth/credentials-signin.js"
-import { getCsrfToken } from "next-auth/react"
+import { getServerCsrfToken } from "next-auth/next"
+import { authOptions } from "../api/auth/[...nextauth]"
 
 export default function SignIn({ csrfToken }) {
   return (
@@ -161,7 +163,7 @@ export default function SignIn({ csrfToken }) {
 export async function getServerSideProps(context) {
   return {
     props: {
-      csrfToken: await getCsrfToken(context),
+      csrfToken: await getServerCsrfToken(context, authOptions),
     },
   }
 }

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -107,6 +107,33 @@ export async function getServerSession(
   return null
 }
 
+export async function getServerCsrfToken(
+  context:
+    | GetServerSidePropsContext
+    | { req: NextApiRequest; res: NextApiResponse },
+  options: NextAuthOptions
+): Promise<string | null> {
+  const session = await NextAuthHandler<{ csrfToken: string }>({
+    options: {
+      ...options,
+      secret: options.secret ?? process.env.NEXTAUTH_SECRET,
+    },
+    req: {
+      host: detectHost(context.req.headers["x-forwarded-host"]),
+      action: "csrf",
+      method: "GET",
+      cookies: context.req.cookies,
+      headers: context.req.headers,
+    },
+  })
+
+  const { body, cookies } = session
+
+  cookies?.forEach((cookie) => setCookie(context.res, cookie))
+
+  return body?.csrfToken ?? null
+}
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace NodeJS {


### PR DESCRIPTION
## ☕️ Reasoning

When we follow the current documentation to create a custom credentials signin page and do everything properly, we're not able to login form our custom page if we load it for the first time with no cookies. The reason for this is that `getCsrfToken` shown in the docs simply does not set the required cookies to validate CSRF when attempting to sign in.

Following [this disucssion](https://github.com/nextauthjs/next-auth/discussions/3588) I added a `getServerCsrfToken` method which makes things work. 

## To test manually

- checkout the main branch of my fork
- `cp apps/dev/.env.local.example apps/dev/.env.local` and populate `NEXTAUTH_SECRET` with [a secret](https://generate-secret.vercel.app/32)
- create a `apps/dev/pages/login.js` file with the follwoing content : 

```jsx
import { getServerCsrfToken } from "next-auth/next"
import { authOptions } from "./api/auth/[...nextauth]"

export default function SignIn({ csrfToken }) {
  return (
    <form method="post" action="/api/auth/callback/credentials">
      <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
      <label>
        Username
        <input name="username" type="text" />
      </label>
      <label>
        Password
        <input name="password" type="password" />
      </label>
      <button type="submit">Sign in</button>
    </form>
  )
}

export async function getServerSideProps(context) {
  return {
    props: {
      csrfToken: await getServerCsrfToken(context, authOptions),
    },
  }
}
```

- configure `apps/dev/pages/api/auth/[...nextauth].ts` and add this option to `authOptions` : 

```ts
  pages: {
    signIn: "/login",
  }
```

- yarn && yarn dev:app
- visit http://localhost:3000/login directly (don't navigate to that page using the signin button on the homepage)
- try to log in with username: "bill", password: "pw"
- See that it works

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [ ] Automated Tests
- [ ] Ready to be merged