### PR TITLE
Add option for custom generateSessionToken

### DIFF
--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -114,6 +114,12 @@ session: {
   // Use it to limit write operations. Set to 0 to always update the database.
   // Note: This option is ignored if using JSON Web Tokens
   updateAge: 24 * 60 * 60, // 24 hours
+  
+  // The session token is usually either a random UUID or string, however if you
+  // need a more customized session token string, you can define your own generate function.
+  generateSessionToken: () => {
+    return randomUUID?.() ?? randomBytes(32).toString("hex")
+  }
 }
 ```
 

--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -1,3 +1,4 @@
+import { randomBytes, randomUUID } from "crypto"
 import { NextAuthOptions } from ".."
 import logger from "../utils/logger"
 import parseUrl from "../utils/parse-url"
@@ -86,6 +87,10 @@ export async function init({
       strategy: userOptions.adapter ? "database" : "jwt",
       maxAge,
       updateAge: 24 * 60 * 60,
+      generateSessionToken: () => {
+        // Use `randomUUID` if available. (Node 15.6++)
+        return randomUUID?.() ?? randomBytes(32).toString("hex")
+      },
       ...userOptions.session,
     },
     // JWT options

--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -88,7 +88,7 @@ export async function init({
       maxAge,
       updateAge: 24 * 60 * 60,
       generateSessionToken: () => {
-        // Use `randomUUID` if available. (Node 15.6++)
+        // Use `randomUUID` if available. (Node 15.6+)
         return randomUUID?.() ?? randomBytes(32).toString("hex")
       },
       ...userOptions.session,

--- a/packages/next-auth/src/core/lib/callback-handler.ts
+++ b/packages/next-auth/src/core/lib/callback-handler.ts
@@ -1,4 +1,3 @@
-import { randomBytes, randomUUID } from "crypto"
 import { AccountNotLinkedError } from "../errors"
 import { fromDate } from "./utils"
 
@@ -37,7 +36,7 @@ export default async function callbackHandler(params: {
     adapter,
     jwt,
     events,
-    session: { strategy: sessionStrategy },
+    session: { strategy: sessionStrategy, generateSessionToken },
   } = options
 
   // If no adapter is configured then we don't have a database and cannot
@@ -218,9 +217,4 @@ export default async function callbackHandler(params: {
       return { session, user, isNewUser: true }
     }
   }
-}
-
-function generateSessionToken() {
-  // Use `randomUUID` if available. (Node 15.6++)
-  return randomUUID?.() ?? randomBytes(32).toString("hex")
 }

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -470,9 +470,9 @@ export interface SessionOptions {
   updateAge: number
   /**
    * Generate a custom session token for database-based sessions.
-   * By default, a random UUID or string is generated depending on Node version
-   * however, you can specific your own custom string (such as cuids) to be used.
-   * @default randomUUID or randomBytes.toHex depending on Node version
+   * By default, a random UUID or string is generated depending on the Node.js version.
+   * However, you can specify your own custom string (such as CUID) to be used.
+   * @default `randomUUID` or `randomBytes.toHex` depending on the Node.js version
    */
   generateSessionToken: () => string
 }

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -468,6 +468,13 @@ export interface SessionOptions {
    * @default 86400 // 1 day
    */
   updateAge: number
+  /**
+   * Generate a custom session token for database-based sessions.
+   * By default, a random UUID or string is generated depending on Node version
+   * however, you can specific your own custom string (such as cuids) to be used.
+   * @default randomUUID or randomBytes.toHex depending on Node version
+   */
+  generateSessionToken: () => string
 }
 
 export interface DefaultUser {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Instead of a random UUID, I want to leverage `cuid` as the session token. This PR allows the ability to define a custom `generateSessionToken` function and return the custom session token. Leverage original logic (random UUID) by default.

## 🧢 Checklist

- [x] Documentation
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: N/A

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
