### PR TITLE
feat(core): add allowedAccountTokens option

### DIFF
--- a/docs/docs/adapters/models.md
+++ b/docs/docs/adapters/models.md
@@ -72,7 +72,7 @@ User creation in the database is automatic, and happens when the user is logging
 The Account model is for information about OAuth accounts associated with a User. It will usually contain `access_token`, `id_token` and other OAuth specific data. [`TokenSet`](https://github.com/panva/node-openid-client/blob/main/docs/README.md#new-tokensetinput) from `openid-client` might give you an idea of all the fields.
 
 :::note
-In case of an OAuth 1.0 provider (like Twitter), you will have to look for `oauth_token` and `oauth_token_secret` string fields. GitHub also has an extra `refresh_token_expires_in` integer field. You have to make sure that your database schema includes these fields.
+In case of an OAuth 1.0 provider (like Twitter), you will have to look for `oauth_token` and `oauth_token_secret` string fields. GitHub also has an extra `refresh_token_expires_in` integer field. You have to make sure that your database schema includes these fields or configure the [`allowedAccountTokens`](/configuration/options#allowedaccounttokens) option.
 :::
 
 A single User can have multiple Accounts, but each Account can only have one User.

--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -29,7 +29,6 @@ Using [System Environment Variables](https://vercel.com/docs/concepts/projects/e
 
 Used to encrypt the NextAuth.js JWT, and to hash [email verification tokens](/adapters/models#verification-token). This is the default value for the `secret` option in [NextAuth](/configuration/options#secret) and [Middleware](/configuration/nextjs#secret).
 
-
 ### NEXTAUTH_URL_INTERNAL
 
 If provided, server-side calls will use this instead of `NEXTAUTH_URL`. Useful in environments when the server doesn't have access to the canonical URL of your site. Defaults to `NEXTAUTH_URL`.
@@ -305,6 +304,34 @@ events: {
 #### Description
 
 By default NextAuth.js does not include an adapter any longer. If you would like to persist user / account data, please install one of the many available adapters. More information can be found in the [adapter documentation](/adapters/overview).
+
+---
+
+### allowedAccountTokens
+
+- **Default value**: All tokens are allowed
+- **Required**: _No_
+
+#### Description
+
+By default NextAuth.js stores all information about an OAuth account gathered by the provider on the [Account Model](/adapters/models#account).
+These tokens can include fields that are not defined on the database schema. With this option the tokens can be filtered before being stored on the Account.
+
+_For example:_
+
+```js
+allowedAccountTokens: [
+  "refresh_token",
+  "access_token",
+  "expires_at",
+  "token_type",
+  "scope",
+  "id_token",
+  "session_state",
+],
+```
+
+ensures only the fields that are supported by the [default Prisma schema](/adapters/prisma) are stored.
 
 ---
 

--- a/docs/docs/providers/azure-ad-b2c.md
+++ b/docs/docs/providers/azure-ad-b2c.md
@@ -11,7 +11,7 @@ Azure AD B2C returns the following fields on `Account`:
 - `id_token_expires_in` (number)
 - `profile_info` (string).
 
-See their [docs](https://docs.microsoft.com/en-us/azure/active-directory-b2c/access-tokens). Remember to add these fields to your database schema, in case if you are using an [Adapter](/adapters/overview).
+See their [docs](https://docs.microsoft.com/en-us/azure/active-directory-b2c/access-tokens). Remember to add these fields to your database schema, in case if you are using an [Adapter](/adapters/overview) or configure the [`allowedAccountTokens`](/configuration/options#allowedaccounttokens) option.
 :::
 
 ## Documentation

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -121,6 +121,15 @@ export interface NextAuthOptions {
    */
   adapter?: Adapter
   /**
+   * Filter the tokens from the provider before storing it in the Account.
+   *
+   * * **Default value**: All tokens are allowed
+   * * **Required**: *No*
+   *
+   * [Documentation](https://next-auth.js.org/configuration/options#allowedaccounttokens) |
+   */
+  allowedAccountTokens?: string[]
+  /**
    * Set debug to true to enable debug messages for authentication and database operations.
    * * **Default value**: `false`
    * * **Required**: *No*
@@ -536,6 +545,7 @@ export interface InternalOptions<T extends ProviderType = any> {
   jwt: JWTOptions
   events: Partial<EventCallbacks>
   adapter?: Adapter
+  allowedAccountTokens?: string[]
   callbacks: CallbacksOptions
   cookies: CookiesOptions
   callbackUrl: string


### PR DESCRIPTION
## ☕️ Reasoning

Just came about the problem described in https://github.com/nextauthjs/next-auth/discussions/4516 when trying to use the GitLab provider.
I could simply add the missing fields to my Prisma schema or remove it in a custom prisma adapter but I would rather not bloat it with unnecessary fields.

This PR introduces a new optional option to configure which fields from the provider will be stored on the `Account`:

> By default NextAuth.js stores all information about an OAuth account gathered by the provider on the [Account Model](https://next-auth.js.org/adapters/models#account).
> These tokens can include fields that are not defined on the database schema. With this option the tokens can be filtered before being stored on the Account.
> 
> _For example:_
> 
> ```js
> allowedAccountTokens: [
>   "refresh_token",
>   "access_token",
>   "expires_at",
>   "token_type",
>   "scope",
>   "id_token",
>   "session_state",
> ],
> ```
> 
> ensures only the fields that are supported by the [default Prisma schema](https://next-auth.js.org/adapters/prisma) are stored.

I am not fixed on a proper name yet. Maybe `allowedAccountFields` makes more sense to not confuse this with anything related to the JWT tokens.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes #3818 (only the original issue, not the second part of the discussion)
Fixes #4515
Fixes #3823
Fixes #3067
