### PR TITLE
feat(providers): return `user` object in Profile of Apple provider

### DIFF
--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -131,6 +131,17 @@ export default async function oAuthCallback(params: {
       })
     } else if (provider.idToken) {
       profile = tokens.claims()
+      if (!profile.user && body?.user && provider.id === 'apple' ) {
+        try {
+          profile.user = typeof body.user === 'string' ? JSON.parse(body.user) : body.user
+        } catch (error) {
+          profile.user = body.user
+          logger.debug("ERR_PARSING_BODY_USER_OBJECT_APPLE", {
+            error: error as Error,
+            providerId: provider.id,
+          })
+        } 
+      }
     } else {
       profile = await client.userinfo(tokens, {
         // @ts-expect-error


### PR DESCRIPTION
## ☕️ Reasoning

In Apple callback, there's `user` object but it's not able to retrieve it using Apple provider
<img width="1708" alt="image" src="https://user-images.githubusercontent.com/15612361/169028493-babaa519-926b-47fd-94bf-0163851ad64b.png">
However, this user object only serve for initial request, subsequent request will not get this [from Apple](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple#:~:text=While%20Apple%20provides,or%20network%20failure)

## 🧢 Checklist

- [ ] Documentation
- [X] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Not found issue related yet

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
