### PR TITLE
Add opt-in for dangerous linking

### DIFF
--- a/docs/docs/configuration/providers/oauth.md
+++ b/docs/docs/configuration/providers/oauth.md
@@ -173,6 +173,7 @@ interface OAuthConfig {
   region?: string
   issuer?: string
   client?: Partial<ClientMetadata>
+  allowDangerousEmailAccountLinking?: boolean
 }
 ```
 
@@ -277,6 +278,10 @@ If your Provider is OpenID Connect (OIDC) compliant, we recommend using the `wel
 ### `client` option
 
 An advanced option, hopefully you won't need it in most cases. `next-auth` uses `openid-client` under the hood, see the docs on this option [here](https://github.com/panva/node-openid-client/blob/main/docs/README.md#new-clientmetadata-jwks-options).
+
+### `allowDangerousEmailAccountLinking` option
+
+Normally, when you sign in with an OAuth provider and another account with the same email address already exists, the accounts are not linked automatically. Automatic account linking on sign in is not secure between arbitrary providers and is disabled by default. However, it may be desireable to allow automatic account linking if you trust that the provider involved has securely verified the email address associated with the account. Just set `allowDangerousEmailAccountLinking: true` in your provider configuration to enable automatic account linking.
 
 ## Using a custom provider
 
@@ -401,6 +406,18 @@ GoogleProvider({
       // to be able identify the account when added to a database
     }
   },
+})
+```
+
+An example of how to enable automatic account linking:
+
+```js title=/api/auth/[...nextauth].js
+import GoogleProvider from "next-auth/providers/google"
+
+GoogleProvider({
+  clientId: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  allowDangerousEmailAccountLinking: true,
 })
 ```
 

--- a/docs/docs/configuration/providers/oauth.md
+++ b/docs/docs/configuration/providers/oauth.md
@@ -281,7 +281,7 @@ An advanced option, hopefully you won't need it in most cases. `next-auth` uses 
 
 ### `allowDangerousEmailAccountLinking` option
 
-Normally, when you sign in with an OAuth provider and another account with the same email address already exists, the accounts are not linked automatically. Automatic account linking on sign in is not secure between arbitrary providers and is disabled by default. However, it may be desireable to allow automatic account linking if you trust that the provider involved has securely verified the email address associated with the account. Just set `allowDangerousEmailAccountLinking: true` in your provider configuration to enable automatic account linking.
+Normally, when you sign in with an OAuth provider and another account with the same email address already exists, the accounts are not linked automatically. Automatic account linking on sign in is not secure between arbitrary providers and is disabled by default (see our [Security FAQ](https://next-auth.js.org/faq#security)).  However, it may be desirable to allow automatic account linking if you trust that the provider involved has securely verified the email address associated with the account. Just set `allowDangerousEmailAccountLinking: true` in your provider configuration to enable automatic account linking.
 
 ## Using a custom provider
 

--- a/packages/next-auth/src/providers/oauth.ts
+++ b/packages/next-auth/src/providers/oauth.ts
@@ -145,6 +145,7 @@ export interface OAuthConfig<P> extends CommonProviderOptions, PartialIssuer {
   requestTokenUrl?: string
   profileUrl?: string
   encoding?: string
+  allowDangerousEmailAccountLinking?: boolean;
 }
 
 /** @internal */

--- a/packages/next-auth/src/utils/detect-host.ts
+++ b/packages/next-auth/src/utils/detect-host.ts
@@ -1,7 +1,7 @@
 /** Extract the host from the environment */
 export function detectHost(forwardedHost: any) {
   // If we detect a Vercel environment, we can trust the host
-  if (process.env.VERCEL || process.env.AUTH_TRUST_HOST)
+  if (process.env.VERCEL ?? process.env.AUTH_TRUST_HOST)
     return forwardedHost
   // If `NEXTAUTH_URL` is `undefined` we fall back to "http://localhost:3000"
   return process.env.NEXTAUTH_URL


### PR DESCRIPTION
This is an updated pull request of [#3557](https://github.com/nextauthjs/next-auth/pull/3557) since it was closed due to inactivity. We also have the same use case as the original author (@Gregoor).

@ThangHuuVu I've updated the pull request against the latest main branch so that it compiles, and I have also addressed the requested changes from the original pull request:
1) The `allowDangerousEmailAccountLinking` option was moved to `OAuthConfig` since it only applies to oauth providers.
2) Added documentation for the new option in docs/configuration/providers/oauth.md

## ☕️ Reasoning

By default account linking can only be done through an active session, to prevent account stealing from low-trust providers. Some next-auth users might trust their chosen providers enough to opt them into more lax account linking.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

https://github.com/nextauthjs/next-auth/pull/3557
https://github.com/nextauthjs/next-auth/issues/5098
https://github.com/nextauthjs/next-auth/issues/5324
https://github.com/nextauthjs/next-auth/issues/4826
https://github.com/nextauthjs/next-auth/issues/4625
https://github.com/nextauthjs/next-auth/issues/4271


