### PR TITLE
fix(core): support base path when redirect to signIn page #5480

### DIFF
--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -101,7 +101,7 @@ async function handleMiddleware(
   options: NextAuthMiddlewareOptions | undefined,
   onSuccess?: (token: JWT | null) => Promise<NextMiddlewareResult>
 ) {
-  const { pathname, search, origin } = req.nextUrl
+  const { pathname, search, origin, basePath: nextUrlBasePath } = req.nextUrl
 
   const signInPage = options?.pages?.signIn ?? "/api/auth/signin"
   const errorPage = options?.pages?.error ?? "/api/auth/error"
@@ -146,7 +146,7 @@ async function handleMiddleware(
 
   // the user is not logged in, redirect to the sign-in page
   const signInUrl = new URL(signInPage, origin)
-  signInUrl.searchParams.append("callbackUrl", `${pathname}${search}`)
+  signInUrl.searchParams.append("callbackUrl", `${nextUrlBasePath}${pathname}${search}`)
   return NextResponse.redirect(signInUrl)
 }
 

--- a/packages/next-auth/tests/middleware.test.ts
+++ b/packages/next-auth/tests/middleware.test.ts
@@ -38,3 +38,22 @@ it("should not redirect on public paths", async () => {
   const res = await handleMiddleware(req, null as any)
   expect(res).toBeUndefined()
 })
+
+it("should redirect according to nextUrl basePath", async () => {
+  const options: NextAuthMiddlewareOptions = {
+    secret: "secret"
+  }
+  const nextUrl: any = {
+    pathname: "/protected/pathA",
+    search: "",
+    origin: "http://127.0.0.1",
+    basePath: "/custom-base-path",
+  }
+  const req: any = { nextUrl, headers: { authorization: "" } }
+
+  const handleMiddleware = withAuth(options) as NextMiddleware
+  const res = await handleMiddleware(req, null as any)
+  expect(res).toBeDefined()
+  expect(res.status).toEqual(307)
+  expect(res.headers.get('location')).toContain("http://127.0.0.1/api/auth/signin?callbackUrl=%2Fcustom-base-path%2Fprotected%2FpathA")
+})


### PR DESCRIPTION
## ☕️ Reasoning

Fix invalid logic when redirecting to signIn page with configured basePath parameter. See #5480 for details

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: [5480 invalid callbackUrl queryParam when basePath configured](https://github.com/nextauthjs/next-auth/issues/5480)
