### PR TITLE
Remove trailing '/' from Authentik issuer example

### DIFF
--- a/docs/docs/providers/authentik.md
+++ b/docs/docs/providers/authentik.md
@@ -31,5 +31,5 @@ providers: [
 ```
 
 :::note
-`issuer` should include the slug – e.g. `https://my-authentik-domain.com/application/o/My_Slug/`
+`issuer` should include the slug without a trailing slash – e.g., `https://my-authentik-domain.com/application/o/My_Slug`
 :::


### PR DESCRIPTION
The Authentik provider already adds a `/` after the `issuer`, so this creates a double slash that causes a NextAuth `SIGNIN_OAUTH_ERROR` ("expected 200 OK, got: 301 Moved Permanently").

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

This updates the documentation for the Authentik provider to mention that you shouldn't add a trailing slash to the issuer, otherwise you get the following error:

```
[next-auth][error][SIGNIN_OAUTH_ERROR] 
https://next-auth.js.org/errors#signin_oauth_error expected 200 OK, got: 301 Moved Permanently {
  error: {
    message: 'expected 200 OK, got: 301 Moved Permanently',
    ...
```
## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: N/A

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
