### PR TITLE
Add logic to pass newUserInfo when creating a new user

### DIFF
--- a/docs/docs/configuration/callbacks.md
+++ b/docs/docs/configuration/callbacks.md
@@ -62,6 +62,8 @@ callbacks: {
 
   You can check for the `verificationRequest` property to avoid sending emails to addresses or domains on a blocklist (or to only explicitly generate them for email address in an allow list).
 
+- If you pass additional info for new users to the `newUserInfo` option of the client `signIn()` method, that information can be found in `user.newUserInfo`. This can help you determine if the new user can be created based on the additional information you provide.
+
 * When using the **Credentials Provider** the `user` object is the response returned from the `authorize` callback and the `profile` object is the raw body of the `HTTP POST` submission.
 
 :::note

--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -126,10 +126,10 @@ function Auth({ children }) {
   // if `{ required: true }` is supplied, `status` can only be "loading" or "authenticated"
   const { status } = useSession({ required: true })
 
-  if (status === 'loading') {
+  if (status === "loading") {
     return <div>Loading...</div>
   }
-  
+
   return children
 }
 ```
@@ -355,6 +355,25 @@ e.g.
   url: string | null
 }
 ```
+
+### Using the `newUserInfo` option
+
+You can pass additional data to save when creating a new user by passing a `newUserInfo` option to the second argument of `signIn()`.
+
+`newUserInfo` can take a string or an object
+
+e.g.
+
+- `signIn("email", {email, newUserInfo: {displayName: 'Bill Johnson'}})`
+- `signIn("google", {email, newUserInfo: 'Bill Johnson'})`
+
+:::note
+ Your database adapter has to be configured to accept the new `newUserInfo` parameter when creating a user or an error will be triggered.
+:::
+
+:::note
+`newUserInfo` will be ignored when the user already exists
+:::
 
 ### Additional parameters
 

--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -3,6 +3,7 @@ import { Account, User, Awaitable } from "."
 export interface AdapterUser extends User {
   id: string
   emailVerified: Date | null
+  newUserInfo?: Record<string, any> | string | null
 }
 
 export interface AdapterSession {

--- a/packages/next-auth/src/core/lib/cookie.ts
+++ b/packages/next-auth/src/core/lib/cookie.ts
@@ -103,6 +103,15 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
         secure: useSecureCookies,
       },
     },
+    newUserInfo: {
+      name: `${cookiePrefix}next-auth.new-user-info`,
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: useSecureCookies,
+      },
+    },
   }
 }
 

--- a/packages/next-auth/src/core/lib/email/signin.ts
+++ b/packages/next-auth/src/core/lib/email/signin.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto"
 import { hashToken } from "../utils"
-import type { InternalOptions } from "../../types"
+import type { EncodedNewUserInfo, InternalOptions } from "../../types"
 
 /**
  * Starts an e-mail login flow, by generating a token,
@@ -8,7 +8,8 @@ import type { InternalOptions } from "../../types"
  */
 export default async function email(
   identifier: string,
-  options: InternalOptions<"email">
+  options: InternalOptions<"email">,
+  newUserInfo: EncodedNewUserInfo
 ) {
   const { url, adapter, provider, logger, callbackUrl } = options
 
@@ -31,7 +32,13 @@ export default async function email(
   })
 
   // Generate a link with email, unhashed token and callback url
-  const params = new URLSearchParams({ callbackUrl, token, email: identifier })
+  const params = new URLSearchParams({
+    callbackUrl,
+    token,
+    email: identifier,
+    // Adding newUserInfo if present
+    ...(newUserInfo && { newUserInfo }),
+  })
   const _url = `${url}/callback/${provider.id}?${params}`
 
   try {

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -360,6 +360,7 @@ export interface CookiesOptions {
   csrfToken: CookieOption
   pkceCodeVerifier: CookieOption
   state: CookieOption
+  newUserInfo: CookieOption
 }
 
 /**
@@ -463,6 +464,8 @@ export interface SessionOptions {
    */
   updateAge: number
 }
+
+export type EncodedNewUserInfo = string
 
 export interface DefaultUser {
   id: string

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -165,6 +165,17 @@ export async function getProviders() {
   >("providers", __NEXTAUTH, logger)
 }
 
+/*
+ * Encodes json to base64, returns string
+ */
+function encodeUserInfoValue(value: Record<string, any> | string) {
+  if (!value) {
+    return null
+  }
+
+  return Buffer.from(JSON.stringify(value), "ascii").toString("base64")
+}
+
 /**
  * Client-side method to initiate a signin flow
  * or send the user to the signin page listing all possible providers.
@@ -185,6 +196,10 @@ export async function signIn<
 
   const baseUrl = apiBaseUrl(__NEXTAUTH)
   const providers = await getProviders()
+
+  if (options?.newUserInfo) {
+    options.newUserInfo = encodeUserInfoValue(options.newUserInfo)
+  }
 
   if (!providers) {
     window.location.href = `${baseUrl}/error`

--- a/packages/next-auth/src/react/types.ts
+++ b/packages/next-auth/src/react/types.ts
@@ -31,6 +31,7 @@ export interface SignInOptions extends Record<string, unknown> {
   callbackUrl?: string
   /** @docs https://next-auth.js.org/getting-started/client#using-the-redirect-false-option */
   redirect?: boolean
+  newUserInfo?: Record<string, any> | string | null
 }
 
 export interface SignInResponse {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

Added logic that allows the passing of additional info when creating a new user. I wanted the ability to give prospective users a verification code that they could use to allow them to create accounts because I don't want anyone to be able to create an account at the moment. I can then check this verification code in the signup callback before the user is created. That being said, I believe there are more use cases for this such as, allowing the user to save things like their display name when creating an account. I think it's pretty common to ask for a little bit more info when signing up other than just wanting a user's email or Gmail/apple/etc account.

Note: This is my very first pull request so if there is anything I'm missing, please lmk.

## 🧢 Checklist

- [x] Documentation
- [x] Tests (passed pnpm test)
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: https://github.com/nextauthjs/next-auth/issues/1069

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
