### PR TITLE
allow user set canonical_urls on request with nextjs.

### DIFF
--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -193,7 +193,18 @@ export interface NextAuthOptions {
    *
    * [Documentation](https://next-auth.js.org/configuration/options#cookies) | [Usage example](https://next-auth.js.org/configuration/options#example)
    */
-  cookies?: Partial<CookiesOptions>
+  cookies?: Partial<CookiesOptions>,
+    /**
+   * You can customize the canonical url for callbacks.
+   * * **Required**: No
+   *
+   * [Documentation](https://next-auth.js.org/configuration/options#canonical_url)
+   *
+   * - ⚠ **This is an advanced option.** Advanced options are passed the same way as basic options,
+   * but **may have complex implications** or side effects.
+   * You should **try to avoid using advanced options** unless you are very comfortable using them.
+   */
+  canonical_url?: string,
 }
 
 /**

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -20,12 +20,14 @@ async function NextAuthNextHandler(
 ) {
   const { nextauth, ...query } = req.query
 
+  options.canonical_url = options.canonical_url ?? req.headers["x-forwarded-host"]
+
   options.secret =
     options.secret ?? options.jwt?.secret ?? process.env.NEXTAUTH_SECRET
 
   const handler = await NextAuthHandler({
     req: {
-      host: detectHost(req.headers["x-forwarded-host"]),
+      host: detectHost(options.canonical_url),
       body: req.body,
       query,
       cookies: req.cookies,


### PR DESCRIPTION
## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

I am using a single Vercel instance for multiple domains, which generate dynamic content based on the domain. This would include which callback/canonical url to use for next-auth.

This is just my assumption of what might work with nextjs.

I wanted to submit early to get some eyes on the approach!

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
