### PR TITLE
fix(docs): Fix link about custom basePath in Environment Variables (Options page)

### DIFF
--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -13,7 +13,7 @@ When deploying to production, set the `NEXTAUTH_URL` environment variable to the
 NEXTAUTH_URL=https://example.com
 ```
 
-If your Next.js application uses a custom base path, specify the route to the API endpoint in full. More informations about the usage of custom base path [here](#custom-base-path).
+If your Next.js application uses a custom base path, specify the route to the API endpoint in full. More informations about the usage of custom base path [here](/getting-started/client#custom-base-path).
 
 _e.g. `NEXTAUTH_URL=https://example.com/custom-route/api/auth`_
 


### PR DESCRIPTION
## ☕️ Reasoning

I've just realised that when I made the previous PR I let the wrong link on Options page which were supposed to send on "/getting-started/client#custom-base-path" instead of "/configuration/options#custom-base-path".

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged