### PR TITLE
fix:ReferenceError: defaultCookies is not defined

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -86,7 +86,7 @@ async function NextAuthHandler(req, res, userOptions) {
       return res.redirect(`${errorPage}?error=Configuration`)
     }
 
-    const { callbackUrl: defaultCallbackUrl } = defaultCookies(
+    const { callbackUrl: defaultCallbackUrl } = cookie.defaultCookies(
       userOptions.useSecureCookies ?? baseUrl.startsWith("https://")
     )
     const callbackUrlCookie =


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

[v3.29.4](https://github.com/nextauthjs/next-auth/commit/87f6f576b1f31249868991a2d1fecc4a9e4f5ce8) is making apps crash because it tries to call a function that has not been imported directly (`defaultCookies()`).
```
node_modules/next-auth/dist/server/index.js:102
    } = defaultCookies((_userOptions$useSecur = userOptions.useSecureCookies) !== null && _userOptions$useSecur !== void 0 ? _userOptions$useSecur : baseUrl.startsWith("https://"));
        ^

ReferenceError: defaultCookies is not defined
```

 Indeed, in `v3` it's a wildcard import:
> import * as cookie from "./lib/cookie"

So the function needs to be called like above in the file: `cookie.defaultCookies()`

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
