### PR TITLE
docs: add providers/pinterest no email warning

### DIFF
--- a/docs/docs/providers/pinterest.md
+++ b/docs/docs/providers/pinterest.md
@@ -30,7 +30,11 @@ providers: [
     clientSecret: process.env.PINTEREST_SECRET
   })
 ]
-...
+```
+
+:::warning
+Email address is not returned by Pinterest.
+:::
 
 :::tip
 To use in production, make sure the app has standard API access and not trial access


### PR DESCRIPTION
## ☕️ Reasoning

Added a warning that pinterest doesn't return the users email adress. Also fixed the markdown formatting.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
