### PR TITLE
fix(providers): change EVE Online to OAuth2

### DIFF
--- a/packages/next-auth/src/providers/eveonline.ts
+++ b/packages/next-auth/src/providers/eveonline.ts
@@ -17,14 +17,9 @@ export default function EVEOnline<P extends EVEOnlineProfile>(
     id: "eveonline",
     name: "EVE Online",
     type: "oauth",
-    wellKnown:
-      "https://login.eveonline.com/.well-known/oauth-authorization-server",
-    authorization: {
-      params: {
-        scope: "publicData",
-      },
-    },
-    idToken: true,
+    authorization: "https://login.eveonline.com/v2/oauth/authorize?scope=publicData",
+    token: "https://login.eveonline.com/v2/oauth/token",
+    userinfo: "https://login.eveonline.com/oauth/verify",
     profile(profile) {
       return {
         id: String(profile.CharacterID),


### PR DESCRIPTION
## ☕️ Reasoning

This PR fixes #3760, which is being caused by missing `id_token` in EvE authentication response as well as missing `userinfo_endpoint` in `.well-known` OIDC configuration.

This PR updates the eve configuration to manually specify endpoints for auth, token, and userinfo.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: #3760
