### PR TITLE
docs: Added documentation on how to use a custom base path in NextAuth

### DIFF
--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -13,9 +13,13 @@ When deploying to production, set the `NEXTAUTH_URL` environment variable to the
 NEXTAUTH_URL=https://example.com
 ```
 
-If your Next.js application uses a custom base path, specify the route to the API endpoint in full.
+If your Next.js application uses a custom base path, specify the route to the API endpoint in full. More informations about the usage of custom base path [here](#custom-base-path).
 
 _e.g. `NEXTAUTH_URL=https://example.com/custom-route/api/auth`_
+
+:::tip
+When you're using a custom base path, you will need to pass the `basePath` page prop to the `<SessionProvider>`. More informations [here](/getting-started/client#custom-base-path).
+:::
 
 :::note
 Using [System Environment Variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) we automatically detect when you deploy to [Vercel](https://vercel.com) so you don't have to define this variable. Make sure **Automatically expose System Environment Variables** is checked in your Project Settings.

--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -506,3 +506,29 @@ However, if it was set to `false`, it stops re-fetching the session and the comp
 :::note
 See [**the Next.js documentation**](https://nextjs.org/docs/advanced-features/custom-app) for more information on **\_app.js** in Next.js applications.
 :::
+
+### Custom base path
+When your Next.js application uses a custom base path, set the `NEXTAUTH_URL` environment variable to the route to the API endpoint in full - as in the example below and as explained [here](/configuration/options#nextauth_url).
+
+Also, make sure to pass the `basePath` page prop to the `<SessionProvider>` – as in the example below – so your custom base path is fully configured and used by NextAuth.js.
+
+#### Example
+In this example, the custom base path used is `/custom-route`.
+
+```
+NEXTAUTH_URL=https://example.com/custom-route/api/auth
+```
+
+```jsx title="pages/_app.js"
+import { SessionProvider } from "next-auth/react"
+export default function App({
+  Component,
+  pageProps: { session, ...pageProps },
+}) {
+  return (
+    <SessionProvider session={session} basePath="/custom-route/api/auth">
+      <Component {...pageProps} />
+    </SessionProvider>
+  )
+}
+```


### PR DESCRIPTION
## ☕️ Reasoning

After being blocked myself for several days, I came across a discussion (#3635) referring to the basePath property of the SessionProvider. I think it's important to add these explanations because I couldn't find anything about it on the current documentation.

So, as @balazsorban44 know from the archived repository, I added a section dedicated to the use of a custom base path in the documentation related to the configuration.

PS: Thanks @balazsorban44 for your reactivity and your understanding, I'm happy to contribute to this project and help you to improve the documentation.

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues
Missing informations about usage of custom base path.