### PR TITLE
Implement updateSession & isUpdate parameter

### DIFF
--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -196,6 +196,28 @@ The tutorial [securing pages and API routes](/tutorials/securing-pages-and-api-r
 
 ---
 
+## updateSession()
+
+- Client Side: **Yes**
+- Server Side: No
+
+The `updateSession()` method can be used client-side to update the SessionProvider's state. This is especially useful, when the token or session has to be updated without a full page reload.
+
+#### Example
+
+```js
+import { updateSession } from "next-auth/react"
+
+const updateUser = async () => {
+  // Update the user, e.g. via a POST request
+
+  // Then update the SessionProvider's state
+  await updateSession()
+}
+```
+
+---
+
 ## getCsrfToken()
 
 - Client Side: **Yes**

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -130,7 +130,14 @@ export async function NextAuthHandler<
       case "providers":
         return (await routes.providers(options.providers)) as any
       case "session": {
-        const session = await routes.session({ options, sessionStore })
+        const isUpdate =
+          req.query !== undefined && req.query.hasOwnProperty("update")
+
+        const session = await routes.session({
+          options,
+          sessionStore,
+          isUpdate,
+        })
         if (session.cookies) cookies.push(...session.cookies)
         return { ...session, cookies } as any
       }

--- a/packages/next-auth/src/core/routes/session.ts
+++ b/packages/next-auth/src/core/routes/session.ts
@@ -9,6 +9,7 @@ import type { SessionStore } from "../lib/cookie"
 interface SessionParams {
   options: InternalOptions
   sessionStore: SessionStore
+  isUpdate: boolean
 }
 
 /**
@@ -19,7 +20,7 @@ interface SessionParams {
 export default async function session(
   params: SessionParams
 ): Promise<OutgoingResponse<Session | {}>> {
-  const { options, sessionStore } = params
+  const { options, sessionStore, isUpdate } = params
   const {
     adapter,
     jwt,
@@ -60,9 +61,13 @@ export default async function session(
       }
 
       // @ts-expect-error
-      const token = await callbacks.jwt({ token: decodedToken })
+      const token = await callbacks.jwt({ token: decodedToken, isUpdate })
       // @ts-expect-error
-      const newSession = await callbacks.session({ session, token })
+      const newSession = await callbacks.session({
+        session,
+        token,
+        isUpdate,
+      })
 
       // Return session payload as response
       response.body = newSession

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -325,6 +325,7 @@ export interface CallbacksOptions<
     session: Session
     user: User
     token: JWT
+    isUpdate: boolean
   }) => Awaitable<Session>
   /**
    * This callback is called whenever a JSON Web Token is created (i.e. at sign in)
@@ -344,6 +345,7 @@ export interface CallbacksOptions<
     account?: A
     profile?: P
     isNewUser?: boolean
+    isUpdate: boolean
   }) => Awaitable<JWT>
 }
 

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -116,14 +116,14 @@ export function useSession<R extends boolean>(options?: UseSessionOptions<R>) {
 }
 
 export type GetSessionParams = CtxOrReq & {
-  event?: "storage" | "timer" | "hidden" | string
+  event?: "storage" | "timer" | "hidden" | "update" | string
   triggerEvent?: boolean
   broadcast?: boolean
 }
 
 export async function getSession(params?: GetSessionParams) {
   const session = await fetchData<Session>(
-    "session",
+    params?.event === "update" ? "session?update" : "session",
     __NEXTAUTH,
     logger,
     params
@@ -354,7 +354,7 @@ export function SessionProvider(props: SessionProviderProps) {
 
         // An event or session staleness occurred, update the client session.
         __NEXTAUTH._lastSync = now()
-        __NEXTAUTH._session = await getSession()
+        __NEXTAUTH._session = await getSession({ event })
         setSession(__NEXTAUTH._session)
       } catch (error) {
         logger.error("CLIENT_SESSION_ERROR", error as Error)

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -134,6 +134,10 @@ export async function getSession(params?: GetSessionParams) {
   return session
 }
 
+export async function updateSession() {
+  __NEXTAUTH._getSession({ event: "update" })
+}
+
 /**
  * Returns the current Cross Site Request Forgery Token (CSRF Token)
  * required to make POST requests (e.g. for signing in and signing out).


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

Implements `updateSession` to be able to update the `SessionProvider`'s state without having to reload the page. The update event is propagated to the `jwt` and `session` callbacks via an `isUpdate` parameter. This helps to avoid having to check if the token and session is up to date on every request.

As there are currently no tests implemented for callbacks, I skipped that step.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #596 
Fixes: #3941
Fixes: #2208
Might fix: #2129

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
