### PR TITLE
break free of NEXTAUTH_URL using http header

### DIFF
--- a/apps/dev/pages/protected-ssr.js
+++ b/apps/dev/pages/protected-ssr.js
@@ -30,7 +30,8 @@ export async function getServerSideProps(context) {
   let content = null
 
   if (session) {
-    const hostname = process.env.NEXTAUTH_URL || "http://localhost:3000"
+    if (!process.env.NEXTAUTH_URL) throw new Error('getServerSideProps does not have NEXTAUTH_URL')
+    const hostname = process.env.NEXTAUTH_URL
     const options = { headers: { cookie: context.req.headers.cookie } }
     const res = await fetch(`${hostname}/api/examples/protected`, options)
     const json = await res.json()

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -69,6 +69,10 @@ export async function NextAuthHandler<
 
   const { action, providerId, error, method = "GET" } = req
 
+  if (!req.host) {
+    throw new Error('req.host is undefined')
+  }
+
   const { options, cookies } = await init({
     userOptions,
     action,

--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -13,7 +13,7 @@ import { createCallbackUrl } from "./lib/callback-url"
 import { IncomingRequest } from "."
 
 interface InitParams {
-  host?: string
+  host: string
   userOptions: NextAuthOptions
   providerId?: string
   action: InternalOptions["action"]

--- a/packages/next-auth/src/jwt/index.ts
+++ b/packages/next-auth/src/jwt/index.ts
@@ -71,7 +71,7 @@ export async function getToken<R extends boolean = false>(
   const {
     req,
     secureCookie = process.env.NEXTAUTH_URL?.startsWith("https://") ??
-      !!process.env.VERCEL,
+      !!(process.env.NEXTAUTH_TRUST_X_FORWARDED_HOST || process.env.VERCEL),
     cookieName = secureCookie
       ? "__Secure-next-auth.session-token"
       : "next-auth.session-token",

--- a/packages/next-auth/src/lib/logger.ts
+++ b/packages/next-auth/src/lib/logger.ts
@@ -82,7 +82,7 @@ export default _logger
 /** Serializes client-side log messages and sends them to the server */
 export function proxyLogger(
   logger: LoggerInstance = _logger,
-  basePath?: string
+  basePath: string
 ): LoggerInstance {
   try {
     if (typeof window === "undefined") {

--- a/packages/next-auth/src/lib/parse-url.ts
+++ b/packages/next-auth/src/lib/parse-url.ts
@@ -12,23 +12,26 @@ export interface InternalUrl {
 }
 
 /** Returns an `URL` like object to make requests/redirects from server-side */
-export default function parseUrl(url?: string): InternalUrl {
-  const defaultUrl = new URL("http://localhost:3000/api/auth")
+export default function parseUrl(nextauthUrl?: string): InternalUrl {
+  const defaultPathname = "/api/auth"
 
-  if (url && !url.startsWith("http")) {
-    url = `https://${url}`
-  }
+  const httpUrl = nextauthUrl.startsWith("http") ? nextauthUrl : (
+    nextauthUrl.startsWith("localhost:")
+      // probably don't want https on localhost:
+      ? `http://${nextauthUrl}`
+      : `https://${nextauthUrl}`
+  )
 
-  const _url = new URL(url ?? defaultUrl)
-  const path = (_url.pathname === "/" ? defaultUrl.pathname : _url.pathname)
+  const urlObj = new URL(httpUrl)
+  const path = (urlObj.pathname === "/" ? defaultPathname : urlObj.pathname)
     // Remove trailing slash
     .replace(/\/$/, "")
 
-  const base = `${_url.origin}${path}`
+  const base = `${urlObj.origin}${path}`
 
   return {
-    origin: _url.origin,
-    host: _url.host,
+    origin: urlObj.origin,
+    host: urlObj.host,
     path,
     base,
     toString: () => base,

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -114,6 +114,7 @@ declare global {
       NEXTAUTH_URL?: string
       VERCEL?: "1"
       NEXTAUTH_TRUST_X_FORWARDED_HOST?: "1"
+      TRUST_HOST_HEADER?: "1"
     }
   }
 }

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -113,6 +113,7 @@ declare global {
     interface ProcessEnv {
       NEXTAUTH_URL?: string
       VERCEL?: "1"
+      NEXTAUTH_TRUST_X_FORWARDED_HOST?: "1"
     }
   }
 }

--- a/packages/next-auth/src/next/utils.ts
+++ b/packages/next-auth/src/next/utils.ts
@@ -17,7 +17,7 @@ export function setCookie(res, cookie: Cookie) {
 /** Extract the host from the environment */
 export function detectHost(forwardedHost: any) {
   // If we detect a Vercel environment, we can trust the host
-  if (process.env.VERCEL) return forwardedHost
+  if (process.env.NEXTAUTH_TRUST_X_FORWARDED_HOST || process.env.VERCEL) return forwardedHost
   // If `NEXTAUTH_URL` is `undefined` we fall back to "http://localhost:3000"
   return process.env.NEXTAUTH_URL
 }

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -193,25 +193,20 @@ export async function signIn<
   P extends RedirectableProviderType ? SignInResponse | undefined : undefined
 > {
   const { callbackUrl = window.location.href, redirect = true } = options ?? {}
-  throw new Error("this signIn method is not used by devinrhode2's company")
-  // @ts-expect-error - remove when `throw` is removed.
-  const baseUrl = apiBaseUrl(__NEXTAUTH)
+  const baseUrl = apiBaseUrl(__NEXTAUTH, window.location.host)
   const providers = await getProviders()
 
   if (!providers) {
     window.location.href = `${baseUrl}/error`
     return
   }
-  // @ts-expect-error - remove when `throw` is removed.
   if (!provider || !(provider in providers)) {
     window.location.href = `${baseUrl}/signin?${new URLSearchParams({
       callbackUrl,
     })}`
     return
   }
-  // @ts-expect-error - remove when `throw` is removed.
   const isCredentials = providers[provider].type === "credentials"
-  // @ts-expect-error - remove when `throw` is removed.
   const isEmail = providers[provider].type === "email"
   const isSupportingReturn = isCredentials || isEmail
 
@@ -269,9 +264,7 @@ export async function signOut<R extends boolean = true>(
   options?: SignOutParams<R>
 ): Promise<R extends true ? undefined : SignOutResponse> {
   const { callbackUrl = window.location.href } = options ?? {}
-  throw new Error('signout not yet supported')
-  // @ts-expect-error
-  const baseUrl = apiBaseUrl(__NEXTAUTH)
+  const baseUrl = apiBaseUrl(__NEXTAUTH, window.location.host)
   const fetchOptions = {
     method: "post",
     headers: {

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -48,6 +48,8 @@ export * from "./types"
 //    variable and defaults to 'http://localhost:3000'.
 let __basePath: undefined | string = undefined
 const __NEXTAUTH: NextAuthClientConfig = {
+  // TODO: create api get something like `getForwardedHost`
+  // TODO: if process.env.NEXTAUTH_URL is undefined
   baseOrigin: (nextauthUrl) => parseUrl(nextauthUrl).origin,
   basePath(nextauthUrl?: string): string {
     if (__basePath) {


### PR DESCRIPTION
We need to support multiple domain names pointing to the same next.js server (multi-tenancy). Other parts of our infrastructure will pass an `X-Forwarded-Host` header to this next.js server, which we need to use in place of the NEXTAUTH_URL.

This is just a hack to get working for our use case.
I noticed the `version:pr` npm script might actually publish this PR as a package, which is what I am trying to do by opening this PR. If it doesn't publish a package, then I will close and re-open later once this is ready for review

<sub>I tried using `patch-package` but was getting this `Can't find lockfile entry for next-auth` error :/</sub>

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

#600

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
