### PR TITLE
made prisma adapter function a generic

### DIFF
--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -1,7 +1,7 @@
-import type { PrismaClient, Prisma } from "@prisma/client"
+import type { Prisma, PrismaClient } from "@prisma/client"
 import type { Adapter, AdapterAccount } from "next-auth/adapters"
 
-export function PrismaAdapter(p: PrismaClient): Adapter {
+export function PrismaAdapter<T extends PrismaClient>(p: T): Adapter {
   return {
     createUser: (data) => p.user.create({ data }),
     getUser: (id) => p.user.findUnique({ where: { id } }),


### PR DESCRIPTION
## ☕️ Reasoning

Transformed the PrismaAdapter function into a generic in order to be able to pass in any PrismaClient type. This change should allow the adapter to not throw an error when importing and using a prisma client that has been generated elsewhere.
