### PR TITLE
chore: add security guidelines to PR & issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_framework.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_framework.yml
@@ -5,6 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        **NOTE:** Issues that are potentially security related should be reported to us by following the [Security guidelines](https://next-auth.js.org/security) rather than on GitHub.
         Thanks for taking the time to fill out this issue after reading/searching through the [documentation](https://next-auth.js.org) first!
         Is this your first time contributing? Check out this video: https://www.youtube.com/watch?v=cuoNzXFLitc
 

--- a/.github/ISSUE_TEMPLATE/2_bug_provider.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_provider.yml
@@ -5,6 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        **NOTE:** Issues that are potentially security related should be reported to us by following the [Security guidelines](https://next-auth.js.org/security) rather than on GitHub.
         Thanks for taking the time to fill out this [Provider](https://next-auth.js.org/providers/overview) related issue!
         Is this your first time contributing? Check out this video: https://www.youtube.com/watch?v=cuoNzXFLitc
 

--- a/.github/ISSUE_TEMPLATE/3_bug_adapter.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_adapter.yml
@@ -5,6 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        **NOTE:** Issues that are potentially security related should be reported to us by following the [Security guidelines](https://next-auth.js.org/security) rather than on GitHub.
         Thanks for taking the time to fill out this [Adapter](https://next-auth.js.org/adapters/overview) related issue!
         Is this your first time contributing? Check out this video: https://www.youtube.com/watch?v=cuoNzXFLitc
 

--- a/.github/ISSUE_TEMPLATE/5_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_request.yml
@@ -9,6 +9,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        **NOTE:** Issues that are potentially security related should be reported to us by following the [Security guidelines](https://next-auth.js.org/security) rather than on GitHub.
         Thank you very much for reaching out to us regarding the awesome feature that you believe should be included in the NextAuth.js library.
 
         _NOTE: Feature requests are converted to [discussions (Ideas 💡)](https://github.com/nextauthjs/next-auth/discussions/categories/ideas). Make sure your idea hasn't been asked yet, and upvote the existing one before opening a new instead._

--- a/.github/ISSUE_TEMPLATE/6_typescript.yml
+++ b/.github/ISSUE_TEMPLATE/6_typescript.yml
@@ -17,6 +17,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        **NOTE:** Issues that are potentially security related should be reported to us by following the [Security guidelines](https://next-auth.js.org/security) rather than on GitHub.
         Make sure you [link]() to external documentation if necessary and provide inline code examples like so:
 
         ```js

--- a/.github/ISSUE_TEMPLATE/7_question.yml
+++ b/.github/ISSUE_TEMPLATE/7_question.yml
@@ -9,6 +9,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        **NOTE:** Issues that are potentially security related should be reported to us by following the [Security guidelines](https://next-auth.js.org/security) rather than on GitHub.
         We are glad that you have a question about this library. Please provide the following information:
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,14 @@ Please fill out the information below to expedite the review and (hopefully)
 merge of your pull request!
 -->
 
+> _NOTE_:
+>
+> - It's a good idea to open an issue first to discuss potential changes.
+> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.
+
 ## ☕️ Reasoning
 
-What changes are being made? What feature/bug is being fixed here?
+<!-- What changes are being made? What feature/bug is being fixed here? -->
 
 ## 🧢 Checklist
 
@@ -23,6 +28,7 @@ Fixes: INSERT_ISSUE_LINK_HERE
 
 ## 📌 Resources
 
-- [Contributing guidelines](./CONTRIBUTING.md)
-- [Code of conduct](./CODE_OF_CONDUCT.md)
+- [Security guidelines](../Security.md)
+- [Contributing guidelines](../CONTRIBUTING.md)
+- [Code of conduct](../CODE_OF_CONDUCT.md)
 - [Contributing to Open Source](https://kcd.im/pull-request)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting info@balazsorban.com, yo@ndo.dev, thvu@hey.com and me@iaincollins.com.
+reported by contacting info@balazsorban.com, yo@ndo.dev, hi@thvu.dev and me@iaincollins.com.
 All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. The project team
 is obligated to maintain confidentiality with regard to the reporter of an

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting info@balazsorban.com, yo@ndo.dev, hi@thvu.dev and me@iaincollins.com.
+reported by contacting hi@thvu.dev, info@balazsorban.com, yo@ndo.dev and me@iaincollins.com.
 All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. The project team
 is obligated to maintain confidentiality with regard to the reporter of an

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ If you contact us regarding a serious issue:
 - We will disclose the issue (and credit you, with your consent) once a fix to resolve the issue has been released.
 - If 90 days has elapsed and we still don't have a fix, we will disclose the issue publicly.
 
-The best way to report an issue is by contacting us via email at info@balazsorban.com, yo@ndo.dev, thvu@hey.com and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
+The best way to report an issue is by contacting us via email at info@balazsorban.com, yo@ndo.dev, hi@thvu.dev and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
 
 > For less serious issues (e.g. RFC compliance for unsupported flows or potential issues that may cause a problem in the future) it is appropriate to submit these publicly as bug reports or feature requests or to raise a question to open a discussion around them.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ If you contact us regarding a serious issue:
 - We will disclose the issue (and credit you, with your consent) once a fix to resolve the issue has been released.
 - If 90 days has elapsed and we still don't have a fix, we will disclose the issue publicly.
 
-The best way to report an issue is by contacting us via email at info@balazsorban.com, yo@ndo.dev, hi@thvu.dev and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
+The best way to report an issue is by contacting us via email at hi@thvu.dev, info@balazsorban.com, yo@ndo.dev and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
 
 > For less serious issues (e.g. RFC compliance for unsupported flows or potential issues that may cause a problem in the future) it is appropriate to submit these publicly as bug reports or feature requests or to raise a question to open a discussion around them.
 

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -16,7 +16,7 @@ If you contact us regarding a serious issue:
 - We will disclose the issue (and credit you, with your consent) once a fix to resolve the issue has been released.
 - If 90 days has elapsed and we still don't have a fix, we will disclose the issue publicly.
 
-The best way to report an issue is by contacting us via email at info@balazsorban.com, yo@ndo.dev, hi@thvu.dev and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
+The best way to report an issue is by contacting us via email at hi@thvu.dev, info@balazsorban.com, yo@ndo.dev and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
 
 :::note
 For less serious issues (e.g. RFC compliance for unsupported flows or potential issues that may cause a problem in the future) it is appropriate to submit these these publically as bug reports or feature requests or to raise a question to open a discussion around them.

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -16,7 +16,7 @@ If you contact us regarding a serious issue:
 - We will disclose the issue (and credit you, with your consent) once a fix to resolve the issue has been released.
 - If 90 days has elapsed and we still don't have a fix, we will disclose the issue publicly.
 
-The best way to report an issue is by contacting us via email at info@balazsorban.com, yo@ndo.dev, thvu@hey.com and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
+The best way to report an issue is by contacting us via email at info@balazsorban.com, yo@ndo.dev, hi@thvu.dev and me@iaincollins.com, or raise a public issue requesting someone get in touch with you via whatever means you prefer for more details. (Please do not disclose sensitive details publicly at this stage.)
 
 :::note
 For less serious issues (e.g. RFC compliance for unsupported flows or potential issues that may cause a problem in the future) it is appropriate to submit these these publically as bug reports or feature requests or to raise a question to open a discussion around them.


### PR DESCRIPTION
## ☕️ Reasoning

Added links to security guidelines to PR & issue templates to aid contributors.  🤝
I also updated my new email address 🙌

