### PR TITLE
fix(next): conditional RSC support

### DIFF
--- a/.github/version-pr/action.yml
+++ b/.github/version-pr/action.yml
@@ -4,5 +4,5 @@ outputs:
   version:
     description: "npm package version"
 runs:
-  using: "node18"
+  using: "node16"
   main: "index.js"

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -1,7 +1,6 @@
 import { NextAuthHandler } from "../core"
 import { detectHost } from "../utils/detect-host"
 import { setCookie } from "./utils"
-import { cookies as nextCookies, headers } from "next/headers"
 
 import type {
   GetServerSidePropsContext,
@@ -121,18 +120,18 @@ export async function unstable_getServerSession(
     experimentalRSCWarningShown = true
   }
 
-  const [req, res, options] = isRSC
-    ? [
-        {
-          headers: headers(),
-          cookies: nextCookies()
-            .getAll()
-            .reduce((acc, c) => ({ ...acc, [c.name]: c.value }), {}),
-        } as any,
-        { getHeader() {}, setCookie() {}, setHeader() {} } as any,
-        args[0],
-      ]
-    : args
+  let req, res, options: NextAuthOptions
+  if (isRSC) {
+    options = args[0]
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { headers, cookies } = require("next/headers")
+    req = { headers, cookies }
+    res = { getHeader() {}, setCookie() {}, setHeader() {} }
+  } else {
+    req = args[0]
+    res = args[1]
+    options = args[2]
+  }
 
   options.secret = options.secret ?? process.env.NEXTAUTH_SECRET
 

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -125,7 +125,12 @@ export async function unstable_getServerSession(
     options = args[0]
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { headers, cookies } = require("next/headers")
-    req = { headers, cookies }
+    req = {
+      headers,
+      cookies: cookies()
+        .getAll()
+        .reduce((acc, c) => ({ ...acc, [c.name]: c.value }), {}),
+    }
     res = { getHeader() {}, setCookie() {}, setHeader() {} }
   } else {
     req = args[0]

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -127,9 +127,11 @@ export async function unstable_getServerSession(
     const { headers, cookies } = require("next/headers")
     req = {
       headers,
-      cookies: cookies()
-        .getAll()
-        .reduce((acc, c) => ({ ...acc, [c.name]: c.value }), {}),
+      cookies: Object.fromEntries(
+        cookies()
+          .getAll()
+          .map((c) => [c.name, c.value])
+      ),
     }
     res = { getHeader() {}, setCookie() {}, setHeader() {} }
   } else {


### PR DESCRIPTION
Fixes #5743

We accidentally broke Next.js 12 support via #5741 which has an import to `next/headers` that only exists in Next.js 13. This PR wraps the import into a conditional to prevent the error from happening in Next.js 12 apps.


## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
