### PR TITLE
chore: bump to node18 (current)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install

--- a/apps/example-nextjs/package.json
+++ b/apps/example-nextjs/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "^17",
+    "@types/node": "^18",
     "@types/react": "^18.0.15",
     "typescript": "^4"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@actions/core": "^1.6.0",
     "@balazsorban/monorepo-release": "0.0.4",
-    "@types/node": "^17.0.25",
+    "@types/node": "^18.7.11",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",
@@ -37,7 +37,7 @@
     "typescript": "^4.5.2"
   },
   "engines": {
-    "node": "^12.19.0 || ^14.15.0 || ^16.13.0",
+    "node": "^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.7.0",
     "pnpm": ">=6.32.3"
   },
   "prettier": {

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -103,7 +103,7 @@
     "@testing-library/react-hooks": "^8.0.0",
     "@testing-library/user-event": "^14.2.0",
     "@types/jest": "^28.1.3",
-    "@types/node": "^17.0.42",
+    "@types/node": "^18.7.11",
     "@types/nodemailer": "^6.4.4",
     "@types/oauth": "^0.9.1",
     "@types/react": "^18.0.15",
@@ -125,7 +125,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "engines": {
-    "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
+    "node": "^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.7.0"
   },
   "eslintConfig": {
     "parserOptions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ importers:
     specifiers:
       '@actions/core': ^1.6.0
       '@balazsorban/monorepo-release': 0.0.4
-      '@types/node': ^17.0.25
+      '@types/node': ^18.7.11
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^4.33.0
       eslint: ^7.32.0
@@ -24,7 +24,7 @@ importers:
     devDependencies:
       '@actions/core': 1.9.0
       '@balazsorban/monorepo-release': 0.0.4
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       '@typescript-eslint/eslint-plugin': 5.29.0_3ekaj7j3owlolnuhj3ykrb7u7i
       '@typescript-eslint/parser': 4.33.0_hxadhbs2xogijvk7vq4t2azzbu
       eslint: 7.32.0
@@ -413,7 +413,7 @@ importers:
       '@testing-library/react-hooks': ^8.0.0
       '@testing-library/user-event': ^14.2.0
       '@types/jest': ^28.1.3
-      '@types/node': ^17.0.42
+      '@types/node': ^18.7.11
       '@types/nodemailer': ^6.4.4
       '@types/oauth': ^0.9.1
       '@types/react': ^18.0.15
@@ -467,7 +467,7 @@ importers:
       '@testing-library/react-hooks': 8.0.1_bb2bxwco6ptpubzwpazr52qf6i
       '@testing-library/user-event': 14.2.1_ihvo3xlg2d6kwqju3os3zitn3y
       '@types/jest': 28.1.3
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       '@types/nodemailer': 6.4.4
       '@types/oauth': 0.9.1
       '@types/react': 18.0.15
@@ -476,7 +476,7 @@ importers:
       babel-plugin-jsx-pragmatic: 1.0.2
       babel-preset-preact: 2.0.0_@babel+core@7.18.5
       cssnano: 5.1.12_postcss@8.4.14
-      jest: 28.1.1_@types+node@17.0.45
+      jest: 28.1.1_@types+node@18.7.11
       jest-environment-jsdom: 28.1.1
       jest-watch-typeahead: 1.1.0_jest@28.1.1
       msw: 0.42.3
@@ -5049,7 +5049,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.1
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
       chalk: 4.1.2
       jest-message-util: 28.1.1
       jest-util: 28.1.1
@@ -5115,14 +5115,14 @@ packages:
       '@jest/test-result': 28.1.1
       '@jest/transform': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.3.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.0.2
-      jest-config: 28.1.1_@types+node@17.0.45
+      jest-config: 28.1.1_@types+node@18.7.11
       jest-haste-map: 28.1.1
       jest-message-util: 28.1.1
       jest-regex-util: 28.0.2
@@ -5167,7 +5167,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       jest-mock: 28.1.1
     dev: true
 
@@ -5206,7 +5206,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.1
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       jest-message-util: 28.1.1
       jest-mock: 28.1.1
       jest-util: 28.1.1
@@ -5285,7 +5285,7 @@ packages:
       '@jest/transform': 28.1.1
       '@jest/types': 28.1.1
       '@jridgewell/trace-mapping': 0.3.13
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -5450,7 +5450,7 @@ packages:
       '@jest/schemas': 28.0.2
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
       '@types/yargs': 17.0.10
       chalk: 4.1.2
     dev: true
@@ -6556,7 +6556,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
     dev: true
 
   /@types/hast/2.3.4:
@@ -6619,7 +6619,7 @@ packages:
   /@types/jsdom/16.2.14:
     resolution: {integrity: sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       '@types/parse5': 6.0.3
       '@types/tough-cookie': 4.0.2
     dev: true
@@ -6691,14 +6691,19 @@ packages:
 
   /@types/node/17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: false
 
   /@types/node/18.0.0:
     resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
 
+  /@types/node/18.7.11:
+    resolution: {integrity: sha512-KZhFpSLlmK/sdocfSAjqPETTMd0ug6HIMIAwkwUpU79olnZdQtMxpQP+G1wDzCH7na+FltSIhbaZuKdwZ8RDrw==}
+    dev: true
+
   /@types/nodemailer/6.4.4:
     resolution: {integrity: sha512-Ksw4t7iliXeYGvIQcSIgWQ5BLuC/mljIEbjf615svhZL10PE9t+ei8O9gDaD3FPCasUJn9KTLwz2JFJyiiyuqw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -6708,7 +6713,7 @@ packages:
   /@types/oauth/0.9.1:
     resolution: {integrity: sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/@types/oauth/-/oauth-0.9.1.tgz}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
     dev: true
 
   /@types/parse-json/4.0.0:
@@ -6941,7 +6946,7 @@ packages:
   /@types/set-cookie-parser/2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
     dev: true
 
   /@types/shelljs/0.8.11:
@@ -7518,8 +7523,10 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -9252,8 +9259,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -11466,7 +11473,7 @@ packages:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.0.9
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       body-parser: 1.20.0
       content-type: 1.0.4
       deep-freeze: 0.0.1
@@ -14095,7 +14102,7 @@ packages:
       '@jest/expect': 28.1.1
       '@jest/test-result': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -14144,7 +14151,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-cli/28.1.1_@types+node@17.0.45:
+  /jest-cli/28.1.1_@types+node@18.7.11:
     resolution: {integrity: sha512-+sUfVbJqb1OjBZ0OdBbI6OWfYM1i7bSfzYy6gze1F1w3OKWq8ZTEKkZ8a7ZQPq6G/G1qMh/uKqpdWhgl11NFQQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -14161,7 +14168,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.1_@types+node@17.0.45
+      jest-config: 28.1.1_@types+node@18.7.11
       jest-util: 28.1.1
       jest-validate: 28.1.1
       prompts: 2.4.2
@@ -14212,7 +14219,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config/28.1.1_@types+node@17.0.45:
+  /jest-config/28.1.1_@types+node@18.7.11:
     resolution: {integrity: sha512-tASynMhS+jVV85zKvjfbJ8nUyJS/jUSYZ5KQxLUN2ZCvcQc/OmhQl2j6VEL3ezQkNofxn5pQ3SPYWPHb0unTZA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -14227,7 +14234,7 @@ packages:
       '@babel/core': 7.18.5
       '@jest/test-sequencer': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       babel-jest: 28.1.1_@babel+core@7.18.5
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -14343,7 +14350,7 @@ packages:
       '@jest/fake-timers': 28.1.1
       '@jest/types': 28.1.1
       '@types/jsdom': 16.2.14
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       jest-mock: 28.1.1
       jest-util: 28.1.1
       jsdom: 19.0.0
@@ -14373,7 +14380,7 @@ packages:
       '@jest/environment': 28.1.1
       '@jest/fake-timers': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       jest-mock: 28.1.1
       jest-util: 28.1.1
     dev: true
@@ -14419,7 +14426,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -14536,7 +14543,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.1
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
     dev: true
 
   /jest-pnp-resolver/1.2.2_jest-resolve@27.5.1:
@@ -14666,7 +14673,7 @@ packages:
       '@jest/test-result': 28.1.1
       '@jest/transform': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.10
@@ -14832,7 +14839,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.1
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
       chalk: 4.1.2
       ci-info: 3.3.2
       graceful-fs: 4.2.10
@@ -14871,7 +14878,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 28.1.1_@types+node@17.0.45
+      jest: 28.1.1_@types+node@18.7.11
       jest-regex-util: 28.0.2
       jest-watcher: 28.1.0
       slash: 4.0.0
@@ -14898,7 +14905,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 17.0.45
+      '@types/node': 18.7.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -14912,7 +14919,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.1
       '@jest/types': 28.1.1
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -14932,7 +14939,7 @@ packages:
     resolution: {integrity: sha512-Au7slXB08C6h+xbJPp7VIb6U0XX5Kc9uel/WFc6/rcTzGiaVCBRngBExSYuXSLFPULPSYU3cJ3ybS988lNFQhQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 18.0.0
+      '@types/node': 18.7.11
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -14958,7 +14965,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest/28.1.1_@types+node@17.0.45:
+  /jest/28.1.1_@types+node@18.7.11:
     resolution: {integrity: sha512-qw9YHBnjt6TCbIDMPMpJZqf9E12rh6869iZaN08/vpOGgHJSAaLLUn6H8W3IAEuy34Ls3rct064mZLETkxJ2XA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -14971,7 +14978,7 @@ packages:
       '@jest/core': 28.1.1
       '@jest/types': 28.1.1
       import-local: 3.1.0
-      jest-cli: 28.1.1_@types+node@17.0.45
+      jest-cli: 28.1.1_@types+node@18.7.11
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -18571,6 +18578,12 @@ packages:
   /react-dev-utils/12.0.1_webpack@5.73.0:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       address: 1.2.0
@@ -18596,12 +18609,11 @@ packages:
       shell-quote: 1.7.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.73.0
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
     dev: false
 
   /react-dom/18.2.0_react@18.2.0:
@@ -19357,7 +19369,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: false
 
@@ -21379,6 +21391,7 @@ packages:
   /unified/8.4.2:
     resolution: {integrity: sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-plain-obj: 2.1.0
@@ -21389,6 +21402,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5


### PR DESCRIPTION
## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

NodeJS v18 is supposed to become LTS in a few weeks (2022-10-25), so IMO we should starting to base the development upon it.

I only tried if the build fails, which apparently it doesn't.

Opening this up for discussions, as I don't know which implications this might have.

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [?] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
