### PR TITLE
Sanitize untrusted inputs in email body

### DIFF
--- a/packages/next-auth/src/providers/email.ts
+++ b/packages/next-auth/src/providers/email.ts
@@ -85,14 +85,23 @@ export default function Email(options: EmailUserConfig): EmailConfig {
   }
 }
 
+function escapeHTML (unsafe:string) {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 // Email HTML body
 function html({ url, host, email }: Record<"url" | "host" | "email", string>) {
   // Insert invisible space into domains and email address to prevent both the
   // email address and the domain from being turned into a hyperlink by email
   // clients like Outlook and Apple mail, as this is confusing because it seems
   // like they are supposed to click on their email address to sign in.
-  const escapedEmail = `${email.replace(/\./g, "&#8203;.")}`
-  const escapedHost = `${host.replace(/\./g, "&#8203;.")}`
+  const escapedEmail = `${escapeHTML(email).replace(/\./g, "&#8203;.")}`
+  const escapedHost = `${escapeHTML(host).replace(/\./g, "&#8203;.")}`
 
   // Some simple styling options
   const backgroundColor = "#f9f9f9"
@@ -121,7 +130,7 @@ function html({ url, host, email }: Record<"url" | "host" | "email", string>) {
       <td align="center" style="padding: 20px 0;">
         <table border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td align="center" style="border-radius: 5px;" bgcolor="${buttonBackgroundColor}"><a href="${url}" target="_blank" style="font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${buttonTextColor}; text-decoration: none; border-radius: 5px; padding: 10px 20px; border: 1px solid ${buttonBorderColor}; display: inline-block; font-weight: bold;">Sign in</a></td>
+            <td align="center" style="border-radius: 5px;" bgcolor="${buttonBackgroundColor}"><a href="${encodeURI(url)}" target="_blank" style="font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${buttonTextColor}; text-decoration: none; border-radius: 5px; padding: 10px 20px; border: 1px solid ${buttonBorderColor}; display: inline-block; font-weight: bold;">Sign in</a></td>
           </tr>
         </table>
       </td>


### PR DESCRIPTION
## ☕️ Reasoning

`EmailProvider` does not sanitize addresses or user names when formatting the body of the HTML email message.  An attacker could generate a forged session token and use this data to trick a next-auth server into sending fraudulent emails to arbitrary addresses.  This behavior could steal tokens or be used as part of a phishing attack.

To prevent this, all user controlled inputs to the HTML template should be sanitized.

## 🧢 Checklist

- [X] Documentation
- [X] Tests
- [X] Ready to be merged

## 🎫 Affected issues

N/A

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
