### PR TITLE
Added an example app to demonstrate sign-in and sign-up

### DIFF
--- a/docs/docs/providers/credentials.md
+++ b/docs/docs/providers/credentials.md
@@ -73,6 +73,15 @@ providers: [
 
 See the [callbacks documentation](/configuration/callbacks) for more information on how to interact with the token.
 
+## Example - Sign-in with email and password
+
+The credentials provider can be used to set-up authentication with email and password.
+
+For more information, check out the example app below:
+
+- [Example App Repo](https://github.com/Issam-Boubcher/credentials-next-auth-example).
+- [Example App Demo](https://credentials-next-auth-example.vercel.app/).
+
 ## Example - Web3 / Signin With Ethereum
 
 The credentials provider can also be used to integrate with a service like [Sign-in With Ethereum](https://login.xyz).


### PR DESCRIPTION
When I first tried out Next Auth, I found it really difficult to find a full example of using Next Auth for authentication in a Next app.
So today I made an example app that contains account creation front-end and back-end logic, Sign-in, and persisting user session locally with Recoil and Recoil Persist.
The example app is available here: https://github.com/Issam-Boubcher/credentials-next-auth-example.

Feel free to check it out and give feedback.