### PR TITLE
fix: show experimental api warning only in dev and only once

### DIFF
--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -82,8 +82,8 @@ function NextAuth(
 }
 
 export default NextAuth
-let shown = false
 
+let experimentalWarningShown = false
 export async function unstable_getServerSession(
   ...args:
     | [

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -93,14 +93,14 @@ export async function unstable_getServerSession(
       ]
     | [NextApiRequest, NextApiResponse, NextAuthOptions]
 ): Promise<Session | null> {
-  if (!shown && process.env.NODE_ENV !== "production") {
+  if (!experimentalWarningShown && process.env.NODE_ENV !== "production") {
     console.warn(
       "[next-auth][warn][EXPERIMENTAL_API]",
       "\n`unstable_getServerSession` is experimental and may be removed or changed in the future, as the name suggested.",
       `\nhttps://next-auth.js.org/configuration/nextjs#unstable_getServerSession}`,
       `\nhttps://next-auth.js.org/warnings#EXPERIMENTAL_API`
     )
-    shown = true
+    experimentalWarningShown = true
   }
 
   const [req, res, options] = args

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -82,6 +82,7 @@ function NextAuth(
 }
 
 export default NextAuth
+let shown = false
 
 export async function unstable_getServerSession(
   ...args:
@@ -92,8 +93,6 @@ export async function unstable_getServerSession(
       ]
     | [NextApiRequest, NextApiResponse, NextAuthOptions]
 ): Promise<Session | null> {
-  let shown = false
-
   if (!shown || process.env.NODE_ENV !== "production") {
     console.warn(
       "[next-auth][warn][EXPERIMENTAL_API]",

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -93,7 +93,7 @@ export async function unstable_getServerSession(
       ]
     | [NextApiRequest, NextApiResponse, NextAuthOptions]
 ): Promise<Session | null> {
-  if (!shown || process.env.NODE_ENV !== "production") {
+  if (!shown && process.env.NODE_ENV !== "production") {
     console.warn(
       "[next-auth][warn][EXPERIMENTAL_API]",
       "\n`unstable_getServerSession` is experimental and may be removed or changed in the future, as the name suggested.",

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -85,18 +85,27 @@ export default NextAuth
 
 export async function unstable_getServerSession(
   ...args:
-    | [GetServerSidePropsContext['req'], GetServerSidePropsContext['res'], NextAuthOptions]
+    | [
+        GetServerSidePropsContext["req"],
+        GetServerSidePropsContext["res"],
+        NextAuthOptions
+      ]
     | [NextApiRequest, NextApiResponse, NextAuthOptions]
 ): Promise<Session | null> {
-  console.warn(
-    "[next-auth][warn][EXPERIMENTAL_API]",
-    "\n`unstable_getServerSession` is experimental and may be removed or changed in the future, as the name suggested.",
-    `\nhttps://next-auth.js.org/configuration/nextjs#unstable_getServerSession}`,
-    `\nhttps://next-auth.js.org/warnings#EXPERIMENTAL_API`
-    )
+  let shown = false
 
-  const [req, res, options] = args;
-  
+  if (!shown || process.env.NODE_ENV !== "production") {
+    console.warn(
+      "[next-auth][warn][EXPERIMENTAL_API]",
+      "\n`unstable_getServerSession` is experimental and may be removed or changed in the future, as the name suggested.",
+      `\nhttps://next-auth.js.org/configuration/nextjs#unstable_getServerSession}`,
+      `\nhttps://next-auth.js.org/warnings#EXPERIMENTAL_API`
+    )
+    shown = true
+  }
+
+  const [req, res, options] = args
+
   options.secret = options.secret ?? process.env.NEXTAUTH_SECRET
 
   const session = await NextAuthHandler<Session | {}>({

--- a/packages/next-auth/tests/getServerSession.test.ts
+++ b/packages/next-auth/tests/getServerSession.test.ts
@@ -50,4 +50,19 @@ describe("Treat secret correctly", () => {
     expect(logger.error).toBeCalledTimes(1)
     expect(logger.error).toBeCalledWith("NO_SECRET", expect.any(MissingSecret))
   })
+
+  it("Only logs warning once and in development", async () => {
+    // Expect console.warn to NOT be called due to NODE_ENV=production
+    await unstable_getServerSession(req, res, { providers: [], logger })
+    expect(console.warn).toBeCalledTimes(0)
+
+    // Expect console.warn to be called ONCE due to NODE_ENV=development
+    process.env.NODE_ENV = "development"
+    await unstable_getServerSession(req, res, { providers: [], logger })
+    expect(console.warn).toBeCalledTimes(1)
+
+    // Expect console.warn to be still only be called ONCE
+    await unstable_getServerSession(req, res, { providers: [], logger })
+    expect(console.warn).toBeCalledTimes(1)
+  })
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Show `[next-auth][warn][EXPERIMENTAL_API]` warning for the `unstable_getServerSession` API only **once** and only in `NODE_ENV=development`.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
