### PR TITLE
fix(providers): send `client_id` and `client_secret` in body for Instagram Provider

### DIFF
--- a/packages/next-auth/src/providers/instagram.js
+++ b/packages/next-auth/src/providers/instagram.js
@@ -35,6 +35,9 @@ export default function Instagram(options) {
     token: "https://api.instagram.com/oauth/access_token",
     userinfo:
       "https://graph.instagram.com/me?fields=id,username,account_type,name",
+    client: {
+      token_endpoint_auth_method: 'client_secret_post',
+    },
     async profile(profile) {
       return {
         id: profile.id,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Found that Instagram only accepts client_id and client_secret in the post body. 

Although  https://github.com/nextauthjs/next-auth/pull/3381 can fix it too.
But I think the client meta options are a more clean way to fix it.

refs: 
- https://developers.facebook.com/docs/instagram-basic-display-api/getting-started
- https://github.com/panva/node-openid-client/blob/main/docs/README.md#client-authentication-methods

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/3564

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
