### PR TITLE
Update the nodemailer well known page URL

### DIFF
--- a/docs/docs/providers/email.md
+++ b/docs/docs/providers/email.md
@@ -32,7 +32,7 @@ You can override any of the options to suit your own use case.
 ## Configuration
 
 1. NextAuth.js does not include `nodemailer` as a dependency, so you'll need to install it yourself if you want to use the Email Provider. Run `npm install nodemailer` or `yarn add nodemailer`.
-2. You will need an SMTP account; ideally for one of the [services known to work with `nodemailer`](http://nodemailer.com/smtp/well-known/).
+2. You will need an SMTP account; ideally for one of the [services known to work with `nodemailer`](https://community.nodemailer.com/2-0-0-beta/setup-smtp/well-known-services/).
 3. There are two ways to configure the SMTP server connection.
 
 You can either use a connection string or a `nodemailer` configuration object.


### PR DESCRIPTION
## ☕️ Reasoning

The [current link](https://nodemailer.com/smtp/well-known/) in the docs for Nodemailer well-known services returns 404.

This PR replaces that with a [working URL](https://community.nodemailer.com/2-0-0-beta/setup-smtp/well-known-services/) of `community.nodemailer.com`.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

