### PR TITLE
Update prisma.md

### DIFF
--- a/docs/docs/adapters/prisma.md
+++ b/docs/docs/adapters/prisma.md
@@ -29,7 +29,7 @@ Configure your NextAuth.js to use the Prisma Adapter:
 import NextAuth from "next-auth"
 import GoogleProvider from "next-auth/providers/google"
 import { PrismaAdapter } from "@next-auth/prisma-adapter"
-import prisma from "../../../lib/prisma"
+import prisma from "../../../lib/prismadb"
 
 export default NextAuth({
   adapter: PrismaAdapter(prisma),

--- a/docs/docs/adapters/prisma.md
+++ b/docs/docs/adapters/prisma.md
@@ -33,6 +33,10 @@ export default NextAuth({
 })
 ```
 
+:::note
+In development, to prevent multiple client instances from creating, apply the [Best practice for instantiating PrismaClient with Next.js](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices).
+:::
+
 Schema for the Prisma Adapter (`@next-auth/prisma-adapter`)
 
 ## Setup

--- a/docs/docs/adapters/prisma.md
+++ b/docs/docs/adapters/prisma.md
@@ -12,15 +12,24 @@ npm install next-auth @prisma/client @next-auth/prisma-adapter
 npm install prisma --save-dev
 ```
 
+Create a file with your Prisma Client:
+
+```javascript title="lib/prismadb.js"
+import { PrismaClient } from "@prisma/client"
+
+const client = globalThis.prisma || new PrismaClient()
+if (process.env.NODE_ENV !== "production") globalThis.prisma = client
+
+export default client
+```
+
 Configure your NextAuth.js to use the Prisma Adapter:
 
 ```javascript title="pages/api/auth/[...nextauth].js"
 import NextAuth from "next-auth"
 import GoogleProvider from "next-auth/providers/google"
 import { PrismaAdapter } from "@next-auth/prisma-adapter"
-import { PrismaClient } from "@prisma/client"
-
-const prisma = new PrismaClient()
+import prisma from "../../../lib/prisma"
 
 export default NextAuth({
   adapter: PrismaAdapter(prisma),
@@ -32,10 +41,6 @@ export default NextAuth({
   ],
 })
 ```
-
-:::note
-In development, to prevent multiple client instances from creating, apply the [Best practice for instantiating PrismaClient with Next.js](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices).
-:::
 
 Schema for the Prisma Adapter (`@next-auth/prisma-adapter`)
 


### PR DESCRIPTION
## ☕️ Reasoning

When using NextAuth with the given Prisma example in local development, the console gives the error:
```
warn(prisma-client) There are already 10 instances of Prisma Client actively running.
```
After searching, the official docs on Prisma's site describe a best practice to use in this case. This method is slightly different from your example, hence the suggestion to include the reference to it as a note underneath the example.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

No issue found concerning this.

## 📌 Resources

- [Best practice for instantiating PrismaClient with Next.js](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices)
