### PR TITLE
docs: fix references to deprecated adapters repo

### DIFF
--- a/apps/example-gatsby/README.md
+++ b/apps/example-gatsby/README.md
@@ -65,7 +65,6 @@ You **can** skip configuring a database and come back to it later if you want.
 For more information about setting up a database, please check out the following links:
 
 * Docs: [next-auth.js.org/adapters/overview](https://next-auth.js.org/adapters/overview)
-* Adapters Repo: [nextauthjs/adapters](https://github.com/nextauthjs/adapters)
 
 ### 3. Configure Authentication Providers
 

--- a/apps/example-nextjs/README.md
+++ b/apps/example-nextjs/README.md
@@ -68,7 +68,6 @@ You **can** skip configuring a database and come back to it later if you want.
 For more information about setting up a database, please check out the following links:
 
 * Docs: [next-auth.js.org/adapters/overview](https://next-auth.js.org/adapters/overview)
-* Adapters Repo: [nextauthjs/adapters](https://github.com/nextauthjs/adapters)
 
 ### 3. Configure Authentication Providers
 

--- a/packages/adapter-dgraph/README.md
+++ b/packages/adapter-dgraph/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <!-- <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="CI Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/prisma-adapter" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/prisma-adapter" alt="@next-auth/prisma-adapter Version" />
    </p> -->
@@ -150,7 +150,7 @@ type User
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-dgraph/package.json
+++ b/packages/adapter-dgraph/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.3",
   "description": "Dgraph adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
-    "url": "https://github.com/nextauthjs/adapters/issues"
+    "url": "https://github.com/nextauthjs/next-auth/issues"
   },
   "author": "Arnaud Derbey <arnaud@derbey.dev>",
   "contributors": [],

--- a/packages/adapter-dynamodb/README.md
+++ b/packages/adapter-dynamodb/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="Build Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="Build Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/dynamodb-adapter/latest" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/dynamodb-adapter" alt="@next-auth/dynamodb-adapter Version" />
    </p>
@@ -96,7 +96,7 @@ Here is a schema of the table :
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-dynamodb/package.json
+++ b/packages/adapter-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-auth/dynamodb-adapter",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "version": "1.0.3",
   "description": "AWS DynamoDB adapter for next-auth.",
   "keywords": [

--- a/packages/adapter-fauna/README.md
+++ b/packages/adapter-fauna/README.md
@@ -7,7 +7,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="Build Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="Build Test" />
       <a href="https://www.npmjs.com/package/@next-auth/faunadb-adapter" target="_blank"><img src="https://img.shields.io/bundlephobia/minzip/@next-auth/fauna-adapter/next" alt="Bundle Size"/></a>
       <a href="https://www.npmjs.com/package/@next-auth/faunadb-adapter" target="_blank"><img src="https://img.shields.io/npm/v/@next-auth/fauna-adapter/next" alt="@next-auth/fauna-adapter Version" /></a>
    </p>
@@ -53,7 +53,7 @@ export default NextAuth({
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-fauna/package.json
+++ b/packages/adapter-fauna/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "Fauna Adapter for NextAuth",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },

--- a/packages/adapter-firebase/README.md
+++ b/packages/adapter-firebase/README.md
@@ -7,7 +7,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="Build Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="Build Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/firebase-adapter/latest" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/firebase-adapter" alt="@next-auth/firebase-adapter Version" />
    </p>
@@ -83,7 +83,7 @@ See [firebase.google.com/docs/web/setup](https://firebase.google.com/docs/web/se
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-firebase/package.json
+++ b/packages/adapter-firebase/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.3",
   "description": "Firebase adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
-    "url": "https://github.com/nextauthjs/adapters/issues"
+    "url": "https://github.com/nextauthjs/next-auth/issues"
   },
   "author": "Ron Houben <ron.houben85@gmail.com>",
   "contributors": [

--- a/packages/adapter-mikro-orm/README.md
+++ b/packages/adapter-mikro-orm/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="CI Test" />
       <a href="https://www.npmjs.com/package/@next-auth/mikro-orm-adapter" target="_blank"><img src="https://img.shields.io/bundlephobia/minzip/@next-auth/mikro-orm-adapter/next" alt="Bundle Size"/></a>
       <a href="https://www.npmjs.com/package/@next-auth/mikro-orm-adapter" target="_blank"><img src="https://img.shields.io/npm/v/@next-auth/mikro-orm-adapter/next" alt="@next-auth/mikro-orm-adapter Version" /></a>
    </p>
@@ -49,7 +49,7 @@ This is the MikroORM Adapter for [`next-auth`](https://next-auth.js.org). This p
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-mikro-orm/package.json
+++ b/packages/adapter-mikro-orm/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "MikroORM adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },

--- a/packages/adapter-mongodb/README.md
+++ b/packages/adapter-mongodb/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="CI Test" />
       <a href="https://www.npmjs.com/package/@next-auth/mongodb-adapter" target="_blank"><img src="https://img.shields.io/bundlephobia/minzip/@next-auth/mongodb-adapter" alt="Bundle Size"/></a>
       <a href="https://www.npmjs.com/package/@next-auth/mongodb-adapter" target="_blank"><img src="https://img.shields.io/npm/v/@next-auth/mongodb-adapter" alt="@next-auth/mongodb-adapter Version" /></a>
    </p>
@@ -79,7 +79,7 @@ export default NextAuth({
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "mongoDB adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },

--- a/packages/adapter-neo4j/README.md
+++ b/packages/adapter-neo4j/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="Canary CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="Canary CI Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/neo4j-adapter" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/neo4j-adapter" alt="@next-auth/neo4j-adapter Version" />
    </p>
@@ -50,7 +50,7 @@ export default NextAuth({
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please first read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/canary/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please first read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/canary/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-neo4j/package.json
+++ b/packages/adapter-neo4j/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "neo4j adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },

--- a/packages/adapter-pouchdb/README.md
+++ b/packages/adapter-pouchdb/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="CI Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/pouchdb-adapter" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/pouchdb-adapter" alt="@next-auth/pouchdb-adapter Version" />
    </p>
@@ -71,7 +71,7 @@ For more details, please see https://pouchdb.com/api.html#sync
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-pouchdb/package.json
+++ b/packages/adapter-pouchdb/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.3",
   "description": "PouchDB adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="CI Test" />
       <a href="https://www.npmjs.com/package/@next-auth/prisma-adapter" target="_blank"><img src="https://img.shields.io/bundlephobia/minzip/@next-auth/prisma-adapter/next" alt="Bundle Size"/></a>
       <a href="https://www.npmjs.com/package/@next-auth/prisma-adapter" target="_blank"><img src="https://img.shields.io/npm/v/@next-auth/prisma-adapter/next" alt="@next-auth/prisma-adapter Version" /></a>
    </p>
@@ -48,7 +48,7 @@ export default NextAuth({
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "Prisma adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },

--- a/packages/adapter-sequelize/README.md
+++ b/packages/adapter-sequelize/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="CI Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/sequelize-adapter" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/sequelize-adapter" alt="@next-auth/sequelize-adapter Version" />
    </p>
@@ -89,7 +89,7 @@ export default NextAuth({
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-sequelize/package.json
+++ b/packages/adapter-sequelize/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.4",
   "description": "Sequelize adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
-    "url": "https://github.com/nextauthjs/adapters/issues"
+    "url": "https://github.com/nextauthjs/next-auth/issues"
   },
   "author": "github.com/luke-j",
   "main": "dist/index.js",

--- a/packages/adapter-typeorm-legacy/README.md
+++ b/packages/adapter-typeorm-legacy/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="Canary CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="Canary CI Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/typeorm-legacy-adapter/canary" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/typeorm-legacy-adapter" alt="@next-auth/typeorm-legacy-adapter Version" />
    </p>

--- a/packages/adapter-typeorm-legacy/package.json
+++ b/packages/adapter-typeorm-legacy/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.3",
   "description": "TypeORM (legacy) adapter for next-auth.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
-    "url": "https://github.com/nextauthjs/adapters/issues"
+    "url": "https://github.com/nextauthjs/next-auth/issues"
   },
   "author": "Iain Collins",
   "contributors": [

--- a/packages/adapter-upstash-redis/README.md
+++ b/packages/adapter-upstash-redis/README.md
@@ -6,7 +6,7 @@
    Open Source. Full Stack. Own Your Data.
    </p>
    <p align="center" style="align: center;">
-      <img src="https://github.com/nextauthjs/adapters/actions/workflows/release.yml/badge.svg" alt="CI Test" />
+      <img src="https://github.com/nextauthjs/next-auth/actions/workflows/release.yml/badge.svg?branch=main" alt="CI Test" />
       <img src="https://img.shields.io/bundlephobia/minzip/@next-auth/upstash-adapter" alt="Bundle Size"/>
       <img src="https://img.shields.io/npm/v/@next-auth/upstash-adapter" alt="@next-auth/upstash-adapter Version" />
    </p>
@@ -80,7 +80,7 @@ export default NextAuth({
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/adapter-upstash-redis/package.json
+++ b/packages/adapter-upstash-redis/package.json
@@ -3,9 +3,9 @@
   "version": "3.0.0",
   "description": "Upstash adapter for next-auth. It uses Upstash's connectionless (HTTP based) Redis client.",
   "homepage": "https://next-auth.js.org",
-  "repository": "https://github.com/nextauthjs/adapters",
+  "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
-    "url": "https://github.com/nextauthjs/adapters/issues"
+    "url": "https://github.com/nextauthjs/next-auth/issues"
   },
   "author": "github.com/kay-is",
   "main": "dist/index.js",

--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -52,7 +52,7 @@ export interface VerificationToken {
  * - `deleteUser`
  * - `unlinkAccount`
  *
- * [Community adapters](https://github.com/nextauthjs/adapters) |
+ * [Adapters Overview](https://next-auth.js.org/adapters/overview) |
  * [Create a custom adapter](https://next-auth.js.org/tutorials/creating-a-database-adapter)
  */
 export interface Adapter {

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -117,7 +117,7 @@ export interface NextAuthOptions {
    * * **Required**: *No*
    *
    * [Documentation](https://next-auth.js.org/configuration/options#adapter) |
-   * [Community adapters](https://github.com/nextauthjs/adapters)
+   * [Adapters Overview](https://next-auth.js.org/adapters/overview)
    */
   adapter?: Adapter
   /**


### PR DESCRIPTION
## ☕️ Reasoning

The [adapters monorepo](https://github.com/nextauthjs/adapters) recently had it's packages moved to this monorepo and was deprecated, but there's still a lot of references to it. The checked items are places that this PR removes or replaces the reference:

- [X] adapter package.json `repository` and `bugs.url` fields
- [X] adapter README CI status badges (these still show failing btw, but they're now pointing to the status of the `release.yml` workflow for the `main` branch of this repo)
- [X] adapter README "Contributing" sections
- [X] example apps READMEs
- [X] TypeScript comments
- [ ] adapter CHANGELOGs
- [ ] v3 docs
- [ ] `packages/adapter-typeorm-legacy/README.md` links to schemas for mysql, postgresql, mssql

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues

None

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
