### PR TITLE
Remove formatVersion from schema

### DIFF
--- a/packages/adapter-xata/README.md
+++ b/packages/adapter-xata/README.md
@@ -41,7 +41,6 @@ Now that we're ready, let's create a new Xata project using our next-auth schema
 
 ```json title="schema.json"
 {
-  "formatVersion": "",
   "tables": [
     {
       "name": "nextauth_users",


### PR DESCRIPTION
Xata schema has removed the formatVersion field since Oct 2022, referencing it in a schema definition results in an error.