### PR TITLE
Remove import of "useSession" from wrong location

### DIFF
--- a/docs/docs/tutorials/securing-pages-and-api-routes.md
+++ b/docs/docs/tutorials/securing-pages-and-api-routes.md
@@ -61,8 +61,9 @@ You can protect server side rendered pages using the `unstable_getServerSession`
 You need to add this to every server rendered page you want to protect. Be aware, `unstable_getServerSession` takes slightly different arguments than the method it is replacing, `getSession`.
 
 ```js title="pages/server-side-example.js"
-import { useSession, unstable_getServerSession } from "next-auth/next"
+import { unstable_getServerSession } from "next-auth/next"
 import { authOptions } from "./api/auth/[...nextauth]"
+import {useSession} from "next-auth/react"
 
 export default function Page() {
   const { data: session } = useSession()


### PR DESCRIPTION
This tutorial snipped erroneously imports useSession from "next-auth/next", when it actually resides in "next-auth/react".

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

To fix an erroneous import statement in the documentation.

## 🧢 Checklist

- [x] Documentation
- [ x] Tests
- [ x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
