### PR TITLE
Add example for getting the session in getInitialProps

### DIFF
--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -419,7 +419,7 @@ Using the supplied `<SessionProvider>` allows instances of `useSession()` to sha
 ```jsx title="pages/_app.js"
 import { SessionProvider } from "next-auth/react"
 
-export default function MyApp({
+export default function App({
   Component,
   pageProps: { session, ...pageProps },
 }) {
@@ -452,10 +452,21 @@ export async function getServerSideProps(ctx) {
 If every one of your pages needs to be protected, you can do this in `getInitialProps` in `_app`, otherwise you can do it on a page-by-page basis. 
 
 ```jsx title="pages/_app.js"
-import type { AppContext, AppInitialProps } from "next/app";
+import type { AppContext, AppInitialProps, AppProps } from "next/app";
 import App from "next/app";
-import { getSession } from "next-auth/react";
+import { getSession, SessionProvider } from "next-auth/react";
 import { Session } from "next-auth";
+
+export default function MyApp({
+  Component,
+  pageProps: { session, ...pageProps },
+}: AppProps) {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  )
+}
 
 MyApp.getInitialProps = async (
   appContext: AppContext

--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -419,7 +419,7 @@ Using the supplied `<SessionProvider>` allows instances of `useSession()` to sha
 ```jsx title="pages/_app.js"
 import { SessionProvider } from "next-auth/react"
 
-export default function App({
+export default function MyApp({
   Component,
   pageProps: { session, ...pageProps },
 }) {
@@ -449,7 +449,24 @@ export async function getServerSideProps(ctx) {
 }
 ```
 
-If every one of your pages needs to be protected, you can do this in `getInitialProps` in `_app`, otherwise you can do it on a page-by-page basis. Alternatively, you can do per page authentication checks client side, instead of having each authentication check be blocking (SSR) by using the method described below in [alternative client session handling](#custom-client-session-handling).
+If every one of your pages needs to be protected, you can do this in `getInitialProps` in `_app`, otherwise you can do it on a page-by-page basis. 
+
+```jsx title="pages/_app.js"
+import type { AppContext, AppInitialProps } from "next/app";
+import App from "next/app";
+import { getSession } from "next-auth/react";
+import { Session } from "next-auth";
+
+MyApp.getInitialProps = async (
+  appContext: AppContext
+): Promise<AppInitialProps & { session: Session | null }> => {
+  const session = await getSession(appContext.ctx);
+  const appProps = await App.getInitialProps(appContext);
+  return { ...appProps, session: session };
+};
+```
+
+Alternatively, you can do per page authentication checks client side, instead of having each authentication check be blocking (SSR) by using the method described below in [alternative client session handling](#custom-client-session-handling).
 
 ### Options
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Adding an example to the docs for how to get the session in getInitialProps as this took me a while to figure it out and thought it would be useful for other users. 

As the docs already says, this is useful if you want to protect every page in your site, so it seems like it would be a common usage scenario. 

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: [Example with getSession() in _app.js?](https://github.com/nextauthjs/next-auth/issues/345)

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
