### PR TITLE
Azure AD: Add appid query param to wellKnown URL

### DIFF
--- a/packages/next-auth/src/providers/azure-ad.ts
+++ b/packages/next-auth/src/providers/azure-ad.ts
@@ -25,7 +25,7 @@ export default function AzureAD<P extends AzureADProfile>(
     id: "azure-ad",
     name: "Azure Active Directory",
     type: "oauth",
-    wellKnown: `https://login.microsoftonline.com/${tenant}/v2.0/.well-known/openid-configuration`,
+    wellKnown: `https://login.microsoftonline.com/${tenant}/v2.0/.well-known/openid-configuration?appid=${options.clientId}`,
     authorization: {
       params: {
         scope: "openid profile email",


### PR DESCRIPTION
## ☕️ Reasoning

Relevant [documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#validating-the-signature):

> If the application has custom signing keys as a result of using the claims-mapping feature, append an appid query parameter that contains the application ID to get a jwks_uri that points to the signing key information of the application, which should be used for validation.

## 🧢 Checklist

- [x] Documentation -> irrelevant, I think
- [x] Tests -> i don't think this code path is tested?
- [ ] Ready to be merged -> no needs to be verified

I'm not sure if applications without this feature will simply ignore the query param or if it will break for them. If someone has an Azure AD setup, it'd be nice if they could test this.
Otherwise, maybe this needs to be a flag.

## 🎫 Affected issues

This fixes: #5137

