### PR TITLE
docs(getting-started): reword NextAuth.js + install

### DIFF
--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -160,7 +160,7 @@ See the documentation for the [pages option](/configuration/pages) for more info
 
 #### Description
 
-The same `secret` used in the [NextAuth config](/configuration/options#options).
+The same `secret` used in the [NextAuth.js config](/configuration/options#options).
 
 #### Example (default value)
 

--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -326,7 +326,7 @@ Set debug to `true` to enable debug messages for authentication and database ope
 
 #### Description
 
-Override any of the logger levels (`undefined` levels will use the built-in logger), and intercept logs in NextAuth. You can use this to send NextAuth logs to a third-party logging service.
+Override any of the logger levels (`undefined` levels will use the built-in logger), and intercept logs in NextAuth.js. You can use this to send NextAuth.js logs to a third-party logging service.
 
 The `code` parameter for `error` and `warn` are explained in the [Warnings](/warnings) and [Errors](/errors) pages respectively.
 

--- a/docs/docs/configuration/providers/oauth.md
+++ b/docs/docs/configuration/providers/oauth.md
@@ -80,7 +80,7 @@ TWITTER_ID=YOUR_TWITTER_CLIENT_ID
 TWITTER_SECRET=YOUR_TWITTER_CLIENT_SECRET
 ```
 
-4. Now you can add the provider settings to the NextAuth options object. You can add as many OAuth providers as you like, as you can see `providers` is an array.
+4. Now you can add the provider settings to the NextAuth.js options object. You can add as many OAuth providers as you like, as you can see `providers` is an array.
 
 ```js title="pages/api/auth/[...nextauth].js"
 import TwitterProvider from "next-auth/providers/"

--- a/docs/docs/getting-started/example.md
+++ b/docs/docs/getting-started/example.md
@@ -13,18 +13,12 @@ The easiest way to get started is to clone the [example app](https://github.com/
 
 ### Install NextAuth
 
-```
-npm i next-auth
-```
-
-or
-
-```
-yarn add next-auth
+```bash npm2yarn2pnpm
+npm install next-auth
 ```
 
 :::info
-If you are using TypeScript, NextAuth comes with its types definitions within the package. To learn more about TypeScript for `next-auth`, check out the [TypeScript documentation](/getting-started/typescript)
+If you are using TypeScript, NextAuth.js comes with its types definitions within the package. To learn more about TypeScript for `next-auth`, check out the [TypeScript documentation](/getting-started/typescript)
 :::
 
 

--- a/docs/docs/getting-started/upgrade-to-v4.md
+++ b/docs/docs/getting-started/upgrade-to-v4.md
@@ -319,7 +319,7 @@ Introduced in https://github.com/nextauthjs/next-auth/releases/tag/v4.0.0-next.8
 
 **This does not require any changes from the user - these are adapter specific changes only**
 
-The Adapter API has been rewritten and significantly simplified in NextAuth v4. The adapters now have less work to do as some functionality has been migrated to the core of NextAuth, like hashing the [verification token](/adapters/models/#verification-token).
+The Adapter API has been rewritten and significantly simplified in NextAuth.js v4. The adapters now have less work to do as some functionality has been migrated to the core of NextAuth, like hashing the [verification token](/adapters/models/#verification-token).
 
 If you are an adapter maintainer or are interested in writing your own adapter, you can find more information about this change in https://github.com/nextauthjs/next-auth/pull/2361 and release https://github.com/nextauthjs/next-auth/releases/tag/v4.0.0-next.22.
 

--- a/docs/docs/providers/email.md
+++ b/docs/docs/providers/email.md
@@ -71,7 +71,7 @@ EMAIL_SERVER_PORT=587
 EMAIL_FROM=noreply@example.com
 ```
 
-Now you can add the provider settings to the NextAuth options object in the Email Provider.
+Now you can add the provider settings to the NextAuth.js options object in the Email Provider.
 
 ```js title="pages/api/auth/[...nextauth].js"
 import EmailProvider from "next-auth/providers/email";

--- a/docs/versioned_docs/version-v3/configuration/options.md
+++ b/docs/versioned_docs/version-v3/configuration/options.md
@@ -335,7 +335,7 @@ Set debug to `true` to enable debug messages for authentication and database ope
 
 #### Description
 
-Override any of the logger levels (`undefined` levels will use the built-in logger), and intercept logs in NextAuth. You can use this to send NextAuth logs to a third-party logging service.
+Override any of the logger levels (`undefined` levels will use the built-in logger), and intercept logs in NextAuth. You can use this to send NextAuth.js logs to a third-party logging service.
 
 Example:
 

--- a/docs/versioned_docs/version-v3/configuration/providers.md
+++ b/docs/versioned_docs/version-v3/configuration/providers.md
@@ -56,7 +56,7 @@ TWITTER_ID=YOUR_TWITTER_CLIENT_ID
 TWITTER_SECRET=YOUR_TWITTER_CLIENT_SECRET
 ```
 
-4. Now you can add the provider settings to the NextAuth options object. You can add as many OAuth providers as you like, as you can see `providers` is an array.
+4. Now you can add the provider settings to the NextAuth.js options object. You can add as many OAuth providers as you like, as you can see `providers` is an array.
 
 ```js title="pages/api/auth/[...nextauth].js"
 import Providers from `next-auth/providers`

--- a/docs/versioned_docs/version-v3/providers/email.md
+++ b/docs/versioned_docs/version-v3/providers/email.md
@@ -68,7 +68,7 @@ EMAIL_SERVER_HOST=smtp.example.com
 	EMAIL_FROM=noreply@example.com
 ```
 
-Now you can add the provider settings to the NextAuth options object in the Email Provider.
+Now you can add the provider settings to the NextAuth.js options object in the Email Provider.
 
 ```js title="pages/api/auth/[...nextauth].js"
 providers: [

--- a/docs/versioned_docs/version-v3/tutorials.md
+++ b/docs/versioned_docs/version-v3/tutorials.md
@@ -11,7 +11,7 @@ _New submissions and edits are welcome!_
 
 ### [NextJS Authentication Crash Course with NextAuth.js](https://youtu.be/o_wZIVmWteQ)
 
-This tutorial dives in to the ins and outs of NextAuth including email, GitHub, Twitter and integrating with Auth0 in under hour.
+This tutorial dives in to the ins and outs of NextAuth.js including email, GitHub, Twitter and integrating with Auth0 in under hour.
 
 ### [Create your own NextAuth.js Login Pages](https://youtu.be/kB6YNYZ63fw)
 


### PR DESCRIPTION
## ☕️ Reasoning

After merging https://github.com/nextauthjs/next-auth/pull/5040, we noticed that **NextAuth** should be **NextAuth.js** in our docs (I updated other outdated instances as well). Also, to install Docusauru's snippet for install example.

## 🧢 Checklist

- [x] Documentation
- [ ] ~~Tests~~
- [x] Ready to be merged

## 🎫 Affected issues

None.

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
