### PR TITLE
feat: lazily import nodemailer

### DIFF
--- a/packages/next-auth/src/providers/email.ts
+++ b/packages/next-auth/src/providers/email.ts
@@ -1,5 +1,3 @@
-import { createTransport } from "nodemailer"
-
 import type { CommonProviderOptions } from "."
 import type { Options as SMTPConnectionOptions } from "nodemailer/lib/smtp-connection"
 import type { Awaitable } from ".."
@@ -71,6 +69,7 @@ export default function Email(options: EmailUserConfig): EmailConfig {
       url,
       provider: { server, from },
     }) {
+      const { createTransport } = await impot('nodemailer')
       const { host } = new URL(url)
       const transport = createTransport(server)
       await transport.sendMail({

--- a/packages/next-auth/src/providers/email.ts
+++ b/packages/next-auth/src/providers/email.ts
@@ -69,7 +69,7 @@ export default function Email(options: EmailUserConfig): EmailConfig {
       url,
       provider: { server, from },
     }) {
-      const { createTransport } = await impot('nodemailer')
+      const { createTransport } = await import('nodemailer')
       const { host } = new URL(url)
       const transport = createTransport(server)
       await transport.sendMail({


### PR DESCRIPTION
I'm roughly following/adapting this guide for sending a six-digit code via email: https://www.ramielcreations.com/nexth-auth-magic-code

I would like to use it in a stack where we're using Amazon SES as an emailing abstraction, rather than an SMTP server directly. And while developing, it has been useful to just `console.log` the verification code in a custom `sendVerificationRequest` implementation. One snag I hit, though, was that not having the `nodemailer` dependency installed caused an error just by requiring the `EmailProvider`, even though it's only used in one place, that I was overriding anyway. I've seen in https://github.com/nextauthjs/next-auth/issues/1913 and some other related issues/discussions that there may be willingness to create a non-email-biased `PasswordlessProvider` in future. But for now this step is a really simple code change to make and decreases the `nodemailer` dependency without needing to create a whole new provider.