### PR TITLE
docs(middleware): fix default value of pages option

### DIFF
--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -16,7 +16,7 @@ In `[...nextauth.js]`:
 ```ts
 import { NextAuth } from 'next-auth'
 import type { NextAuthOptions } from 'next-auth'
- 
+
 export const authOptions: NextAuthOptions = {
   // your configs
 }
@@ -145,8 +145,8 @@ This should match the `pages` configuration that's found in `[...nextauth].ts`.
 
 ```js
 pages: {
-  signIn: '/auth/signin',
-  error: '/auth/error',
+  signIn: '/api/auth/signin',
+  error: '/api/auth/error',
 }
 ```
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

The default value of `signIn` and `error` in the middleware docs should be `/api/auth/signin` and `/api/auth/error` respectively, as shown in the code snippet below.

https://github.com/nextauthjs/next-auth/blob/424af6cbc52a602960e69a8fd4c4dc5c931e5bde/packages/next-auth/src/next/middleware.ts#L106-L107

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues


## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
