### PR TITLE
Add build-adapter stept to CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,25 +34,31 @@ git clone git@github.com:nextauthjs/next-auth.git
 cd next-auth
 ```
 
-1. Install packages. Developing requires Node.js v16:
+2. Install packages. Developing requires Node.js v16:
 
 ```sh
 pnpm install
 ```
 
-3. Populate `.env.local`:
+3. Build adapters
+````
+cd packages
+pnpm build
+````
+
+4. Populate `.env.local`:
 
 Copy `apps/dev/.env.local.example` to `apps/dev/.env.local`, and add your env variables for each provider you want to test.
 
 ```sh
-cd apps/dev
+cd ../apps/dev
 cp .env.local.example .env.local
 ```
 
 > NOTE: You can add any environment variables to .env.local that you would like to use in your dev app.
 > You can find the next-auth config under`apps/dev/pages/api/auth/[...nextauth].js`.
 
-4. Start the developer application/server:
+5. Start the developer application/server:
 
 ```sh
 pnpm dev


### PR DESCRIPTION
## ☕️ Reasoning

Adds the missing building adapter step that is required after cloning the repository. Without the adapter building,
the website won't function, which causes confusion since it isn't mentioned anywhere in the instructions.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: [https://github.com/nextauthjs/next-auth/issues/5070](https://github.com/nextauthjs/next-auth/issues/5070)

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
