### PR TITLE
fix: detectHost should respect env NEXTAUTH_URL_INTERNAL

### DIFF
--- a/packages/next-auth/src/utils/detect-host.ts
+++ b/packages/next-auth/src/utils/detect-host.ts
@@ -1,5 +1,9 @@
 /** Extract the host from the environment */
 export function detectHost(forwardedHost: any) {
+  // if `NEXTAUTH_URL_INTERNAL` is set for development purposes, use it.
+  if (process.env.NEXTAUTH_URL_INTERNAL) {
+    return process.env.NEXTAUTH_URL_INTERNAL
+  }
   // If we detect a Vercel environment, we can trust the host
   if (process.env.VERCEL ?? process.env.AUTH_TRUST_HOST)
     return forwardedHost


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

close https://github.com/nextauthjs/next-auth/discussions/5676

`vercel dev` would always lead me to `https://localhost:3000/api/auth/****` not `http://localhost:3000/api/auth/***`, because:

- when it initializes the next auth, it uses `detectHost` to pretend the URL for the server
-  with vercel, `detectHost` extract `x-forwarded-host` from the HTTP request header, which is always `locahost:3000`(without none of `http` or `https` prefix) in my scenario
- because the return value of `detectHost` do not contains the http/https schema, it automatic append `https` for it, **which is not expected in development environment**

https://github.com/nextauthjs/next-auth/blob/733fd5f2345cbf7c123ba8175ea23506bcb5c453/packages/next-auth/src/utils/parse-url.ts#L18-L20


<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
