### PR TITLE
fix(example-nextjs): hydrate problem in react18

### DIFF
--- a/apps/example-nextjs/pages/protected.tsx
+++ b/apps/example-nextjs/pages/protected.tsx
@@ -4,8 +4,7 @@ import Layout from "../components/layout"
 import AccessDenied from "../components/access-denied"
 
 export default function ProtectedPage() {
-  const { data: session, status } = useSession()
-  const loading = status === "loading"
+  const { data: session } = useSession()
   const [content, setContent] = useState()
 
   // Fetch content from protected route
@@ -19,9 +18,7 @@ export default function ProtectedPage() {
     }
     fetchData()
   }, [session])
-
-  // When rendering client side don't display anything until loading is complete
-  if (typeof window !== "undefined" && loading) return null
+ 
 
   // If no session exists, display access denied message
   if (!session) {


### PR DESCRIPTION
## ☕️ Reasoning
https://user-images.githubusercontent.com/15878786/192699837-c3acf773-47bc-4fd4-b076-38faa53c81a3.mov

Currently https://next-auth-example.vercel.app/protected will render its content twice beacause of **hydration mismatch**

In initial render, the server will render 
https://github.com/nextauthjs/next-auth/blob/54b1845e58a7b7ca10762d8e272a10d9eb431d66/apps/example-nextjs/pages/protected.tsx#L27-L33 into html correctly.

But the client render result is null because of https://github.com/nextauthjs/next-auth/blob/54b1845e58a7b7ca10762d8e272a10d9eb431d66/apps/example-nextjs/pages/protected.tsx#L24, which is different from initial html content. 

In react 17, the initial content in `<div id="__next"><div>` will be removed.
In react 18, it will be kept


## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged


