### PR TITLE
fix(ts): remove TS workaround for `withAuth`

### DIFF
--- a/apps/dev/middleware.ts
+++ b/apps/dev/middleware.ts
@@ -30,12 +30,11 @@ export const config = { matcher: ["/middleware-protected"] }
 // export default withAuth(
 //   function middleware(req, ev) {
 //     console.log(req, ev)
-//     return undefined // NOTE: `NextMiddleware` should allow returning `void`
 //   },
 //   {
 //     callbacks: {
 //       authorized: ({ token }) => token.name === "Balázs Orbán",
-//     }
+//     },
 //   }
 // )
 

--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -177,13 +177,11 @@ If you do not define the options, NextAuth.js will use the default values for th
 #### wrap middleware
 
 ```ts title="middleware.ts"
-import type { NextRequest } from "next/server"
-import type { JWT } from "next-auth/jwt"
 import { withAuth } from "next-auth/middleware"
 
 export default withAuth(
-  // `withAuth` can augment your Request with the user's token.
-  function middleware(req: NextRequest & { nextauth: { token: JWT | null } }) {
+  // `withAuth` augments your `Request` with the user's token.
+  function middleware(req) {
     console.log(req.nextauth.token)
   },
   {

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -189,12 +189,10 @@ export function withAuth(...args: WithAuthArgs) {
   if (typeof args[0] === "function") {
     const middleware = args[0]
     const options = args[1] as NextAuthMiddlewareOptions | undefined
-    return async (...args: Parameters<NextMiddleware>) =>
+    return async (...args: Parameters<NextMiddlewareWithAuth>) =>
       await handleMiddleware(args[0], options, async (token) => {
-        const [req, ...rest] = args
-        // @ts-expect-error
-        req.nextauth = { token }
-        return await middleware(req as NextRequestWithAuth, ...rest)
+        args[0].nextauth = { token }
+        return await middleware(...args)
       })
   }
 

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -94,7 +94,7 @@ export interface NextAuthMiddlewareOptions {
 
 // TODO: `NextMiddleware` should allow returning `void`
 // Simplify when https://github.com/vercel/next.js/pull/38625 is merged.
-type NextMiddlewareResult = ReturnType<NextMiddleware> | void
+type NextMiddlewareResult = ReturnType<NextMiddleware> | void // eslint-disable-line @typescript-eslint/no-invalid-void-type
 
 async function handleMiddleware(
   req: NextRequest,


### PR DESCRIPTION
Removes workaround for typing `withAuth`'s inner Middleware. Closes #4925. Fixes #4817.

We control what happens inside `withAuth` so we shouldn't require the user to type anything themselves.

This is now correctly typed:

```ts
import { withAuth } from "next-auth/middleware"

export default withAuth(
  function middleware(req) {
    console.log(req.nextauth.token)
  }
)

// or

export default withAuth((req) => {
  console.log(req.nextauth.token)
})
```

I also noticed that `NextMiddleware` could not return `void` which I opened a PR for upstream in Next.js https://github.com/vercel/next.js/pull/38625