### PR TITLE
fix(jwt): sort chunk cookies by key num index

### DIFF
--- a/packages/next-auth/src/core/lib/cookie.ts
+++ b/packages/next-auth/src/core/lib/cookie.ts
@@ -111,7 +111,7 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
         path: "/",
         secure: useSecureCookies,
       },
-    }
+    },
   }
 }
 
@@ -120,6 +120,18 @@ export interface Cookie extends CookieOption {
 }
 
 type Chunks = Record<string, string>
+
+/**
+ * Sort cookies by chunk name to avoid joining them in the wrong order
+ */
+function sortedObject(obj) {
+  const index = Object.keys(obj).sort()
+  const sorted = {}
+  index.forEach((key) => {
+    sorted[key] = obj[key]
+  })
+  return sorted
+}
 
 export class SessionStore {
   #chunks: Chunks = {}
@@ -152,7 +164,7 @@ export class SessionStore {
   }
 
   get value() {
-    return Object.values(this.#chunks)?.join("")
+    return Object.values(sortedObject(this.#chunks))?.join("")
   }
 
   /** Given a cookie, return a list of cookies, chunked to fit the allowed cookie size. */

--- a/packages/next-auth/tests/jwt.test.ts
+++ b/packages/next-auth/tests/jwt.test.ts
@@ -1,0 +1,23 @@
+import { SessionStore } from "../src/core/lib/cookie"
+
+it("should result in the correct cookie order", async () => {
+  const cookieName = "__Secure-next-auth.session-token"
+  const logger = console
+  const sessionStore = new SessionStore(
+    { name: cookieName, options: { secure: true } },
+    {
+      cookies: {
+        [`${cookieName}.2`]: "2",
+        [`${cookieName}.0`]: "0",
+        [`${cookieName}.1`]: "1",
+      },
+      headers: {
+        cookie: `${cookieName}.2=2; ${cookieName}.0=0; ${cookieName}.1=1`,
+      },
+    },
+    logger
+  )
+
+  // Order should always follow numeric order of keys
+  expect(sessionStore.value).toBe("012")
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

What changes are being made? What feature/bug is being fixed here?

I'm adding in a sort function on cookie chunks in the JWT `SessionStore` value to ensure that when these chunks are received in the wrong order from the browser that they are joined in the correct order and do not cause null sessions or JWE decryption errors in production.

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

- No issue on this repo was found

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
