### PR TITLE
feat: Add nonce option to callback check

### DIFF
--- a/packages/next-auth/src/core/lib/cookie.ts
+++ b/packages/next-auth/src/core/lib/cookie.ts
@@ -103,6 +103,15 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
         secure: useSecureCookies,
       },
     },
+    nonce: {
+      name: `${cookiePrefix}next-auth.nonce`,
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: useSecureCookies,
+      },
+    },
   }
 }
 

--- a/packages/next-auth/src/core/lib/oauth/authorization-url.ts
+++ b/packages/next-auth/src/core/lib/oauth/authorization-url.ts
@@ -1,6 +1,7 @@
 import { openidClient } from "./client"
 import { oAuth1Client } from "./client-legacy"
 import { createState } from "./state-handler"
+import { createNonce } from "./nonce-handler"
 import { createPKCE } from "./pkce-handler"
 
 import type { AuthorizationParameters } from "openid-client"
@@ -60,6 +61,12 @@ export default async function getAuthorizationUrl({
   if (state) {
     authorizationParams.state = state.value
     cookies.push(state.cookie)
+  }
+
+  const nonce = await createNonce(options)
+  if (nonce) {
+    authorizationParams.nonce = nonce.value
+    cookies.push(nonce.cookie)
   }
 
   const pkce = await createPKCE(options)

--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -2,6 +2,7 @@ import { TokenSet } from "openid-client"
 import { openidClient } from "./client"
 import { oAuth1Client } from "./client-legacy"
 import { useState } from "./state-handler"
+import { useNonce } from "./nonce-handler"
 import { usePKCECodeVerifier } from "./pkce-handler"
 import { OAuthCallbackError } from "../../errors"
 
@@ -77,6 +78,13 @@ export default async function oAuthCallback(params: {
     if (state) {
       checks.state = state.value
       resCookies.push(state.cookie)
+    }
+
+    const nonce = await useNonce(cookies?.[options.cookies.nonce.name], options)
+
+    if (nonce) {
+      checks.nonce = nonce.value
+      resCookies.push(nonce.cookie)
     }
 
     const codeVerifier = cookies?.[options.cookies.pkceCodeVerifier.name]

--- a/packages/next-auth/src/core/lib/oauth/nonce-handler.ts
+++ b/packages/next-auth/src/core/lib/oauth/nonce-handler.ts
@@ -1,0 +1,63 @@
+import { generators } from "openid-client"
+
+import type { InternalOptions } from "../../types"
+import type { Cookie } from "../cookie"
+
+const NONCE_MAX_AGE = 60 * 15 // 15 minutes in seconds
+
+/** Returns nonce if the provider supports it */
+export async function createNonce(
+  options: InternalOptions<"oauth">
+): Promise<{ cookie: Cookie; value: string } | undefined> {
+  const { logger, provider, jwt, cookies } = options
+
+  if (!provider.checks?.includes("nonce")) {
+    // Provider does not support nonce, return nothing
+    return
+  }
+
+  const nonce = generators.nonce()
+
+  const encodedNonce = await jwt.encode({
+    ...jwt,
+    maxAge: NONCE_MAX_AGE,
+    token: { nonce },
+  })
+
+  logger.debug("CREATE_NONCE", { nonce, maxAge: NONCE_MAX_AGE })
+
+  const expires = new Date()
+  expires.setTime(expires.getTime() + NONCE_MAX_AGE * 1000)
+  return {
+    value: nonce,
+    cookie: {
+      name: cookies.nonce.name,
+      value: encodedNonce,
+      options: { ...cookies.nonce.options, expires },
+    },
+  }
+}
+
+/**
+ * Returns nonce from if the provider supports nonces,
+ * and clears the container cookie afterwards.
+ */
+export async function useNonce(
+  nonce: string | undefined,
+  options: InternalOptions<"oauth">
+): Promise<{ value: string; cookie: Cookie } | undefined> {
+  const { cookies, provider, jwt } = options
+
+  if (!provider.checks?.includes("nonce") || !nonce) return
+
+  const value = (await jwt.decode({ ...options.jwt, token: nonce })) as any
+
+  return {
+    value: value?.nonce ?? undefined,
+    cookie: {
+      name: cookies.nonce.name,
+      value: "",
+      options: { ...cookies.pkceCodeVerifier.options, maxAge: 0 },
+    },
+  }
+}

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -361,6 +361,7 @@ export interface CookiesOptions {
   csrfToken: CookieOption
   pkceCodeVerifier: CookieOption
   state: CookieOption
+  nonce: CookieOption
 }
 
 /**

--- a/packages/next-auth/src/providers/oauth.ts
+++ b/packages/next-auth/src/providers/oauth.ts
@@ -17,7 +17,7 @@ type Client = InstanceType<Issuer["Client"]>
 
 export type { OAuthProviderType } from "./oauth-types"
 
-type ChecksType = "pkce" | "state" | "none"
+type ChecksType = "pkce" | "state" | "nonce" | "none"
 
 export type OAuthChecks = OpenIDCallbackChecks | OAuthCallbackChecks
 


### PR DESCRIPTION
## ☕️ Reasoning

Nonce check for authorisation and token request

## Notes

By adding 'nonce' to a providers check parameter, a nonce will be generated as part of the auth request and validated on the callback from token.

eg.
checks: ['state', 'nonce'],

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
