### PR TITLE
Export SessionContext solve #5437

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -74,7 +74,7 @@ export type SessionContextValue<R extends boolean = false> = R extends true
       | { data: Session; status: "authenticated" }
       | { data: null; status: "unauthenticated" | "loading" }
 
-const SessionContext = React.createContext<SessionContextValue | undefined>(
+export const SessionContext = React.createContext<SessionContextValue | undefined>(
   undefined
 )
 


### PR DESCRIPTION
## ☕️ Reasoning

Exporting the SessionContext variable allows customising of SessionProvider for mocking and testing.

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes #5437
