### PR TITLE
fix(react): support importing "next-auth/react" in Server Component environment

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -95,9 +95,9 @@ export type SessionContextValue<R extends boolean = false> = R extends true
       | { data: Session; status: "authenticated" }
       | { data: null; status: "unauthenticated" | "loading" }
 
-export const SessionContext = React.createContext<
-  SessionContextValue | undefined
->(undefined)
+export const SessionContext = React.createContext
+  ? React.createContext<SessionContextValue | undefined>(undefined)
+  : undefined
 
 /**
  * React Hook that gives you access
@@ -106,6 +106,10 @@ export const SessionContext = React.createContext<
  * [Documentation](https://next-auth.js.org/getting-started/client#usesession)
  */
 export function useSession<R extends boolean>(options?: UseSessionOptions<R>) {
+  if (!SessionContext) {
+    throw new Error("React Context is unavailable in Server Components")
+  }
+
   // @ts-expect-error Satisfy TS if branch on line below
   const value: SessionContextValue<R> = React.useContext(SessionContext)
   if (!value && process.env.NODE_ENV !== "production") {
@@ -322,6 +326,10 @@ export async function signOut<R extends boolean = true>(
  * [Documentation](https://next-auth.js.org/getting-started/client#sessionprovider)
  */
 export function SessionProvider(props: SessionProviderProps) {
+  if (!SessionContext) {
+    throw new Error("React Context is unavailable in Server Components")
+  }
+
   const { children, basePath, refetchInterval, refetchWhenOffline } = props
 
   if (basePath) __NEXTAUTH.basePath = basePath


### PR DESCRIPTION
## ☕️ Reasoning

Currently, importing "next-auth/react" in a Server Component module (or in a module imported by a Server Component module) will fail with `Uncaught TypeError: React.createContext is not a function`.

This is because React Context is unavailable in Server Components.

With this change, "next-auth/react" can be imported without error, and an informative error is thrown if there's an attempt to actually *use* React Context.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Related issue: #5647 (this PR doesn't add complete support, but improves support)
