### PR TITLE
Fix font size for small devices

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -57,12 +57,6 @@ html[data-theme="dark"] svg[id^="mermaid-svg"] text[id*="-attr"] {
 @import "navbar.css";
 @import "search.css";
 
-@media screen and (max-width: 360px) {
-  html {
-    font-size: 0.8rem;
-  }
-}
-
 a {
   font-weight: 600;
 }


### PR DESCRIPTION
I have never seen any documentation using such a small font size before. It's readable, but still I think this media query is unnecessary.