### PR TITLE
docs(nextjs): change typo from js to ts

### DIFF
--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -12,7 +12,7 @@ Otherwise, if you only want to get the session token, see [`getToken`](/tutorial
 
 `unstable_getServerSession` requires passing the same object you would pass to `NextAuth` when initializing NextAuth.js. To do so, you can export your NextAuth.js options in the following way:
 
-In `[...nextauth].js`:
+In `[...nextauth].ts`:
 ```ts
 import { NextAuth } from 'next-auth'
 import type { NextAuthOptions } from 'next-auth'


### PR DESCRIPTION
## ☕️ Reasoning
Changing `js` to `ts` on docs [https://next-auth.js.org/configuration/nextjs#unstable_getserversession](https://next-auth.js.org/configuration/nextjs#unstable_getserversession)
Im changing this because on the docs, appears js an then the following example is a `typescript` code:
<img width="501" alt="image" src="https://user-images.githubusercontent.com/58749813/186536568-a3840794-0aad-4723-bf4b-eeda330fae46.png">

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
