### PR TITLE
Add Ethereum provider to support Sign-In with Ethereum

### DIFF
--- a/docs/versioned_docs/version-v3/providers/ethereum.md
+++ b/docs/versioned_docs/version-v3/providers/ethereum.md
@@ -1,0 +1,145 @@
+---
+id: ethereum
+title: Ethereum
+---
+
+## Overview
+
+The Ethereum provider allows a user to sign in with an ethereum account. The provider implements
+[EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) with the Sign-In with Ethereum (SIWE) [library](https://login.xyz).
+
+### How it works
+
+To sign in with an Ethereum account, a user needs an Ethereum wallet like the one provided by the
+[Metamask](https://metamask.io/) browser extension.
+
+Your app creates a Sign-In with Ethereum
+[message](https://docs.login.xyz/sign-in-with-ethereum/quickstart-guide/creating-siwe-messages).
+This message is passed to the wallet where the user cryptographically
+[signs the message](https://medium.com/immunefi/intro-to-cryptography-and-signatures-in-ethereum-2025b6a4a33d).
+
+The message and the associated signature are passed to the Ethereum provider. If the signature is
+valid, the user is authenticated and the sign in flow proceeds.
+
+## Users
+
+Like the Email provider and the OAuth providers, Ethereum provider creates and accesses
+users from the database if an adapter is configured. However, users created by Ethereum
+provider do not have `email` populated.
+
+## Options
+
+In addition to the common provider options, the Ethereum provider accepts a `siweVerifyOptions` parameter.
+This allows you to pass SIWE
+[`VerifyOpts`](https://github.com/spruceid/siwe/blob/053f16bf7dce3ff587e00bc4d3754a29ee9c26e6/packages/siwe/lib/types.ts#L25)
+to customize the signature verification behavior.
+
+## Example
+
+Ethereum provider can be constructed with no options:
+
+```js title="pages/api/auth/[...nextauth].js"
+import Ethereum from 'next-auth/providers/ethereum'
+...
+providers: [
+  Ethereum(),
+],
+```
+
+The provider `name` defaults to "Ethereum" and the `id` to "ethereum".
+
+The frontend example uses [Ethers.js](https://docs.ethers.io/v5/) to interact with the user's wallet.
+[Web3.js](https://web3js.readthedocs.io/en/v1.8.0/) is an alternative option.
+
+:::tip
+Various front-end libraries exist to help your app interact with a user's wallet.
+[Onboard](https://onboard.blocknative.com/) and [wagmi](https://wagmi.sh/)(React) are two options.
+:::
+
+
+```js title="siwe.js"
+import { ethers } from "ethers"
+import { SiweMessage } from "siwe"
+
+const domain = window.location.host // Should match NEXTAUTH_URL's host
+const origin = window.location.origin
+const provider = new ethers.providers.Web3Provider(window.ethereum)
+const signer = provider.getSigner()
+
+function connectWallet() {
+  provider
+    .send("eth_requestAccounts", [])
+    .catch(() => console.log("user rejected request"))
+}
+
+async function signInWithEthereum() {
+  // Create message
+  const csrfResponse = await fetch("/api/auth/csrf")
+  const { csrfToken } = await csrfResponse.json()
+  const address = signer.getAddress()
+  const message = new SiweMessage({
+    address,
+    chainId: "1",
+    domain,
+    nonce: csrfToken,
+    statement: "Sign in to NextAuth with Ethereum",
+    uri: origin,
+    version: "1",
+  })
+
+  // Sign message
+  const signature = await signer.signMessage(message)
+
+  // Call NextAuth
+  const params = new URLSearchParams()
+  params.append("message", message)
+  params.append("signature", signature)
+  params.append("csrfToken", csrfToken)
+
+  const response = await fetch(`/api/auth/callback/ethereum`, {
+    body: params,
+    method: "post",
+    redirect: "follow",
+  })
+
+  if (response.status === 200 && response.redirected === true) {
+    window.location.replace(response.url)
+  }
+}
+
+// Buttons from the HTML page
+const connectWalletButton = document.getElementById("connectWalletButton")
+const siweButton = document.getElementById("siweButton")
+connectWalletButton.onclick = connectWallet
+siweButton.onclick = signInWithEthereum
+```
+
+```html title="siwe.html"
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>NextAuth SIWE</title>
+  </head>
+
+  <body>
+    <div><button id="connectWalletButton">Connect Wallet</button></div>
+    <div><button id="siweButton">Sign-In with Ethereum</button></div>
+  </body>
+</html>
+```
+
+:::tip
+See the Sign-In with Ethereum
+["Implement the Frontend"](https://docs.login.xyz/sign-in-with-ethereum/quickstart-guide/implement-the-frontend)
+documentation for more detail.
+:::
+
+### A note on `nonce`
+
+Strictly, the `SiweMessage` nonce does not have to be the CSRF token. However,
+to prevent replay attacks the SIWE documentation
+[suggests](https://docs.login.xyz/sign-in-with-ethereum/quickstart-guide/implement-sessions)
+that the nonce should be tied to the end user's browser session. To encourage this
+good practice, the callback payload includes a `csrfToken` parameter and its value is used
+as the nonce.

--- a/packages/adapter-prisma/prisma/schema.prisma
+++ b/packages/adapter-prisma/prisma/schema.prisma
@@ -10,7 +10,7 @@ generator client {
 model User {
   id            String    @id @default(cuid())
   name          String?
-  email         String    @unique
+  email         String?    @unique
   emailVerified DateTime?
   image         String?
   accounts      Account[]

--- a/packages/next-auth/config/jest.config.js
+++ b/packages/next-auth/config/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
       },
       coveragePathIgnorePatterns: ["tests"],
       testEnvironment: "@edge-runtime/jest-environment",
-      transformIgnorePatterns: ["node_modules/(?!uuid)/"],
+      transformIgnorePatterns: ["node_modules/(?!uuid)/", "/apg-js/"],
       /** @type {import("@edge-runtime/vm").EdgeVMOptions} */
       testEnvironmentOptions: {
         codeGeneration: {

--- a/packages/next-auth/config/swc.config.js
+++ b/packages/next-auth/config/swc.config.js
@@ -4,6 +4,7 @@ module.exports = {
     parser: {
       syntax: "typescript",
       tsx: true,
+      dynamicImport: true,
     },
     transform: {
       react: {

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -70,11 +70,13 @@
     "@babel/runtime": "^7.16.3",
     "@panva/hkdf": "^1.0.1",
     "cookie": "^0.5.0",
+    "ethers": "^5.5.1",
     "jose": "^4.9.3",
     "oauth": "^0.9.15",
     "openid-client": "^5.1.0",
     "preact": "^10.6.3",
     "preact-render-to-string": "^5.1.19",
+    "siwe": "^2.1.3",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -2,7 +2,7 @@ import { Account, User, Awaitable } from "."
 
 export interface AdapterUser extends User {
   id: string
-  email: string
+  email: string | null
   emailVerified: Date | null
 }
 

--- a/packages/next-auth/src/core/lib/assert.ts
+++ b/packages/next-auth/src/core/lib/assert.ts
@@ -96,7 +96,11 @@ export function assertConfig(params: {
   for (const provider of options.providers) {
     if (provider.type === "credentials") hasCredentials = true
     else if (provider.type === "email") hasEmail = true
-    else if (provider.id === "twitter" && provider.version === "2.0")
+    else if (
+      provider.type === "oauth" &&
+      "twitter" &&
+      provider.version === "2.0"
+    )
       hasTwitterOAuth2 = true
   }
 

--- a/packages/next-auth/src/core/routes/callback.ts
+++ b/packages/next-auth/src/core/routes/callback.ts
@@ -3,11 +3,12 @@ import callbackHandler from "../lib/callback-handler"
 import { hashToken } from "../lib/utils"
 import getAdapterUserFromEmail from "../lib/email/getUserFromEmail"
 
-import type { InternalOptions } from "../types"
+import type { Account, InternalOptions } from "../types"
 import type { RequestInternal, OutgoingResponse } from ".."
 import type { Cookie, SessionStore } from "../lib/cookie"
 import type { User } from "../.."
-import type { AdapterSession } from "../../adapters"
+import type { AdapterSession, AdapterUser } from "../../adapters"
+import { EthereumInput } from "src/providers/ethereum"
 
 /** Handle callbacks from login services */
 export default async function callback(params: {
@@ -223,6 +224,12 @@ export default async function callback(params: {
         adapter,
       })
 
+      // Profile was fetched by email, so the email must exist.
+      // Refine the type.
+      if (!profile.email) {
+        throw new Error()
+      }
+
       const account = {
         providerAccountId: profile.email,
         type: "email" as const,
@@ -412,6 +419,148 @@ export default async function callback(params: {
     await events.signIn?.({ user, account })
 
     return { redirect: callbackUrl, cookies }
+  } else if (provider.type === "ethereum" && method === "POST") {
+    const parameters = body as EthereumInput
+
+    let verifiedAddress: string | null = null
+    try {
+      const verifyResponse = await provider.verifySignature(
+        {
+          csrfToken: parameters.csrfToken,
+          domain: url.host,
+          message: parameters.message,
+          signature: parameters.signature,
+        },
+        {
+          query,
+          body,
+          headers,
+          method,
+        }
+      )
+      if (verifyResponse) verifiedAddress = verifyResponse.address
+    } catch (e) {
+      return {
+        status: 401,
+        redirect: `${url}/error?error=${encodeURIComponent(
+          (e as Error).message
+        )}`,
+        cookies,
+      }
+    }
+
+    if (!verifiedAddress) {
+      // Signature wasn't correct
+      return {
+        status: 401,
+        redirect: `${url}/error?${new URLSearchParams({
+          error: "EthereumSignin",
+          provider: provider.id,
+        })}`,
+        cookies,
+      }
+    }
+
+    const account: Account = {
+      providerAccountId: verifiedAddress,
+      type: "ethereum",
+      provider: provider.id,
+    }
+
+    let adapterUser: AdapterUser | null = null
+    if (adapter) {
+      adapterUser = await adapter.getUserByAccount({
+        providerAccountId: account.providerAccountId,
+        provider: provider.id,
+      })
+    }
+
+    try {
+      const isAllowed = await callbacks.signIn({
+        user: adapterUser ?? { id: verifiedAddress },
+        account,
+      })
+      if (!isAllowed) {
+        return { redirect: `${url}/error?error=AccessDenied`, cookies }
+      } else if (typeof isAllowed === "string") {
+        return { redirect: isAllowed, cookies }
+      }
+    } catch (error) {
+      return {
+        redirect: `${url}/error?error=${encodeURIComponent(
+          (error as Error).message
+        )}`,
+        cookies,
+      }
+    }
+
+    try {
+      // Sign user in
+      const { user, session, isNewUser } = await callbackHandler({
+        sessionToken: sessionStore.value,
+        profile: adapterUser ?? { id: verifiedAddress },
+        account,
+        options,
+      })
+
+      if (useJwtSession) {
+        const defaultToken = {
+          name: user.name,
+          email: user.email,
+          picture: user.image,
+          sub: user.id?.toString(),
+        }
+        const token = await callbacks.jwt({
+          token: defaultToken,
+          user,
+          account,
+          isNewUser,
+        })
+
+        // Encode token
+        const newToken = await jwt.encode({ ...jwt, token })
+
+        // Set cookie expiry date
+        const cookieExpires = new Date()
+        cookieExpires.setTime(cookieExpires.getTime() + sessionMaxAge * 1000)
+
+        const sessionCookies = sessionStore.chunk(newToken, {
+          expires: cookieExpires,
+        })
+        cookies.push(...sessionCookies)
+      } else {
+        // Save Session Token in cookie
+        cookies.push({
+          name: options.cookies.sessionToken.name,
+          value: (session as AdapterSession).sessionToken,
+          options: {
+            ...options.cookies.sessionToken.options,
+            expires: (session as AdapterSession).expires,
+          },
+        })
+      }
+
+      await events.signIn?.({ user, account, isNewUser })
+
+      // Handle first logins on new accounts
+      // e.g. option to send users to a new account landing page on initial login
+      // Note that the callback URL is preserved, so the journey can still be resumed
+      if (isNewUser && pages.newUser) {
+        return {
+          redirect: `${pages.newUser}${
+            pages.newUser.includes("?") ? "&" : "?"
+          }callbackUrl=${encodeURIComponent(callbackUrl)}`,
+          cookies,
+        }
+      }
+
+      // Callback URL is already verified at this point, so safe to use if specified
+      return { redirect: callbackUrl, cookies }
+    } catch (error) {
+      // TODO: Fix this
+      logger.error("ETHEREUM_SIGNIN_ERROR", error as Error)
+      return { redirect: `${url}/error?error=Callback`, cookies }
+    }
   }
   return {
     status: 500,

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -6,6 +6,7 @@ import type {
   EmailConfig,
   CredentialsConfig,
   InternalOAuthConfig,
+  EthereumConfig,
 } from "../providers"
 import type { TokenSetParameters } from "openid-client"
 import type { JWT, JWTOptions } from "../jwt"
@@ -506,6 +507,8 @@ export type InternalProvider<T = ProviderType> = (T extends "oauth"
   ? EmailConfig
   : T extends "credentials"
   ? CredentialsConfig
+  : T extends "ethereum"
+  ? EthereumConfig
   : never) & {
   signinUrl: string
   callbackUrl: string

--- a/packages/next-auth/src/providers/ethereum.ts
+++ b/packages/next-auth/src/providers/ethereum.ts
@@ -1,0 +1,84 @@
+import type { Awaitable, LoggerInstance } from ".."
+import { SiweMessage, VerifyOpts } from "siwe"
+
+import type { CommonProviderOptions } from "."
+import type { RequestInternal } from "../core"
+
+/**
+ * Body type for the POST /callback/ethereum endpoint
+ */
+export interface EthereumInput {
+  message: string
+  signature: string
+  csrfToken: string
+}
+
+export interface EthereumConfig extends CommonProviderOptions {
+  type: "ethereum"
+  siweVerifyOptions: VerifyOpts
+  verifySignature: (
+    parameters: {
+      csrfToken: string
+      domain: string
+      message: string
+      signature: string
+    },
+    req: Pick<RequestInternal, "body" | "query" | "headers" | "method">
+  ) => Awaitable<{ address: string } | null>
+}
+
+export type EthereumProvider = (
+  options: Partial<EthereumConfig>
+) => EthereumConfig
+
+export type EthereumProviderType = "Ethereum"
+
+type UserEthereumConfig = Partial<
+  Omit<EthereumConfig, "options" | "verifySignature">
+>
+
+/**
+ * Enables authentication with NextAuth using an Ethereum wallet
+ * via Sign-In with Ethereum (https://login.xyz/)
+ */
+export default function Ethereum(options: UserEthereumConfig = {}): EthereumConfig {
+  return {
+    id: "ethereum",
+    name: "Ethereum",
+    type: "ethereum",
+    siweVerifyOptions: options.siweVerifyOptions ?? {},
+    verifySignature: async (parameters: {
+      csrfToken: string
+      domain: string
+      message: string
+      signature: string
+      logger?: LoggerInstance
+    }): Promise<{ address: string } | null> => {
+      try {
+        const siwe = new SiweMessage(parameters.message)
+
+        const siweResponse = await siwe.verify(
+          {
+            domain: parameters.domain,
+            nonce: parameters.csrfToken,
+            signature: parameters.signature,
+            time: new Date().toISOString(),
+          },
+          options.siweVerifyOptions ?? {}
+        )
+
+        if (!siweResponse.success) {
+          throw new Error(siweResponse.error ? siweResponse.error.type : "Eth signature invalid")
+        }
+
+        return {
+          address: siwe.address,
+        }
+      } catch (e) {
+        parameters.logger?.warn(e)
+        return null
+      }
+    },
+    options,
+  }
+}

--- a/packages/next-auth/src/providers/index.ts
+++ b/packages/next-auth/src/providers/index.ts
@@ -2,6 +2,8 @@ import type { OAuthConfig, OAuthProvider, OAuthProviderType } from "./oauth"
 
 import type { EmailConfig, EmailProvider, EmailProviderType } from "./email"
 
+import type { EthereumConfig } from "./ethereum"
+
 import type {
   CredentialsConfig,
   CredentialsProvider,
@@ -10,9 +12,10 @@ import type {
 
 export * from "./oauth"
 export * from "./email"
+export * from "./ethereum"
 export * from "./credentials"
 
-export type ProviderType = "oauth" | "email" | "credentials"
+export type ProviderType = "oauth" | "email" | "credentials" | "ethereum"
 
 export interface CommonProviderOptions {
   id: string
@@ -21,7 +24,7 @@ export interface CommonProviderOptions {
   options?: Record<string, unknown>
 }
 
-export type Provider = OAuthConfig<any> | EmailConfig | CredentialsConfig
+export type Provider = OAuthConfig<any> | EmailConfig | CredentialsConfig | EthereumConfig
 
 export type BuiltInProviders = Record<OAuthProviderType, OAuthProvider> &
   Record<CredentialsProviderType, CredentialsProvider> &

--- a/packages/next-auth/tests/ethereum.test.ts
+++ b/packages/next-auth/tests/ethereum.test.ts
@@ -1,0 +1,269 @@
+import { createCSRF, handler, mockAdapter } from "./lib"
+
+import type { AdapterUser } from "../src/adapters"
+import { CallbacksOptions } from "../src/core/types"
+import EthereumProvider from "../src/providers/ethereum"
+import { SiweMessage } from "siwe"
+import { ethers } from "ethers"
+
+let csrf: { value: string; token: string; cookie: string }
+let secret: string
+let testMessage: SiweMessage
+let wallet: ethers.Wallet
+
+describe("Ethereum Provider", () => {
+  beforeEach(async () => {
+    // NOTE: One strategy is to use the CSRF value as the nonce on the SIWE message.
+    // The previous test value of "csrf" is not long enough to be a valid nonce.
+    const csrfResult = await createCSRF("supersecurecsrfvalue")
+    secret = csrfResult.secret
+    csrf = csrfResult.csrf
+
+    wallet = new ethers.Wallet(
+      "0xacf31b9822a6c78768ff69efc92425f6588000952bcc3d0e4ee10d3fbf142598"
+    ) // 0x8c77aC88e481FDFAcD801dF29C406b545883467d
+
+    testMessage = new SiweMessage({
+      domain: "localhost:3000",
+      address: wallet.address,
+      statement: "Sign in test",
+      uri: "http://localhost:3000",
+      version: "1",
+      chainId: 1,
+      nonce: csrf.value,
+    })
+  })
+
+  it("redirects on an invalid signature", async () => {
+    const ethereumProvider = EthereumProvider({})
+    const authorizeSpy = jest.spyOn(ethereumProvider, "verifySignature")
+
+    const { res } = await handler(
+      {
+        adapter: mockAdapter(),
+        providers: [ethereumProvider],
+        callbacks: {},
+        secret,
+      },
+      {
+        path: "callback/ethereum",
+        requestInit: {
+          method: "POST",
+          headers: { cookie: csrf.cookie },
+          body: JSON.stringify({
+            message: "auth message",
+            signature: "0xsignme",
+            csrfToken: csrf.value,
+          }),
+        },
+      }
+    )
+    expect(authorizeSpy.mock.calls[0][0]).toEqual({
+      csrfToken: csrf.value,
+      domain: "localhost:3000",
+      message: "auth message",
+      signature: "0xsignme"
+    })
+
+    expect(res.redirect).toEqual(
+      "http://localhost:3000/api/auth/error?error=EthereumSignin&provider=ethereum"
+    )
+  })
+
+  it("fetches a user if one exists in the database", async () => {
+    const signIn = jest.fn<boolean, Parameters<CallbacksOptions["signIn"]>>(
+      () => false
+    )
+
+    const ethereumProvider = EthereumProvider({})
+
+    const testUser: AdapterUser = {
+      id: "adapter-user-id",
+      email: "",
+      emailVerified: null,
+    }
+
+    const mockAdapterInstance = mockAdapter()
+    mockAdapterInstance.getUserByAccount = jest
+      .fn()
+      .mockResolvedValueOnce(testUser)
+
+    const testSignature = await wallet.signMessage(testMessage.prepareMessage())
+
+    await handler(
+      {
+        adapter: mockAdapterInstance,
+        providers: [ethereumProvider],
+        callbacks: { signIn },
+        secret,
+      },
+      {
+        path: "callback/ethereum",
+        requestInit: {
+          method: "POST",
+          headers: { cookie: csrf.cookie },
+          body: JSON.stringify({
+            message: testMessage.prepareMessage(),
+            signature: testSignature,
+            csrfToken: csrf.value,
+          }),
+        },
+      }
+    )
+    expect(mockAdapterInstance.getUserByAccount).toHaveBeenCalledWith({
+      provider: "ethereum",
+      providerAccountId: wallet.address,
+    })
+    expect(signIn.mock.calls[0][0].user).toEqual(testUser)
+  })
+
+  it("calls signin after a valid signature", async () => {
+    const signIn = jest.fn<boolean, Parameters<CallbacksOptions["signIn"]>>(
+      () => false
+    )
+
+    const ethereumProvider = EthereumProvider({})
+
+    const testSignature = await wallet.signMessage(testMessage.prepareMessage())
+
+    const { res } = await handler(
+      {
+        adapter: mockAdapter(),
+        providers: [ethereumProvider],
+        callbacks: { signIn },
+        secret,
+      },
+      {
+        path: "callback/ethereum",
+        requestInit: {
+          method: "POST",
+          headers: { cookie: csrf.cookie },
+          body: JSON.stringify({
+            message: testMessage.prepareMessage(),
+            signature: testSignature,
+            csrfToken: csrf.value,
+          }),
+        },
+      }
+    )
+
+    expect(signIn).toHaveBeenCalledWith({
+      account: {
+        provider: "ethereum",
+        providerAccountId: wallet.address,
+        type: "ethereum",
+      },
+      user: {
+        id: wallet.address,
+      },
+    })
+
+    expect(res.redirect).toEqual(
+      "http://localhost:3000/api/auth/error?error=AccessDenied"
+    )
+  })
+
+  it("creates a new user if none exists", async () => {
+    const ethereumProvider = EthereumProvider({})
+
+    const testUser: AdapterUser = {
+      id: "adapter-user-id",
+      email: "",
+      emailVerified: null,
+    }
+    const mockAdapterInstance = mockAdapter()
+    mockAdapterInstance.createUser = jest.fn().mockResolvedValueOnce(testUser)
+
+    const testSignature = await wallet.signMessage(testMessage.prepareMessage())
+
+    await handler(
+      {
+        adapter: mockAdapterInstance,
+        providers: [ethereumProvider],
+        callbacks: {},
+        secret,
+      },
+      {
+        path: "callback/ethereum",
+        requestInit: {
+          method: "POST",
+          headers: { cookie: csrf.cookie },
+          body: JSON.stringify({
+            message: testMessage.prepareMessage(),
+            signature: testSignature,
+            csrfToken: csrf.value,
+          }),
+        },
+      }
+    )
+
+    expect(mockAdapterInstance.createUser).toHaveBeenCalledWith({
+      email: null,
+      emailVerified: null,
+      name: wallet.address,
+    })
+
+    expect(mockAdapterInstance.linkAccount).toHaveBeenCalledWith({
+      provider: "ethereum",
+      providerAccountId: wallet.address,
+      type: "ethereum",
+      userId: "adapter-user-id",
+    })
+  })
+
+  it("creates a session", async () => {
+    const ethereumProvider = EthereumProvider({})
+
+    const testUser: AdapterUser = {
+      id: "adapter-user-id",
+      email: "",
+      emailVerified: null,
+    }
+
+    const mockAdapterInstance = mockAdapter()
+    mockAdapterInstance.getUserByAccount = jest.fn().mockResolvedValue(testUser)
+    mockAdapterInstance.createSession = jest
+      .fn()
+      .mockImplementationOnce(async (x) => x)
+
+    const testSignature = await wallet.signMessage(testMessage.prepareMessage())
+
+    const { res } = await handler(
+      {
+        adapter: mockAdapterInstance,
+        providers: [ethereumProvider],
+        callbacks: {},
+        secret,
+      },
+      {
+        path: "callback/ethereum",
+        requestInit: {
+          method: "POST",
+          headers: { cookie: csrf.cookie },
+          body: JSON.stringify({
+            message: testMessage.prepareMessage(),
+            signature: testSignature,
+            csrfToken: csrf.value,
+          }),
+        },
+      }
+    )
+
+    expect(mockAdapterInstance.createSession).toHaveBeenCalled()
+    expect(
+      (mockAdapterInstance.createSession as jest.Mock).mock.calls[0][0].userId
+    ).toEqual("adapter-user-id")
+    const sessionToken = (mockAdapterInstance.createSession as jest.Mock).mock
+      .calls[0][0].sessionToken
+    expect(
+      /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/.test(
+        sessionToken
+      )
+    ).toEqual(true)
+    expect(
+      (mockAdapterInstance.createSession as jest.Mock).mock.calls[0][0].expires
+    ).toBeInstanceOf(Date)
+
+    expect(res.redirect).toEqual("http://localhost:3000")
+  })
+})

--- a/packages/next-auth/tests/lib.ts
+++ b/packages/next-auth/tests/lib.ts
@@ -47,9 +47,7 @@ export async function handler(
   }
 }
 
-export function createCSRF() {
-  const secret = "secret"
-  const value = "csrf"
+export function createCSRF(value: string = "csrf", secret: string = "secret") {
   const token = createHash("sha256").update(`${value}${secret}`).digest("hex")
 
   return {
@@ -60,8 +58,12 @@ export function createCSRF() {
 
 export function mockAdapter(): Adapter {
   const adapter: Adapter = {
+    createSession: jest.fn(() => {}),
+    createUser: jest.fn(() => {}),
     createVerificationToken: jest.fn(() => {}),
+    linkAccount: jest.fn(() => {}),
     useVerificationToken: jest.fn(() => {}),
+    getUserByAccount: jest.fn(() => {}),
     getUserByEmail: jest.fn(() => {}),
   }
   return adapter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,7 @@ importers:
       concurrently: ^7
       cookie: ^0.5.0
       cssnano: ^5.1.11
+      ethers: ^5.5.1
       jest: ^28.1.1
       jest-environment-jsdom: ^28.1.1
       jest-watch-typeahead: ^1.1.0
@@ -484,17 +485,20 @@ importers:
       preact-render-to-string: ^5.1.19
       react: ^18
       react-dom: ^18
+      siwe: ^2.1.3
       uuid: ^8.3.2
       whatwg-fetch: ^3.6.2
     dependencies:
       '@babel/runtime': 7.18.3
       '@panva/hkdf': 1.0.2
       cookie: 0.5.0
+      ethers: 5.7.2
       jose: 4.11.0
       oauth: 0.9.15
       openid-client: 5.1.6
       preact: 10.8.2
       preact-render-to-string: 5.2.0_preact@10.8.2
+      siwe: 2.1.3_ethers@5.7.2
       uuid: 8.3.2
     devDependencies:
       '@babel/cli': 7.17.10_@babel+core@7.18.5
@@ -5936,6 +5940,321 @@ packages:
       - supports-color
     dev: true
 
+  /@ethersproject/abi/5.7.0:
+    resolution: {integrity: sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==}
+    dependencies:
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/abstract-provider/5.7.0:
+    resolution: {integrity: sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+    dev: false
+
+  /@ethersproject/abstract-signer/5.7.0:
+    resolution: {integrity: sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+    dev: false
+
+  /@ethersproject/address/5.7.0:
+    resolution: {integrity: sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+    dev: false
+
+  /@ethersproject/base64/5.7.0:
+    resolution: {integrity: sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+    dev: false
+
+  /@ethersproject/basex/5.7.0:
+    resolution: {integrity: sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/properties': 5.7.0
+    dev: false
+
+  /@ethersproject/bignumber/5.7.0:
+    resolution: {integrity: sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      bn.js: 5.2.1
+    dev: false
+
+  /@ethersproject/bytes/5.7.0:
+    resolution: {integrity: sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/constants/5.7.0:
+    resolution: {integrity: sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+    dev: false
+
+  /@ethersproject/contracts/5.7.0:
+    resolution: {integrity: sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+    dev: false
+
+  /@ethersproject/hash/5.7.0:
+    resolution: {integrity: sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/hdnode/5.7.0:
+    resolution: {integrity: sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/wordlists': 5.7.0
+    dev: false
+
+  /@ethersproject/json-wallets/5.7.0:
+    resolution: {integrity: sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      aes-js: 3.0.0
+      scrypt-js: 3.0.1
+    dev: false
+
+  /@ethersproject/keccak256/5.7.0:
+    resolution: {integrity: sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      js-sha3: 0.8.0
+    dev: false
+
+  /@ethersproject/logger/5.7.0:
+    resolution: {integrity: sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==}
+    dev: false
+
+  /@ethersproject/networks/5.7.1:
+    resolution: {integrity: sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/pbkdf2/5.7.0:
+    resolution: {integrity: sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+    dev: false
+
+  /@ethersproject/properties/5.7.0:
+    resolution: {integrity: sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/providers/5.7.2:
+    resolution: {integrity: sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+      bech32: 1.1.4
+      ws: 7.4.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@ethersproject/random/5.7.0:
+    resolution: {integrity: sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/rlp/5.7.0:
+    resolution: {integrity: sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/sha2/5.7.0:
+    resolution: {integrity: sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/signing-key/5.7.0:
+    resolution: {integrity: sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      bn.js: 5.2.1
+      elliptic: 6.5.4
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/solidity/5.7.0:
+    resolution: {integrity: sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/strings/5.7.0:
+    resolution: {integrity: sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/transactions/5.7.0:
+    resolution: {integrity: sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==}
+    dependencies:
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+    dev: false
+
+  /@ethersproject/units/5.7.0:
+    resolution: {integrity: sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/wallet/5.7.0:
+    resolution: {integrity: sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/json-wallets': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/wordlists': 5.7.0
+    dev: false
+
+  /@ethersproject/web/5.7.1:
+    resolution: {integrity: sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==}
+    dependencies:
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/wordlists/5.7.0:
+    resolution: {integrity: sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
   /@fauna-labs/fauna-schema-migrate/2.2.1_faunadb@4.6.0:
     resolution: {integrity: sha512-UYefaEMYwAg810vYvbvgQ2TbYGvnA2ZITZiX/yLG6BBSQEfTfA47AfzYeF9+1SQ0NM1fpUdse6d5z2NDmeDiTw==}
     hasBin: true
@@ -7608,6 +7927,10 @@ packages:
     dev: true
     optional: true
 
+  /@noble/hashes/1.1.3:
+    resolution: {integrity: sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==}
+    dev: false
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -7828,9 +8151,39 @@ packages:
       webpack-sources: 3.2.3
     dev: true
 
+  /@spruceid/siwe-parser/2.0.2:
+    resolution: {integrity: sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==}
+    dependencies:
+      '@noble/hashes': 1.1.3
+      apg-js: 4.1.2
+      uri-js: 4.4.1
+      valid-url: 1.0.9
+    dev: false
+
   /@sqltools/formatter/1.2.3:
     resolution: {integrity: sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg==}
     dev: true
+
+  /@stablelib/binary/1.0.1:
+    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
+    dependencies:
+      '@stablelib/int': 1.0.1
+    dev: false
+
+  /@stablelib/int/1.0.1:
+    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
+    dev: false
+
+  /@stablelib/random/1.0.2:
+    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
+    dependencies:
+      '@stablelib/binary': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/wipe/1.0.1:
+    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
+    dev: false
 
   /@supabase/functions-js/2.0.0:
     resolution: {integrity: sha512-ozb7bds2yvf5k7NM2ZzUkxvsx4S4i2eRKFSJetdTADV91T65g4gCzEs9L3LUXSrghcGIkUaon03VPzOrFredqg==}
@@ -9429,6 +9782,10 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
+  /aes-js/3.0.0:
+    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+    dev: false
+
   /agent-base/6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -9616,6 +9973,10 @@ packages:
       normalize-path: 3.0.0
       picomatch: 2.3.1
     dev: true
+
+  /apg-js/4.1.2:
+    resolution: {integrity: sha512-2OALKUe82NLVPe4NTooom8NykWIa2D7YxO7jG1pgnYWnkfhTUriXpITmLvVD8k8TzDfa9G5O4y8rPe2/uUB1Bg==}
+    dev: false
 
   /app-root-path/3.0.0:
     resolution: {integrity: sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==}
@@ -10255,6 +10616,10 @@ packages:
       tweetnacl: 0.14.5
     dev: true
 
+  /bech32/1.1.4:
+    resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
+    dev: false
+
   /big-integer/1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
@@ -10307,6 +10672,14 @@ packages:
   /bluebird/3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
     dev: true
+
+  /bn.js/4.12.0:
+    resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
+    dev: false
+
+  /bn.js/5.2.1:
+    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
+    dev: false
 
   /body-parser/1.20.0:
     resolution: {integrity: sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==}
@@ -10406,6 +10779,10 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
+
+  /brorand/1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+    dev: false
 
   /browser-process-hrtime/1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
@@ -12718,6 +13095,18 @@ packages:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
     dev: true
 
+  /elliptic/6.5.4:
+    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
+    dependencies:
+      bn.js: 4.12.0
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
+
   /emittery/0.10.2:
     resolution: {integrity: sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==}
     engines: {node: '>=12'}
@@ -13364,6 +13753,44 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
     dev: true
+
+  /ethers/5.7.2:
+    resolution: {integrity: sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/json-wallets': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/providers': 5.7.2
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/solidity': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/units': 5.7.0
+      '@ethersproject/wallet': 5.7.0
+      '@ethersproject/web': 5.7.1
+      '@ethersproject/wordlists': 5.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
 
   /eval/0.1.8:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
@@ -14745,6 +15172,13 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /hash.js/1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: false
+
   /hast-to-hyperscript/9.0.1:
     resolution: {integrity: sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==}
     dependencies:
@@ -14830,6 +15264,14 @@ packages:
       tiny-warning: 1.0.3
       value-equal: 1.0.1
     dev: true
+
+  /hmac-drbg/1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
 
   /hoist-non-react-statics/3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -15222,7 +15664,6 @@ packages:
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /ini/1.3.7:
     resolution: {integrity: sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==}
@@ -17231,6 +17672,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /js-sha3/0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+    dev: false
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -18358,7 +18803,10 @@ packages:
 
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-    dev: true
+
+  /minimalistic-crypto-utils/1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+    dev: false
 
   /minimatch/3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
@@ -20622,7 +21070,6 @@ packages:
   /punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
-    dev: true
 
   /pupa/2.1.1:
     resolution: {integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==}
@@ -21527,6 +21974,10 @@ packages:
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: true
 
+  /scrypt-js/3.0.1:
+    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
+    dev: false
+
   /section-matter/1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
@@ -21857,6 +22308,18 @@ packages:
       arg: 5.0.2
       sax: 1.2.4
     dev: true
+
+  /siwe/2.1.3_ethers@5.7.2:
+    resolution: {integrity: sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==}
+    peerDependencies:
+      ethers: ^5.5.1
+    dependencies:
+      '@spruceid/siwe-parser': 2.0.2
+      '@stablelib/random': 1.0.2
+      ethers: 5.7.2
+      uri-js: 4.4.1
+      valid-url: 1.0.9
+    dev: false
 
   /slash/2.0.0:
     resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
@@ -23731,7 +24194,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
-    dev: true
 
   /url-join/0.0.1:
     resolution: {integrity: sha1-HbSK1CLTQCRpqH99l73r/k+x48g=}
@@ -23868,7 +24330,6 @@ packages:
 
   /valid-url/1.0.9:
     resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
-    dev: true
 
   /validate-npm-package-license/3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -24398,6 +24859,19 @@ packages:
     dependencies:
       readable-stream: 0.0.4
     dev: true
+
+  /ws/7.4.6:
+    resolution: {integrity: sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /ws/7.5.8:
     resolution: {integrity: sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==}


### PR DESCRIPTION
## Description

Add first-class support for Sign-In with Ethereum.
- Create an Ethereum provider
- Update callback to support `ethereum` provider type
- Add unit tests
- Add documentation

I realize this is a big change but would love to help get it across the finish line.

## ☕️ Reasoning

A few weeks ago I opened #5546. TLDR: NextAuth currently supports signing in with an Ethereum wallet through the credentials provider; however, doing so is subject to the intentional limitations of the credentials provider. Signing in with an Ethereum wallet is secure and password-less in the spirt of NextAuth and should be fully supported.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
