### PR TITLE
🐛 Save updated tokens from a new sign-in

### DIFF
--- a/packages/next-auth/src/core/lib/callback-handler.ts
+++ b/packages/next-auth/src/core/lib/callback-handler.ts
@@ -149,6 +149,13 @@ export default async function callbackHandler(params: {
             expires: fromDate(options.session.maxAge),
           })
 
+      if (account.access_token ?? account.refresh_token ?? account.id_token) {
+        // If we have any tokens in the request, then these need updating in the stored Account information.
+        // This is important as some auth providers will only allow one refresh token at a time for a given
+        // application (looking at you twitter). Failure to update them can leave the tokens in an non-working state.
+        await linkAccount({ ...account, userId: userByAccount.id })
+      }
+
       return { session, user: userByAccount, isNewUser }
     } else {
       if (user) {


### PR DESCRIPTION
## ☕️ Reasoning

When a user signs in, the response may contain an updated set of
access/id/refresh tokens. When these are present, they need
updating in the stored Account information. This is important as
some auth providers will only allow one refresh token at a time
for a given application (looking at you twitter).

Failure to update them can leave the tokens in an non-working state.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues

I'm happy to raise an issue if necessary. I hit this with the twitter provider (oauth 2.0), complete with the offline.access scope, which causes access/refresh/id tokens to be returned on a successful sign in. 
