### PR TITLE
Add error for oauth denial

### DIFF
--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -54,6 +54,8 @@ The following errors are passed as error query parameters to the default or over
 - **EmailSignin**: Sending the e-mail with the verification token failed
 - **CredentialsSignin**: The `authorize` callback returned `null` in the [Credentials provider](/providers/credentials). We don't recommend providing information about which part of the credentials were wrong, as it might be abused by malicious hackers.
 - **SessionRequired**: The content of this page requires you to be signed in at all times. See [useSession](/getting-started/client#require-session) for configuration.
+- **Configuration**: The provider was configured wrongly, check the debug log to see detailed information from the provider.
+- **UnavailableService**: The provider is currently not reachable or has internal server problems.
 - **Default**: Catch all, will apply, if none of the above matched
 
 Example: `/auth/signin?error=Default`

--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -45,6 +45,7 @@ Example: `/auth/error?error=Configuration`
 The following errors are passed as error query parameters to the default or overridden sign-in page:
 
 - **OAuthSignin**: Error in constructing an authorization URL ([1](https://github.com/nextauthjs/next-auth/blob/457952bb5abf08b09861b0e5da403080cd5525be/src/server/lib/signin/oauth.js), [2](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/lib/oauth/pkce-handler.ts), [3](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/lib/oauth/state-handler.ts)),
+- **OAuthDenied**: User canceled OAuth request.
 - **OAuthCallback**: Error in handling the response ([1](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/lib/oauth/callback.ts), [2](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/lib/oauth/pkce-handler.ts), [3](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/lib/oauth/state-handler.ts)) from an OAuth provider.
 - **OAuthCreateAccount**: Could not create OAuth provider user in the database.
 - **EmailCreateAccount**: Could not create email provider user in the database.

--- a/docs/versioned_docs/version-v3/configuration/pages.md
+++ b/docs/versioned_docs/version-v3/configuration/pages.md
@@ -41,6 +41,7 @@ Example: `/auth/error?error=Configuration`
 The following errors are passed as error query parameters to the default or overriden sign-in page:
 
 - **OAuthSignin**: Error in constructing an authorization URL ([1](https://github.com/nextauthjs/next-auth/blob/457952bb5abf08b09861b0e5da403080cd5525be/src/server/lib/signin/oauth.js), [2](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/pkce-handler.js), [3](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/state-handler.js)),
+- **OAuthDenied**: User canceled OAuth request.
 - **OAuthCallback**: Error in handling the response ([1](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/callback.js), [2](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/pkce-handler.js), [3](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/state-handler.js)) from an OAuth provider.
 - **OAuthCreateAccount**: Could not create OAuth provider user in the database.
 - **EmailCreateAccount**: Could not create email provider user in the database.

--- a/docs/versioned_docs/version-v3/configuration/pages.md
+++ b/docs/versioned_docs/version-v3/configuration/pages.md
@@ -49,6 +49,8 @@ The following errors are passed as error query parameters to the default or over
 - **OAuthAccountNotLinked**: If the email on the account is already linked, but not with this OAuth account
 - **EmailSignin**: Sending the e-mail with the verification token failed
 - **CredentialsSignin**: The `authorize` callback returned `null` in the [Credentials provider](/providers/credentials). We don't recommend providing information about which part of the credentials were wrong, as it might be abused by malicious hackers.
+- **Configuration**: The provider was configured wrongly, check the debug log to see detailed information from the provider. 
+- **UnavailableService**: The provider is currently not reachable or has internal server problems. 
 - **Default**: Catch all, will apply, if none of the above matched
 
 Example: `/auth/error?error=Default`

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -198,6 +198,7 @@ export async function NextAuthHandler<
             "Signin",
             "OAuthSignin",
             "OAuthCallback",
+            "OAuthDenied",
             "OAuthCreateAccount",
             "EmailCreateAccount",
             "Callback",

--- a/packages/next-auth/src/core/pages/signin.tsx
+++ b/packages/next-auth/src/core/pages/signin.tsx
@@ -7,6 +7,7 @@ import type { InternalProvider, Theme } from "../types"
 export type SignInErrorTypes =
   | "Signin"
   | "OAuthSignin"
+  | "OAuthDenied"
   | "OAuthCallback"
   | "OAuthCreateAccount"
   | "EmailCreateAccount"
@@ -58,6 +59,7 @@ export default function SigninPage(props: SignInServerPageParams) {
   const errors: Record<SignInErrorTypes, string> = {
     Signin: "Try signing in with a different account.",
     OAuthSignin: "Try signing in with a different account.",
+    OAuthDenied: "You canceled the signin",
     OAuthCallback: "Try signing in with a different account.",
     OAuthCreateAccount: "Try signing in with a different account.",
     EmailCreateAccount: "Try signing in with a different account.",

--- a/packages/next-auth/src/core/pages/signin.tsx
+++ b/packages/next-auth/src/core/pages/signin.tsx
@@ -16,6 +16,8 @@ export type SignInErrorTypes =
   | "EmailSignin"
   | "CredentialsSignin"
   | "SessionRequired"
+  | "Configuration"
+  | "ServiceUnavailable"
   | "default"
 
 export interface SignInServerPageParams {
@@ -59,7 +61,7 @@ export default function SigninPage(props: SignInServerPageParams) {
   const errors: Record<SignInErrorTypes, string> = {
     Signin: "Try signing in with a different account.",
     OAuthSignin: "Try signing in with a different account.",
-    OAuthDenied: "You canceled the signin",
+    OAuthDenied: "You canceled the signin.",
     OAuthCallback: "Try signing in with a different account.",
     OAuthCreateAccount: "Try signing in with a different account.",
     EmailCreateAccount: "Try signing in with a different account.",
@@ -70,6 +72,8 @@ export default function SigninPage(props: SignInServerPageParams) {
     CredentialsSignin:
       "Sign in failed. Check the details you provided are correct.",
     SessionRequired: "Please sign in to access this page.",
+    Configuration: "Please contact an administrator and choose another provider.",
+    ServiceUnavailable: "This service is currently unavailable, please choose another.",
     default: "Unable to sign in.",
   }
 

--- a/packages/next-auth/src/core/routes/callback.ts
+++ b/packages/next-auth/src/core/routes/callback.ts
@@ -192,6 +192,8 @@ export default async function callback(params: {
       if ((error as Error).name === "OAuthCallbackError") {
         logger.error("CALLBACK_OAUTH_ERROR", error as Error)
         return { redirect: `${url}/error?error=OAuthCallback`, cookies }
+      } else if ((error as Error).message === "access_denied") {
+        return { redirect: `${url}/error?error=OAuthDenied`, cookies }
       }
       logger.error("OAUTH_CALLBACK_ERROR", error as Error)
       return { redirect: `${url}/error?error=Callback`, cookies }


### PR DESCRIPTION
## ☕️ Reasoning

Adds another error type to oauth2 abortion. When an oauth2 request is actively cancelled by the user, this error type will be used.

With that, it is possible to identify an cancellation as intended and react properly. This is useful if you have for example only one provider and redirect on `/api/auth/signin` directly to this provider. That would currently end in an infintie loop, which
can be avoid by checking if the user canceled the request intentionally.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: [https://github.com/nextauthjs/next-auth/discussions/3682](https://github.com/nextauthjs/next-auth/discussions/3682)

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
