### PR TITLE
[FEAT] DisplayName for React Context Devtools

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -78,6 +78,9 @@ const SessionContext = React.createContext<SessionContextValue | undefined>(
   undefined
 )
 
+// DisplayName for React Context Devtools
+SessionContext.displayName = "SessionContext";
+
 /**
  * React Hook that gives you access
  * to the logged in user's session data.


### PR DESCRIPTION
```javascript
SessionContext.displayName = "SessionContext";
```

Before

![Before displayName in Devtools](https://i.ibb.co/rZ1DzgP/Dise-o-sin-t-tulo-4.png)

After 

 "SessionContext"
