### PR TITLE
Do not throw exception if callbackUrl is malformed

### DIFF
--- a/packages/next-auth/src/core/lib/default-callbacks.ts
+++ b/packages/next-auth/src/core/lib/default-callbacks.ts
@@ -5,9 +5,13 @@ export const defaultCallbacks: CallbacksOptions = {
     return true
   },
   redirect({ url, baseUrl }) {
-    if (url.startsWith("/")) return `${baseUrl}${url}`
-    else if (new URL(url).origin === baseUrl) return url
-    return baseUrl
+    try {
+      if (url.startsWith("/")) return `${baseUrl}${url}`
+      else if (new URL(url).origin === baseUrl) return url
+      return baseUrl
+    } catch (err) {
+      return baseUrl
+    }
   },
   session({ session }) {
     return session


### PR DESCRIPTION
## ☕️ Reasoning

In our application we incorrectly had `callbackUrl: String(url)` which was producing `"undefined"` as `callbackUrl` sent to next-auth. Next auth was trying to do a `new URL` with it that was throwing an exception.

Even if the error was on our side, it would be nice from next auth to do not throw trying to parse the callback url and if it's malformed just ignore it.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
