### PR TITLE
fix: safe use of localStorage API

### DIFF
--- a/packages/next-auth/src/client/_utils.ts
+++ b/packages/next-auth/src/client/_utils.ts
@@ -94,10 +94,18 @@ export function BroadcastChannel(name = "nextauth.message") {
     /** Notify other tabs/windows. */
     post(message: Record<string, unknown>) {
       if (typeof window === "undefined") return
-      localStorage.setItem(
-        name,
-        JSON.stringify({ ...message, timestamp: now() })
-      )
+      try {
+        localStorage.setItem(
+          name,
+          JSON.stringify({ ...message, timestamp: now() })
+        )
+      } catch {
+        /**
+         * The localStorage API isn't always available.
+         * It won't work in private mode prior to Safari 11 for example.
+         * Notifications are simply dropped if an error is encountered.
+         */
+      }
     },
   }
 }


### PR DESCRIPTION
## ☕️ Reasoning

The `localStorage` API can be traitorous. Making sure that it exists on the `window` object is not enough. In some cases browsers will define the `localStorage` property but will set it to `null`. Some will throw an error when trying to use its methods.

We are using `next-auth` in production on a high traffic website and it results in hundreds of thousands of errors (`Cannot read properties of null (reading 'setItem')`) per minute due to the lack of `localStorage` on some browsers.

For this reason, I added a try/catch to handle cases where the API might not be available.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged