### PR TITLE
fix: return null in unstable_getServerSession if there's an error

### DIFF
--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -107,7 +107,7 @@ export async function unstable_getServerSession(
 
   options.secret = options.secret ?? process.env.NEXTAUTH_SECRET
 
-  const session = await NextAuthHandler<Session | {}>({
+  const session = await NextAuthHandler<Session | {} | string>({
     options,
     req: {
       host: detectHost(req.headers["x-forwarded-host"]),
@@ -118,13 +118,12 @@ export async function unstable_getServerSession(
     },
   })
 
-  const { body, cookies, status } = session
+  const { body, cookies } = session
 
   cookies?.forEach((cookie) => setCookie(res, cookie))
 
-  const error = status && status !== 200
-
-  if (!error && body && Object.keys(body).length) return body as Session
+  if (body && typeof body !== "string" && Object.keys(body).length)
+    return body as Session
 
   return null
 }

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -118,11 +118,14 @@ export async function unstable_getServerSession(
     },
   })
 
-  const { body, cookies } = session
+  const { body, cookies, status } = session
 
   cookies?.forEach((cookie) => setCookie(res, cookie))
 
-  if (body && Object.keys(body).length) return body as Session
+  const error = status && status !== 200
+
+  if (!error && body && Object.keys(body).length) return body as Session
+
   return null
 }
 

--- a/packages/next-auth/tests/getServerSession.test.ts
+++ b/packages/next-auth/tests/getServerSession.test.ts
@@ -45,8 +45,12 @@ describe("Treat secret correctly", () => {
   })
 
   it("Error if missing NEXTAUTH_SECRET and secret", async () => {
-    await unstable_getServerSession(req, res, { providers: [], logger })
+    const session = await unstable_getServerSession(req, res, {
+      providers: [],
+      logger,
+    })
 
+    expect(session).toEqual(null)
     expect(logger.error).toBeCalledTimes(1)
     expect(logger.error).toBeCalledWith("NO_SECRET", expect.any(MissingSecret))
   })
@@ -80,17 +84,6 @@ describe("Return correct data", () => {
       providers: [],
       logger,
       secret: "secret",
-    })
-
-    expect(session).toEqual(null)
-  })
-
-  it("Should return null if there is a config error", async () => {
-    // Forced a `NO_SECRET` error underneath because no secret in the config
-    // and NEXTAUTH_SECRET doesn't exist either.
-    const session = await unstable_getServerSession(req, res, {
-      providers: [],
-      logger,
     })
 
     expect(session).toEqual(null)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Make sure `unstable_getServerSession` returns null if there's a config error underneath. Previously in that scenario, it was returning a string of the error page HTML (see linked issue for details).

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #5166 

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
