### PR TITLE
fix: update jose to fix nextjs edge error with middleware

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -70,7 +70,7 @@
     "@babel/runtime": "^7.16.3",
     "@panva/hkdf": "^1.0.1",
     "cookie": "^0.5.0",
-    "jose": "^4.3.7",
+    "jose": "^4.9.3",
     "oauth": "^0.9.15",
     "openid-client": "^5.1.0",
     "preact": "^10.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,7 +433,7 @@ importers:
       jest: ^28.1.1
       jest-environment-jsdom: ^28.1.1
       jest-watch-typeahead: ^1.1.0
-      jose: ^4.3.7
+      jose: ^4.9.3
       msw: ^0.42.3
       next: 12.2.0
       oauth: ^0.9.15
@@ -451,7 +451,7 @@ importers:
       '@babel/runtime': 7.18.3
       '@panva/hkdf': 1.0.2
       cookie: 0.5.0
-      jose: 4.8.1
+      jose: 4.9.3
       oauth: 0.9.15
       openid-client: 5.1.6
       preact: 10.8.2
@@ -14514,8 +14514,8 @@ packages:
       valid-url: 1.0.9
     dev: true
 
-  /jose/4.8.1:
-    resolution: {integrity: sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==}
+  /jose/4.9.3:
+    resolution: {integrity: sha512-f8E/z+T3Q0kA9txzH2DKvH/ds2uggcw0m3vVPSB9HrSkrQ7mojjifvS7aR8cw+lQl2Fcmx9npwaHpM/M3GD8UQ==}
     dev: false
 
   /js-beautify/1.14.4:
@@ -16427,7 +16427,7 @@ packages:
     resolution: {integrity: sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==}
     engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
     dependencies:
-      jose: 4.8.1
+      jose: 4.9.3
       lru-cache: 6.0.0
       object-hash: 2.2.0
       oidc-token-hash: 5.0.1


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Just a update of latest jose dependency, will fix https://github.com/nextauthjs/next-auth/issues/5374

Basically when building a nextjs-app, you'll get

```console
A Node.js API is used (process.versions at line: 6) which is not supported in the Edge Runtime.
Import trace for requested module:
../../node_modules/jose/dist/browser/runtime/jwk_to_key.js (...)
./src/middleware.ts
```

```console
$ yarn why
├─ next-auth@npm:4.10.3
│  └─ jose@npm:4.3.7 (via npm:^4.3.7)
```

The problem was fixed upstream in the jose library v4.8.0. 

As I installed next-auth long ago and wasn't using middlewares, jose wasn't updated in the lock file by subsequent updates. So I still got the old one (at least with yarn 3+, not sure about npm, pnpm)


This P/R just prevent this issue, by requiring a version that at least works in the edge/workers.


PS:

Workarounds: 
- explicitly add jose as a direct dep in my project and dedupe: like this https://github.com/belgattitude/nextjs-monorepo-example/pull/2622/commits/f7d8b1f6bc13362d5d6d19ce7e35a0d19330f324
- recreate the lock file (less a good idea)

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Will close this: https://github.com/nextauthjs/next-auth/pull/5372

PS: another has been closed before: https://github.com/nextauthjs/next-auth/issues/4806, but I suspect the author did recreate a new lock file

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
