### PR TITLE
fix(core): return JSON for non-HTML server route errors

### DIFF
--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -96,7 +96,7 @@ export async function NextAuthHandler<
     // Bail out early if there's an error in the user config
     logger.error(assertionResult.code, assertionResult)
 
-    const htmlPages = ["signin", "verify-request", "signout"]
+    const htmlPages = ["signin", "signout", "error", "verify-request"]
     if (!htmlPages.includes(req.action) || req.method !== "GET") {
       const message = `There is a problem with the server configuration. Check the server logs for more information.`
       return {
@@ -108,7 +108,7 @@ export async function NextAuthHandler<
     const { pages, theme } = userOptions
 
     const authOnErrorPage =
-      pages?.error && req.query?.callbackUrl.startsWith(pages.error)
+      pages?.error && req.query?.callbackUrl?.startsWith(pages.error)
 
     if (!pages?.error || authOnErrorPage) {
       if (authOnErrorPage) {

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -94,13 +94,21 @@ export async function NextAuthHandler<
     assertionResult.forEach(logger.warn)
   } else if (assertionResult instanceof Error) {
     // Bail out early if there's an error in the user config
-    const { pages, theme } = userOptions
     logger.error(assertionResult.code, assertionResult)
 
+    const htmlPages = ["signin", "verify-request", "signout"]
+    if (!htmlPages.includes(req.action) || req.method !== "GET") {
+      const message = `There is a problem with the server configuration. Check the server logs for more information.`
+      return {
+        status: 500,
+        headers: [{ key: "Content-Type", value: "application/json" }],
+        body: { message } as any,
+      }
+    }
+    const { pages, theme } = userOptions
+
     const authOnErrorPage =
-      pages?.error &&
-      req.action === "signin" &&
-      req.query?.callbackUrl.startsWith(pages.error)
+      pages?.error && req.query?.callbackUrl.startsWith(pages.error)
 
     if (!pages?.error || authOnErrorPage) {
       if (authOnErrorPage) {

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -122,8 +122,10 @@ export async function unstable_getServerSession(
 
   cookies?.forEach((cookie) => setCookie(res, cookie))
 
-  if (body && typeof body !== "string" && Object.keys(body).length)
+  if (body && typeof body !== "string" && Object.keys(body).length) {
+    if (session.status === 500) throw new Error((body as any).message)
     return body as Session
+  }
 
   return null
 }

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -118,13 +118,13 @@ export async function unstable_getServerSession(
     },
   })
 
-  const { body, cookies } = session
+  const { body, cookies, status = 200 } = session
 
   cookies?.forEach((cookie) => setCookie(res, cookie))
 
   if (body && typeof body !== "string" && Object.keys(body).length) {
-    if (session.status === 500) throw new Error((body as any).message)
-    return body as Session
+    if (status === 200) return body as Session
+    throw new Error((body as any).message)
   }
 
   return null

--- a/packages/next-auth/tests/getServerSession.test.ts
+++ b/packages/next-auth/tests/getServerSession.test.ts
@@ -47,17 +47,19 @@ describe("Treat secret correctly", () => {
   })
 
   it("Error if missing NEXTAUTH_SECRET and secret", async () => {
-    const session = await unstable_getServerSession(req, res, {
-      providers: [],
-      logger,
-    })
+    const configError = new Error(
+      "There is a problem with the server configuration. Check the server logs for more information."
+    )
+    await expect(
+      unstable_getServerSession(req, res, { providers: [], logger })
+    ).rejects.toThrowError(configError)
 
-    expect(session).toEqual(null)
     expect(logger.error).toBeCalledTimes(1)
     expect(logger.error).toBeCalledWith("NO_SECRET", expect.any(MissingSecret))
   })
 
   it("Only logs warning once and in development", async () => {
+    process.env.NEXTAUTH_SECRET = "secret"
     // Expect console.warn to NOT be called due to NODE_ENV=production
     await unstable_getServerSession(req, res, { providers: [], logger })
     expect(console.warn).toBeCalledTimes(0)
@@ -71,6 +73,7 @@ describe("Treat secret correctly", () => {
     // Expect console.warn to be still only be called ONCE
     await unstable_getServerSession(req, res, { providers: [], logger })
     expect(console.warn).toBeCalledTimes(1)
+    delete process.env.NEXTAUTH_SECRET
   })
 })
 

--- a/packages/next-auth/tests/middleware.test.ts
+++ b/packages/next-auth/tests/middleware.test.ts
@@ -1,40 +1,40 @@
 import { NextMiddleware } from "next/server"
-import { NextAuthMiddlewareOptions, withAuth } from "../next/middleware"
+import { NextAuthMiddlewareOptions, withAuth } from "../src/next/middleware"
 
 it("should not match pages as public paths", async () => {
   const options: NextAuthMiddlewareOptions = {
     pages: {
       signIn: "/",
-      error: "/"
+      error: "/",
     },
-    secret: "secret"
+    secret: "secret",
   }
 
   const nextUrl: any = {
     pathname: "/protected/pathA",
     search: "",
-    origin: "http://127.0.0.1"
+    origin: "http://127.0.0.1",
   }
   const req: any = { nextUrl, headers: { authorization: "" } }
 
   const handleMiddleware = withAuth(options) as NextMiddleware
-  const res = await handleMiddleware(req, null)
+  const res = await handleMiddleware(req, null as any)
   expect(res).toBeDefined()
-  expect(res.status).toBe(307)
+  expect(res?.status).toBe(307)
 })
 
 it("should not redirect on public paths", async () => {
   const options: NextAuthMiddlewareOptions = {
-    secret: "secret"
+    secret: "secret",
   }
   const nextUrl: any = {
     pathname: "/_next/foo",
     search: "",
-    origin: "http://127.0.0.1"
+    origin: "http://127.0.0.1",
   }
   const req: any = { nextUrl, headers: { authorization: "" } }
 
   const handleMiddleware = withAuth(options) as NextMiddleware
-  const res = await handleMiddleware(req, null)
+  const res = await handleMiddleware(req, null as any)
   expect(res).toBeUndefined()
 })


### PR DESCRIPTION
In certain cases when the documentation is not followed, deployments on serverless platforms like Vercel can lead to unexpected rate limiting, since the code ends up in an infinite loop.

It is important to always follow the documentation (Eg. for Vercel, we have a dedicated section here: https://next-auth.js.org/deployment#vercel).

But in this case, we can bail out early from unexpected redirect loops by sending a proper JSON response for requests that expect a non-HTML response.

Let's look at the following example:

```js
// `pages/api/auth/[...nextauth].js` with custom pages

import NextAuth from "next-auth"
import GitHub from "next-auth/providers/github"

export default NextAuth({
  pages: { error: "/auth/login", signIn: "/auth/login" },
  providers: [
    GitHub({
      clientId: process.env.GOOGLE_ID,
      clientSecret: process.env.GOOGLE_SECRET,
    }),
  ],
})

// Custom login page at `pages/auth/login.jsx`.

import { getSession, signIn } from "next-auth/react"

export default function Login() {
  return <button onClick={() => signIn("github")}>Log in</button>
}

export async function getServerSideProps(ctx) {
  const session = await getSession(ctx)
  if (!session) return { props: {} }
  return { redirect: { destination: "/logged-in" } }
}
```

This looks innocent enough, but if the developer forgets to set `NEXTAUTH_SECRET`, the `getSession()` call until now would have returned with a redirect to the same error page (since NextAuth.js identified the missing secret as a misconfiguration). But that error page will call `getSession()` again, and an infinite loop can start.

To avoid this, we now terminate `getSession()` (and similar methods that would expect a JSON response) with a `500` status response and an error message:

> There is a problem with the server configuration. Check the server logs for more information.

The error cause will be logged in the server-side so the developer can fix the issue and after a redeploy, everything should be working fine.