### PR TITLE
fix: signIn infer provider type

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -175,7 +175,7 @@ export async function getProviders() {
 export async function signIn<
   P extends RedirectableProviderType | undefined = undefined
 >(
-  provider?: LiteralUnion<BuiltInProviderType>,
+  provider?: LiteralUnion<P | BuiltInProviderType>,
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ): Promise<


### PR DESCRIPTION
The "P" type it's not passed in any props, so the result type doesn't understand and returns the "false type" always, Adding the "P" at provider type props.

My local test implementation:

```d.ts
// next-auth.d.ts
import 'next-auth'
import {
  BuiltInProviderType,
  RedirectableProviderType
} from 'next-auth/providers'
import {
  LiteralUnion,
  SignInAuthorizationParams,
  SignInOptions,
  SignInResponse
} from 'next-auth/react'

declare module 'next-auth/react' {
  export * from 'next-auth/react'

  export declare function signIn<
    P extends RedirectableProviderType | undefined = undefined
  >(
    provider?: LiteralUnion<P | BuiltInProviderType>,
    options?: SignInOptions,
    authorizationParams?: SignInAuthorizationParams
  ): Promise<
    P extends RedirectableProviderType ? SignInResponse | undefined : undefined
  >
}
```

before:
![image](https://user-images.githubusercontent.com/52859409/170499622-a9dba4b6-1e6d-4351-a72f-c4dda891d5f1.png)

after:
![image](https://user-images.githubusercontent.com/52859409/170499676-f420f037-bdd7-4aa0-b506-18f4d9034a12.png)

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
