### PR TITLE
fix: Change getToken parameter type to required

### DIFF
--- a/packages/next-auth/src/jwt/index.ts
+++ b/packages/next-auth/src/jwt/index.ts
@@ -66,7 +66,7 @@ export interface GetTokenParams<R extends boolean = false> {
  * [Documentation](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#using-gettoken)
  */
 export async function getToken<R extends boolean = false>(
-  params?: GetTokenParams<R>
+  params: GetTokenParams<R>
 ): Promise<R extends true ? string : JWT | null> {
   const {
     req,

--- a/packages/next-auth/src/jwt/index.ts
+++ b/packages/next-auth/src/jwt/index.ts
@@ -79,7 +79,7 @@ export async function getToken<R extends boolean = false>(
     decode: _decode = decode,
     logger = console,
     secret = process.env.NEXTAUTH_SECRET,
-  } = params ?? {}
+  } = params
 
   if (!req) throw new Error("Must pass `req` to JWT getToken()")
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

This PR changes the parameter TypeScript type for `getToken` to required as previously it was optional.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: [getToken requires request to be passed but has params as optional](https://github.com/nextauthjs/next-auth/issues/5226)

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
