### PR TITLE
Middleware unauthorized callback option

### DIFF
--- a/apps/dev/middleware.ts
+++ b/apps/dev/middleware.ts
@@ -4,6 +4,35 @@ export const config = { matcher: ["/middleware-protected"] }
 
 // Other ways to use this middleware
 
+
+
+// import { NextResponse } from 'next/server';
+// import { withAuth } from "next-auth/middleware"
+// import { JWT } from 'next-auth/jwt';
+
+
+// //Just done here fore quick example of middleware changes. In practice would recommend extending JWT type in types/next-auth.d.ts
+// interface TokenMiddle extends Partial<JWT>{ 
+//   home: URL | null
+// }
+
+// export default withAuth(
+//   function middleware(req, ev) { //function here can run custom logic and return next response.
+//     console.log(req, ev)
+//     return undefined // NOTE: `NextMiddleware` should allow returning `void`
+//   },
+//   {
+//     pages: {
+//       signIn: "/unauthorized"
+//     },
+//     callbacks: {
+//       authorized: ({ token }) => !!token && false, //User isAuthorized should different then logged in.
+//       unAuthorized: ({ req, token }) => NextResponse.redirect(new URL((token as TokenMiddle).home ?? "/unauthorized", req.nextUrl.origin)), 
+//     }
+//   }
+// )
+
+
 // import withAuth from "next-auth/middleware"
 // import { withAuth } from "next-auth/middleware"
 


### PR DESCRIPTION
# Discussions
#4791 

## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?
Added callback option for middleware isAuthorized returning false. 

###Previous behavior was to always go to get stuck in signIn redirect loop. 
 Changing Pages.signIn option in middleware is inadequate because a user can be logged in but not authorized to a page. Changing the sign in page would cause user's not signed in to end up on the same page. 
 
Current workaround is to Create a middleware function and pass as first arg of withAuth. This issue with this is that you would have to validate only user login with isAuthorized and handle actual permissions check in the function being fired "onSuccess".
This is not intuitive and more complex then needed for most use cases. Callbacks stream line the handling of different authentication scenarios.
 
Default Behavior remains the same with noUser actions converted to configurable callback with default behavior working as current release. 

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues


Fixes: #4787 #4234


## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
