### PR TITLE
feat(adapters): let user configure MongoDB database name

### DIFF
--- a/packages/adapter-mongodb/README.md
+++ b/packages/adapter-mongodb/README.md
@@ -73,7 +73,7 @@ import clientPromise from "lib/mongodb"
 // https://next-auth.js.org/configuration/options
 export default NextAuth({
   adapter: MongoDBAdapter(clientPromise, {
-    dataBaseName: 'my-data-base-name'
+    databaseName: 'my-data-base-name'
   }),
   ...
 })

--- a/packages/adapter-mongodb/README.md
+++ b/packages/adapter-mongodb/README.md
@@ -72,7 +72,9 @@ import clientPromise from "lib/mongodb"
 // For more information on each option (and a full list of options) go to
 // https://next-auth.js.org/configuration/options
 export default NextAuth({
-  adapter: MongoDBAdapter(clientPromise),
+  adapter: MongoDBAdapter(clientPromise, {
+    dataBaseName: 'my-data-base-name'
+  }),
   ...
 })
 ```

--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -17,7 +17,7 @@ export interface MongoDBAdapterOptions {
     Sessions?: string
     VerificationTokens?: string
   }
-  dataBaseName?: string
+  databaseName?: string
 }
 
 export const defaultCollections: Required<
@@ -74,7 +74,7 @@ export function MongoDBAdapter(
   const { from, to } = format
 
   const db = (async () => {
-    const _db = (await client).db(options.dataBaseName)
+    const _db = (await client).db(options.databaseName)
     const c = { ...defaultCollections, ...collections }
     return {
       U: _db.collection<AdapterUser>(c.Users),

--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -17,6 +17,7 @@ export interface MongoDBAdapterOptions {
     Sessions?: string
     VerificationTokens?: string
   }
+  dataBaseName?: string
 }
 
 export const defaultCollections: Required<
@@ -73,7 +74,7 @@ export function MongoDBAdapter(
   const { from, to } = format
 
   const db = (async () => {
-    const _db = (await client).db()
+    const _db = (await client).db(options.dataBaseName)
     const c = { ...defaultCollections, ...collections }
     return {
       U: _db.collection<AdapterUser>(c.Users),


### PR DESCRIPTION
## ☕️ Reasoning

Providing database name is important, because, by default it is "test", and if you use another name in your application, you can't get user data without additional code.

## 🧢 Checklist

- [x] Documentation
- [x] Tests (not needed)
- [x] Ready to be merged

## 🎫 Affected issues
Fixes: https://github.com/nextauthjs/next-auth/issues/5289

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
