### PR TITLE
docs(configuration/nextjs.md): Add caution for middleware usage restrictions

### DIFF
--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -76,6 +76,10 @@ Next.js 12 has introduced [Middleware](https://nextjs.org/docs/middleware). It i
 
 If the following options look familiar, this is because they are a subset of [these options](/configuration/options#options). You can extract these to a common configuration object to reuse them. In the future, we would like to be able to run everything in Middleware. (See [Caveats](#caveats)).
 
+:::caution
+Middleware only supports the `"jwt"` [session strategy](/configuration/options#session). (See [Caveats](#caveats) for more)
+:::
+
 You can get the `withAuth` middleware function from `next-auth/middleware` either as a default or a named import:
 
 ### Prerequisites


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Add a separate warning section to the Next.js middleware section to more visibly bring out the `jwt` strategy restriction.

It's only mentioned at the bottom of the page in Caveats at the moment, which can easily be missed and can cause multiple hours of needless debugging time. 

## 🧢 Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: n/a

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
