### PR TITLE
fix(next-auth): update docstring for jwt field in NextAuthOptions

### DIFF
--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -58,10 +58,8 @@ export interface NextAuthOptions {
    */
   session?: Partial<SessionOptions>
   /**
-   * JSON Web Tokens are enabled by default if you have not specified a database.
-   * By default JSON Web Tokens are signed (JWS) but not encrypted (JWE),
-   * as JWT encryption adds additional overhead and comes with some caveats.
-   * You can enable encryption by setting `encryption: true`.
+   * JSON Web Tokens are enabled by default if you have not specified an adapter.
+   * JSON Web Tokens are encrypted (JWE) by default. We recommend you keep this behaviour.
    * * **Default value**: See the documentation page
    * * **Required**: *No*
    *


### PR DESCRIPTION
## ☕️ Reasoning

The docs say that JWTs are encrypted by default:

<img width="965" alt="image" src="https://user-images.githubusercontent.com/32391231/201499759-6ac9c2d1-9558-4b0b-8610-62a064837319.png">

While the docstring begs to differ:

![image](https://user-images.githubusercontent.com/32391231/201499786-1b87ded3-4753-4301-b1b2-f6f11cbae019.png)

From the looks of the default implementation of `encode` in [jwt](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/jwt/index.ts), the docstring is incorrect and remnants of v3.

This led to me having to double check if the JWT was actually encrypted by default, so maybe this PR can save someone from doing the same digging.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Found no related issues for this. 


