### PR TITLE
replace onFail with onUnauthenticated in client docs

### DIFF
--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -67,7 +67,7 @@ export default function Component() {
 
 Due to the way how Next.js handles `getServerSideProps` and `getInitialProps`, every protected page load has to make a server-side request to check if the session is valid and then generate the requested page (SSR). This increases server load, and if you are good with making the requests from the client, there is an alternative. You can use `useSession` in a way that makes sure you always have a valid session. If after the initial loading state there was no session found, you can define the appropriate action to respond.
 
-The default behavior is to redirect the user to the sign-in page, from where - after a successful login - they will be sent back to the page they started on. You can also define an `onFail()` callback, if you would like to do something else:
+The default behavior is to redirect the user to the sign-in page, from where - after a successful login - they will be sent back to the page they started on. You can also define an `onUnauthenticated()` callback, if you would like to do something else:
 
 #### Example
 


### PR DESCRIPTION
## ☕️ Reasoning

The `onFail()` callback currently listed in the docs doesn't exist and it should be listed as `onUnauthenticated()` instead

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

None that I can see

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
