### PR TITLE
feat(adapters): allow `Account` mapping before DB

### DIFF
--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -1,8 +1,25 @@
-import { Account, User, Awaitable } from "."
+import type { Account, User, Awaitable } from "."
+import type { ProviderType } from "./providers"
 
 export interface AdapterUser extends User {
   id: string
   emailVerified: Date | null
+}
+
+export interface AdapterAccount extends Account {
+  /**
+   * This value depends on the type of the provider being used to create the account.
+   * - oauth: The OAuth account's id, returned from the `profile()` callback.
+   * - email: The user's email address.
+   * - credentials: `id` returned from the `authorize()` callback
+   */
+  providerAccountId: string
+  /** id of the user this account belongs to. */
+  userId: string
+  /** id of the provider used for this account */
+  provider: string
+  /** Provider's type for this account */
+  type: ProviderType
 }
 
 export interface AdapterSession {
@@ -61,7 +78,7 @@ export interface Adapter {
   getUserByEmail: (email: string) => Awaitable<AdapterUser | null>
   /** Using the provider id and the id of the user for a specific account, get the user. */
   getUserByAccount: (
-    providerAccountId: Pick<Account, "provider" | "providerAccountId">
+    providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">
   ) => Awaitable<AdapterUser | null>
   updateUser: (user: Partial<AdapterUser>) => Awaitable<AdapterUser>
   /** @todo Implement */
@@ -69,12 +86,12 @@ export interface Adapter {
     userId: string
   ) => Promise<void> | Awaitable<AdapterUser | null | undefined>
   linkAccount: (
-    account: Account
-  ) => Promise<void> | Awaitable<Account | null | undefined>
+    account: AdapterAccount
+  ) => Promise<void> | Awaitable<AdapterAccount | null | undefined>
   /** @todo Implement */
   unlinkAccount?: (
-    providerAccountId: Pick<Account, "provider" | "providerAccountId">
-  ) => Promise<void> | Awaitable<Account | undefined>
+    providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">
+  ) => Promise<void> | Awaitable<AdapterAccount | undefined>
   /** Creates a session for the user and returns it. */
   createSession: (session: {
     sessionToken: string

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -231,23 +231,8 @@ export type TokenSet = TokenSetParameters
  * Usually contains information about the provider being used
  * and also extends `TokenSet`, which is different tokens returned by OAuth Providers.
  */
-export interface DefaultAccount extends Partial<TokenSet> {
-  /**
-   * This value depends on the type of the provider being used to create the account.
-   * - oauth: The OAuth account's id, returned from the `profile()` callback.
-   * - email: The user's email address.
-   * - credentials: `id` returned from the `authorize()` callback
-   */
-  providerAccountId: string
-  /** id of the user this account belongs to. */
-  userId: string
-  /** id of the provider used for this account */
-  provider: string
-  /** Provider's type for this account */
-  type: ProviderType
-}
 
-export interface Account extends Record<string, unknown>, DefaultAccount {}
+export interface Account extends Partial<TokenSet> {}
 
 export interface DefaultProfile {
   sub?: string

--- a/packages/next-auth/src/providers/oauth.ts
+++ b/packages/next-auth/src/providers/oauth.ts
@@ -123,7 +123,10 @@ export interface OAuthConfig<P, A = any>
    * If set to `"minimal"`
    * @default "pass-through"
    */
-  account?: "minimal" | "pass-through" | ((account: A) => Awaitable<Account>)
+  account?:
+    | "minimal"
+    | "pass-through"
+    | ((account: A & TokenSet) => Awaitable<Account>)
   checks?: ChecksType | ChecksType[]
   client?: Partial<ClientMetadata>
   jwks?: { keys: JWK[] }

--- a/packages/next-auth/src/providers/oauth.ts
+++ b/packages/next-auth/src/providers/oauth.ts
@@ -123,14 +123,7 @@ export interface OAuthConfig<P, A = any>
    * If set to `"minimal"`
    * @default "pass-through"
    */
-  account?:
-    | "minimal"
-    | "pass-through"
-    | ((
-        account: A
-      ) => Awaitable<
-        Omit<Account, "provider" | "type" | "providerAccountId" | "userId">
-      >)
+  account?: "minimal" | "pass-through" | ((account: A) => Awaitable<Account>)
   checks?: ChecksType | ChecksType[]
   client?: Partial<ClientMetadata>
   jwks?: { keys: JWK[] }

--- a/packages/next-auth/src/providers/oauth.ts
+++ b/packages/next-auth/src/providers/oauth.ts
@@ -120,7 +120,6 @@ export interface OAuthConfig<P, A = any>
   profile?: (profile: P, tokens: TokenSet) => Awaitable<User & { id: string }>
   /**
    * Which part of the provider account should be saved in the database.
-   * If set to `"minimal"`
    * @default "pass-through"
    */
   account?:


### PR DESCRIPTION
This is an alternative proposal to #4893

Right now, we pass through all the values of a provider account to the DB, and it causes confusion/unforeseen breaks when a provider decides to return a new property.

To solve this, we can add an `account` property to the provider configuration, similar to the `profile` callback, to control what part of the account should be saved to the database.


Example:

```ts
// pages/api/auth/[...nextauth].ts
import NextAuth from "next-auth"
import AzureAD from "next-auth/providers/azure-ad"

// this can be in `next-auth/providers/azure-ad`
interface AzureADAccount {
  ext_expires_in: number
}

declare module "next-auth" {
  interface Account extends AzureADAccount {}
}


export default NextAuth({
  providers: [
    AzureAD({
      ...
      // this would show a type error, because we required `ext_expires_in`
      account({ ext_expires_in, ...a }) {
        return a
      }
      // account: "minimal" // conversely, we can also only allow the most common properties
    })
  ]
})
```


Closes #4893