### PR TITLE
Linkedin requires client_id and client_secret

### DIFF
--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -119,7 +119,15 @@ export default async function oAuthCallback(params: {
     } else if (provider.idToken) {
       tokens = await client.callback(provider.callbackUrl, params, checks)
     } else {
-      tokens = await client.oauthCallback(provider.callbackUrl, params, checks)
+      let additionalParams = {}
+      if(provider.id === "linkedin") {
+        // LinkedIn requires a client_id and client_secret to be passed in the
+        // request body.
+        additionalParams = {
+          exchangeBody: {client_id: provider.clientId, client_secret: provider.clientSecret},
+        }
+      }
+      tokens = await client.oauthCallback(provider.callbackUrl, params, checks, additionalParams)
     }
 
     // REVIEW: How can scope be returned as an array?


### PR DESCRIPTION
Linkedin requires client_id and client_secret as part of the callback request body. This patch adds them.
Fixes #5220

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Linkedin now requires client_id and client_secret parameters.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #5220 

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
