### PR TITLE
Export default next pages

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -31,6 +31,7 @@
     "./jwt": "./jwt/index.js",
     "./react": "./react/index.js",
     "./core": "./core/index.js",
+    "./core/pages/*": "./core/pages/*.js",
     "./next": "./next/index.js",
     "./middleware": "./middleware.js",
     "./client/_utils": "./client/_utils.js",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
I would like to customize the next-auth ui, while keeping the basic functionality in place. An example use case would be a redirect in case of errors:

```typescript
import * as React from "react";
import { GetServerSideProps } from "next";
import SignInPage, { SignInServerPageParams } from "next-auth/core/pages/signin";
import { useRouter } from "next/router";
import { getProviders } from "next-auth/react";

export const getServerSideProps: GetServerSideProps = async () => {
  const providers = await getProviders();
  return {
    props: { providers },
  };
};

const SignIn: React.FC<SignInServerPageParams> = ({ error, ...props }) => {
  const router = useRouter();
  React.useEffect(() => {
    if (error === "OAuthCallback") {
      router.replace("/");
    }
  }, [error, router]);

  return <SignInPage error={error} {...props} />;
};
export default SignIn;
```

Currently, this is not possible when using ESM because the pages are not exported from the package.

## 🧢 Checklist

~- [ ] Documentation~
~- [ ] Tests~
- [x] Ready to be merged

## 🎫 Affected issues
-
