### PR TITLE
fix(jwt): make `getToken` work in node 14/16

### DIFF
--- a/packages/next-auth/src/jwt/index.ts
+++ b/packages/next-auth/src/jwt/index.ts
@@ -92,7 +92,7 @@ export async function getToken<R extends boolean = false>(
   let token = sessionStore.value
 
   const authorizationHeader =
-    req.headers instanceof Headers
+    typeof Headers !== 'undefined' && req.headers instanceof Headers
       ? req.headers.get("authorization")
       : req.headers.authorization
 


### PR DESCRIPTION
## ☕️ Reasoning

My team use node v14.17.0 and this line was throwing because `Headers` is undefined. Looks like it was [added in v17.5.0](https://nodejs.org/api/globals.html#class-headers).

Verified that this fix worked, but since package.json declares `"engines": {    "node": "^12.19.0 || ^14.15.0 || ^16.13.0"   }` might be worth using an eslint rule to make it easier to spot this kind of thing, since there will probably be more new nodejs features that don't exist in older node versions.

What changes are being made? What feature/bug is being fixed here?

## 🧢 Checklist

Haven't done docs or testing, because this is just a thing that's broken that would become not-broken. A test could be sensible but since we've already worked around this will leave that to someone else!