### PR TITLE
fix(middleware): use `includes()` for NextAuth pages

### DIFF
--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -106,12 +106,13 @@ async function handleMiddleware(
   const signInPage = options?.pages?.signIn ?? "/api/auth/signin"
   const errorPage = options?.pages?.error ?? "/api/auth/error"
   const basePath = parseUrl(process.env.NEXTAUTH_URL).path
-  const publicPaths = [signInPage, errorPage, "/_next", "/favicon.ico"]
+  const publicPaths = ["/_next", "/favicon.ico"]
 
   // Avoid infinite redirects/invalid response
   // on paths that never require authentication
   if (
     pathname.startsWith(basePath) ||
+    [signInPage, errorPage].includes(pathname) ||
     publicPaths.some((p) => pathname.startsWith(p))
   ) {
     return

--- a/packages/next-auth/tests/middleware.test.ts
+++ b/packages/next-auth/tests/middleware.test.ts
@@ -1,0 +1,40 @@
+import { NextMiddleware } from "next/server"
+import { NextAuthMiddlewareOptions, withAuth } from "../next/middleware"
+
+it("should not match pages as public paths", async () => {
+  const options: NextAuthMiddlewareOptions = {
+    pages: {
+      signIn: "/",
+      error: "/"
+    },
+    secret: "secret"
+  }
+
+  const nextUrl: any = {
+    pathname: "/protected/pathA",
+    search: "",
+    origin: "http://127.0.0.1"
+  }
+  const req: any = { nextUrl, headers: { authorization: "" } }
+
+  const handleMiddleware = withAuth(options) as NextMiddleware
+  const res = await handleMiddleware(req, null)
+  expect(res).toBeDefined()
+  expect(res.status).toBe(307)
+})
+
+it("should not redirect on public paths", async () => {
+  const options: NextAuthMiddlewareOptions = {
+    secret: "secret"
+  }
+  const nextUrl: any = {
+    pathname: "/_next/foo",
+    search: "",
+    origin: "http://127.0.0.1"
+  }
+  const req: any = { nextUrl, headers: { authorization: "" } }
+
+  const handleMiddleware = withAuth(options) as NextMiddleware
+  const res = await handleMiddleware(req, null)
+  expect(res).toBeUndefined()
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

_Something went wrong with #5085, GitHub wasn't updating the PR with the new commits_

## ☕️ Reasoning

Some users could be setting their `signIn` and `error` pages option to
`/` to disable the automatically generated pages, as suggested in https://github.com/nextauthjs/next-auth/discussions/2330#discussioncomment-1678298.

This PR reverts the behaviour for matching `signIn` and `error`
pages in `handleMiddleware` to pre-v4.10.3.

EDIT:
```
const signInPage = "/"
const errorPage = "/"
const publicPaths = [signInPage, errorPage, "/_next", "/favicon.ico"]

// pathname = "/protected" will always return true
publicPaths.some((p) => pathname.startsWith(p))
```

Fixes: aedabc8d ("fix: avoid redirect on always public paths")

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
