### PR TITLE
Update pages.md

### DIFF
--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -172,6 +172,7 @@ export async function getServerSideProps(context) {
 ```
 
 You can also use the `signIn()` function which will handle obtaining the CSRF token for you:
+(When I tried to follow the documentation to create a Credential Login Provider, it's not specified that the signIn() function uses the "id" that is defined in the NextAuth(). For the CredentialsProvider, I only defined a "name" property as suggested in the documentation and I spend hours figuring out why my custom login page is not working. The problem was I was missing the "id" property and I was using the name property instead. Because of that, the signIn function wasn't aware of which provider to use. Please specify here that when a Credential Provider is defined, in order to use the signIn function with the defined Credential Provider, the defined CredentialProvider must have an "id" property.)
 
 ```js
 signIn("credentials", { username: "jsmith", password: "1234" })


### PR DESCRIPTION
(When I tried to follow the documentation to create a Credential Login Provider, it's not specified that the signIn() function uses the "id" that is defined in the NextAuth(). For the CredentialsProvider, I only defined a "name" property as suggested in the documentation and I spend hours figuring out why my custom login page is not working. The problem was I was missing the "id" property and I was using the name property instead. Because of that, the signIn function wasn't aware of which provider to use. Please specify here that when a Credential Provider is defined, in order to use the signIn function with the defined Credential Provider, the defined CredentialProvider must have an "id" property.)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
