### PR TITLE
[docs] signIn() 'email' or 'credential' provider

### DIFF
--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -329,6 +329,19 @@ e.g.
 - `signIn('credentials', { redirect: false, password: 'password' })`
 - `signIn('email', { redirect: false, email: 'bill@fillmurray.com' })`
 
+### Using the `email` or `credentials` as redirectable provider type
+
+:::note
+The redirectable provider type is only available for `credentials` and `email` providers.
+:::
+
+If you are using credentials or email as provider, you have to pass an additional type param, so that results be correctly typed.
+
+e.g.
+
+- `signIn<'credentials'>('credentials', { password: 'password' })`
+- `signIn<'email'>('email', { email: 'bill@fillmurray.com' })`
+
 `signIn` will then return a Promise, that resolves to the following:
 
 ```ts


### PR DESCRIPTION
I'm submitting this addition for the docs, but I'm not sure if it is a lack of email and credentials provider docs, or if it is an error in the types.

But basically, if you pass this args types, the response will be correctly typed with 'SignInResponse | undefined', but if you don't pass, the types will be only 'undefined'.

So, I'm assuming that the purpose of who made the types, It's to pass this args, for the ternary condition at the result of the signIn promise, to get the 'SignInResponse | undefined' type.

If someone can check and give me an opinion about that, I will appreciate it.

e.g.
![image](https://user-images.githubusercontent.com/52859409/170261653-c3d4276e-6742-4f3d-8836-6c7dbffc367f.png)
![image](https://user-images.githubusercontent.com/52859409/170261719-464215ef-dfd0-4188-abdd-981eb7403672.png)

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
