### PR TITLE
Use relative URL for Signin page callbackUrl

### DIFF
--- a/apps/dev/components/header.js
+++ b/apps/dev/components/header.js
@@ -104,7 +104,7 @@ export default function Header() {
             </Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/middleware-protected?with-params">
+            <Link href="/middleware-protected">
               <a>Middleware protected</a>
             </Link>
           </li>

--- a/apps/dev/components/header.js
+++ b/apps/dev/components/header.js
@@ -108,6 +108,11 @@ export default function Header() {
               <a>Middleware protected</a>
             </Link>
           </li>
+          <li className={styles.navItem}>
+            <Link href="/middleware-protected?params=next">
+              <a>Middleware protected with params</a>
+            </Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/apps/dev/components/header.js
+++ b/apps/dev/components/header.js
@@ -104,13 +104,8 @@ export default function Header() {
             </Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/middleware-protected">
+            <Link href="/middleware-protected?with-params">
               <a>Middleware protected</a>
-            </Link>
-          </li>
-          <li className={styles.navItem}>
-            <Link href="/middleware-protected?params=next">
-              <a>Middleware protected with params</a>
             </Link>
           </li>
         </ul>

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -91,7 +91,7 @@ async function handleMiddleware(
 
   // the user is not logged in, redirect to the sign-in page
   const signInUrl = new URL(signInPage, req.nextUrl.origin)
-  signInUrl.searchParams.append("callbackUrl", req.nextUrl.pathname)
+  signInUrl.searchParams.append("callbackUrl", `${req.nextUrl.pathname}${req.nextUrl.search}`)
   return NextResponse.redirect(signInUrl)
 }
 

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -91,7 +91,7 @@ async function handleMiddleware(
 
   // the user is not logged in, redirect to the sign-in page
   const signInUrl = new URL(signInPage, req.nextUrl.origin)
-  signInUrl.searchParams.append("callbackUrl", req.url)
+  signInUrl.searchParams.append("callbackUrl", req.nextUrl.pathname)
   return NextResponse.redirect(signInUrl)
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

As of now, there's no way to determine actual address (protocol, host, port) which end-user access next app within middleware functions. Sign in page 's `callbackUrl` does not behave as expected when next app is behind ssl proxy or load balancer.  

As a simple fix, using relative URL for `callbackUrl` would restore the expected behavior.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/4483

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
