### PR TITLE
Added `getServerProviders` handler

### DIFF
--- a/packages/next-auth/src/core/routes/providers.ts
+++ b/packages/next-auth/src/core/routes/providers.ts
@@ -1,13 +1,5 @@
 import type { OutgoingResponse } from ".."
-import type { InternalProvider } from "../types"
-
-export interface PublicProvider {
-  id: string
-  name: string
-  type: string
-  signinUrl: string
-  callbackUrl: string
-}
+import type { InternalProvider, PublicProvider } from "../types"
 
 /**
  * Return a JSON object with a list of all OAuth providers currently configured

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -555,3 +555,12 @@ export type NextAuthApiHandler<Result = void, Response = any> = (
   req: NextAuthRequest,
   res: NextAuthResponse<Response>
 ) => Awaitable<Result>
+
+/** @internal */
+export interface PublicProvider {
+  id: string
+  name: string
+  type: string
+  signinUrl: string
+  callbackUrl: string
+}

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -140,7 +140,16 @@ export function getServerProviders(
   })
 
   return Object.fromEntries(
-    providers.map((provider) => [provider.id, provider])
+    providers.map((provider) => [
+      provider.id,
+      {
+        id: provider.id,
+        name: provider.name,
+        type: provider.type,
+        signinUrl: provider.signinUrl,
+        callbackUrl: provider.callbackUrl,
+      } as PublicProvider,
+    ])
   )
 }
 

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -1,3 +1,5 @@
+import parseProviders from "../core/lib/providers"
+import parseUrl from "../utils/parse-url"
 import { NextAuthHandler } from "../core"
 import { detectHost } from "../utils/detect-host"
 import { setCookie } from "./utils"
@@ -12,6 +14,7 @@ import type {
   NextAuthAction,
   NextAuthRequest,
   NextAuthResponse,
+  PublicProvider,
 } from "../core/types"
 
 async function NextAuthNextHandler(
@@ -124,6 +127,21 @@ export async function unstable_getServerSession(
 
   if (body && Object.keys(body).length) return body as Session
   return null
+}
+
+export function getServerProviders(
+  options: NextAuthOptions
+): Record<string, PublicProvider> {
+  const url = parseUrl(`${process.env.NEXTAUTH_URL}/api/auth`)
+
+  const { providers } = parseProviders({
+    providers: options.providers,
+    url,
+  })
+
+  return Object.fromEntries(
+    providers.map((provider) => [provider.id, provider])
+  )
 }
 
 declare global {


### PR DESCRIPTION
## ☕️ Reasoning

#### What's been changed?
 - Moved `PublicProvider` from providers route to core types module
 - Added new `getServerProviders` to next module

### Why have these changes been made?

This is a very niche use case but I have a custom login page set up with SSG (`getStaticProps`), instead of using SSR (`getServerSideProps`) as it's slower, to dynamically fetch the providers using `getProviders` & pass them to the client for rendering.

However, using the current recommended `getProviders` handler relies on an active endpoint fetch in order to retrieve the providers at build time which is possible for production builds, though outdated, but impossible for local builds.

As such I have added this new `getServerProviders` handler designed for dedicated backend / server side use, such as `getStaticProps`, to retrieve providers.

## 🧢 Checklist

- [ ] Documentation
    - [ ] Add `getServerProviders` section to `/configuration/nextjs` docs page
- [x] Tests
    - [x] Test locally in development environment
- [ ] Ready to be merged
