### PR TITLE
docs(provider): added example for logging out of cognito

### DIFF
--- a/docs/docs/providers/cognito.md
+++ b/docs/docs/providers/cognito.md
@@ -47,3 +47,19 @@ Make sure you select all the appropriate client settings or the OAuth flow will 
 :::
 
 ![cognito](https://user-images.githubusercontent.com/7902980/83951604-cd096e80-a832-11ea-8bd2-c496ec9a16cb.PNG)
+
+:::tip
+To properly sign out of Cognito, you need to call the [logout](https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html) endpoint.
+For example:
+```js
+import { signOut } from 'next-auth/react';
+
+const handleSignOut = async e => {
+  e.preventDefault()
+  await signOut(); // this only clears the cookie session
+  const url = `https://YOUR_PREFIX.auth.YOUR_REGION.amazoncognito.com/logout?client_id=YOUR_CLIENT_ID&logout_uri=http://localhost:3000`;
+  window.location.href = url;
+};
+```
+Make sure that the `logout_uri` matches **exactly** the *Sign out URL(s)*.
+:::


### PR DESCRIPTION
## ☕️ Reasoning

Added a tip for logging out in Cognito

When only signOut is used, cognito isn't logged out completely. Meaning the user will still logged in after hitting signin in again without being able to input another username and password.

## 🧢 Checklist

- [x] Documentation
- [x] Ready to be merged

## 🎫 Affected issues

related to #836 and #946

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
