### PR TITLE
typo in slack.md

### DIFF
--- a/docs/docs/providers/slack.md
+++ b/docs/docs/providers/slack.md
@@ -13,7 +13,7 @@ https://api.slack.com/docs/sign-in-with-slack
 https://api.slack.com/apps
 
 :::warning
-Slack requires you that the redirect URL of your app uses `https`, even for local development. An easy workaround for this is using a service like [`ngrok`](https://ngrok.com) that creates a secure tunnel to your app, using `https`. Remember to set the url as `NEXTAUTH_URL` as well.
+Slack requires that the redirect URL of your app uses `https`, even for local development. An easy workaround for this is using a service like [`ngrok`](https://ngrok.com) that creates a secure tunnel to your app, using `https`. Remember to set the url as `NEXTAUTH_URL` as well.
 :::
 
 ![](https://i.imgur.com/ydYKTLD.png)


### PR DESCRIPTION
typo in slack.md, thanks for the warning though!

## ☕️ Reasoning
Just a small typo

## 🧢 Checklist
- [x] Documentation

