### PR TITLE
s/OAUTH_CALLBACK_ERROR/CALLBACK_OAUTH_ERROR/

### DIFF
--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -146,7 +146,7 @@ export default async function oAuthCallback(params: {
     })
     return { ...profileResult, cookies: resCookies }
   } catch (error) {
-    logger.error("OAUTH_CALLBACK_ERROR", {
+    logger.error("CALLBACK_OAUTH_ERROR", {
       error: error as Error,
       providerId: provider.id,
     })

--- a/packages/next-auth/src/core/routes/callback.ts
+++ b/packages/next-auth/src/core/routes/callback.ts
@@ -193,7 +193,7 @@ export default async function callback(params: {
         logger.error("CALLBACK_OAUTH_ERROR", error as Error)
         return { redirect: `${url}/error?error=OAuthCallback`, cookies }
       }
-      logger.error("OAUTH_CALLBACK_ERROR", error as Error)
+      logger.error("CALLBACK_OAUTH_ERROR", error as Error)
       return { redirect: `${url}/error?error=Callback`, cookies }
     }
   } else if (provider.type === "email") {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning
There is an inconsistent use of two of the error codes, `OAUTH_CALLBACK_ERROR` and `CALLBACK_OAUTH_ERROR`. Especially in `routes/callback.ts` the two sit next to each other and emit subtly discrepant errors. They apparently do not contain asymmetrical information, and practically look interchangeable. But since errors page only mentions the latter, let's align them and make use of it: https://next-auth.js.org/errors#callback_oauth_error. With this fix I hope anybody like me will no longer navigate unfortunately through the different link with a broken anchor.

Skimming through the history, I found `OAUTH_CALLBACK_ERROR` had been replaced in #235, reintroduced perhaps accidentally in #332 and #1698. Let me know if I'm missing any context!

Below is the like of what I've seen in the log:

```
[next-auth][error][OAUTH_CALLBACK_ERROR] 
https://next-auth.js.org/errors#oauth_callback_error connect ECONNREFUSED 127.0.0.1:80 {
  error: {
    message: 'connect ECONNREFUSED 127.0.0.1:80',
    stack: 'Error: connect ECONNREFUSED 127.0.0.1:80\n' +
      '    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1237:16)',
    name: 'Error'
  },
  providerId: 'some-provider',
  message: 'connect ECONNREFUSED 127.0.0.1:80'
}
[next-auth][error][CALLBACK_OAUTH_ERROR] 
https://next-auth.js.org/errors#callback_oauth_error connect ECONNREFUSED 127.0.0.1:80 Error: connect ECONNREFUSED 127.0.0.1:80
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1237:16) {
  name: 'OAuthCallbackError',
  code: 'ECONNREFUSED'
}
```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
