### PR TITLE
fix(next): correctly parse headers with RSC

### DIFF
--- a/apps/dev/app/server-component/page.tsx
+++ b/apps/dev/app/server-component/page.tsx
@@ -1,7 +1,6 @@
 import { unstable_getServerSession } from "next-auth/next"
-import { authOptions } from "pages/api/auth/[...nextauth]"
 
 export default async function Page() {
-  const session = await unstable_getServerSession(authOptions)
+  const session = await unstable_getServerSession()
   return <pre>{JSON.stringify(session, null, 2)}</pre>
 }

--- a/apps/dev/pages/api/examples/session.js
+++ b/apps/dev/pages/api/examples/session.js
@@ -3,6 +3,6 @@ import { unstable_getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 
 export default async (req, res) => {
-  const session = await unstable_getServerSession(authOptions)
+  const session = await unstable_getServerSession(req, res, authOptions)
   res.json(session)
 }

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -126,7 +126,7 @@ export async function unstable_getServerSession(
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { headers, cookies } = require("next/headers")
     req = {
-      headers,
+      headers: Object.fromEntries(headers() as Headers),
       cookies: Object.fromEntries(
         cookies()
           .getAll()

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -94,6 +94,7 @@ export async function unstable_getServerSession(
       ]
     | [NextApiRequest, NextApiResponse, NextAuthOptions]
     | [NextAuthOptions]
+    | []
 ): Promise<Session | null> {
   if (!experimentalWarningShown && process.env.NODE_ENV !== "production") {
     console.warn(
@@ -105,7 +106,7 @@ export async function unstable_getServerSession(
     experimentalWarningShown = true
   }
 
-  const isRSC = args.length === 1
+  const isRSC = args.length === 0 || args.length === 1
   if (
     !experimentalRSCWarningShown &&
     isRSC &&
@@ -122,7 +123,7 @@ export async function unstable_getServerSession(
 
   let req, res, options: NextAuthOptions
   if (isRSC) {
-    options = args[0]
+    options = args[0] ?? { providers: [] }
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { headers, cookies } = require("next/headers")
     req = {


### PR DESCRIPTION
We weren't correctly parsing `headers` and it caused issues when deployed.


Also, `authOptions` is not required anymore
```diff
- import { authOptions } from "pages/api/auth/[...nextauth]"

export default async function Page() {
-  const session = await unstable_getServerSession(authOptions)
+  const session = await unstable_getServerSession()
...
}
```


## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
