### PR TITLE
[edge] support request.cookies as a map

### DIFF
--- a/packages/next-auth/src/core/lib/cookie.ts
+++ b/packages/next-auth/src/core/lib/cookie.ts
@@ -120,7 +120,7 @@ export class SessionStore {
   constructor(
     option: CookieOption,
     req: {
-      cookies?: Record<string, string>
+      cookies?: Record<string, string> | { get: (key: string) => string }
       headers?: Headers | IncomingHttpHeaders | Record<string, string>
     },
     logger: LoggerInstance | Console
@@ -132,7 +132,10 @@ export class SessionStore {
 
     for (const name in req.cookies) {
       if (name.startsWith(option.name)) {
-        this.#chunks[name] = req.cookies[name]
+        this.#chunks[name] =
+          typeof req.cookies.get === "function"
+            ? req.cookies.get(name)
+            : req.cookies[name]
       }
     }
   }


### PR DESCRIPTION
## ☕️ Reasoning

in next Next.js versions, NextRequest.cookies will be an instance of NextCookies which is
some kind of a Map, instead of a plain object.

This commit checks whether there's a `get` function in req.cookies, and acts accordingly,
to make sure we will support newer Next.js versions with Edge Functions/Middleware

I don't see any tests here for that. I can introduce some, but not sure if it makes sense. Please let me know what to do with this!

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
