### PR TITLE
chore: fix dev app URL parse error

### DIFF
--- a/apps/dev/pages/api/auth/[...nextauth].ts
+++ b/apps/dev/pages/api/auth/[...nextauth].ts
@@ -225,7 +225,7 @@ export const authOptions: NextAuthOptions = {
       clientSecret: process.env.WORKOS_SECRET,
     }),
     BoxyHQSAMLProvider({
-      issuer: process.env.BOXYHQSAML_ISSUER,
+      issuer: process.env.BOXYHQSAML_ISSUER ?? "https://example.com",
       clientId: process.env.BOXYHQSAML_ID,
       clientSecret: process.env.BOXYHQSAML_SECRET,
     }),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

When using the dev app out of the box, without `BoxyHQSAMLProvider` environment variables set (specifically the `ISSUER` one). The dev app won't work and throws an error when parsing the BoxyHQ provider's authorization URL, as it ends up being a relative URL without that environment variable. See:

![image](https://user-images.githubusercontent.com/7415984/178143824-8112ab4e-ed66-45b5-aff0-0a7753efc93b.png)

Therefore, here just for dev i'm falling it back to `https://example.com` just so you can use the dev app without having to explicitly set a BoxyHQSAMLProvider `ISSUER` environment variable.

This made it really annoying to test out anything because I always have to modify the `[...nextauth].ts` file, stash the changes when making a commit, etc. I guess I could have kept a dummy `BoxyHQSAMLProvider` `ISSUER` around in my local env file, but this fixes it for everyone..


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
