### PR TITLE
chore: add tour de source link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Please raise any significant new functionality or breaking change an issue for d
 
 Anyone can be a contributor. Either you found a typo, or you have an awesome feature request you could implement, we encourage you to create a Pull Request.
 
+Before contributing, we recommend you read the [Tour de Source: NextAuth.js](https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTc2MQ==) post to become more familiar with the libraries inner workings.
+
 ### Pull Requests
 
 - The latest changes are always in `main`, so please make your Pull Request against that branch.


### PR DESCRIPTION
## ☕️ Reasoning

- Add recent ["Tour de Source"](https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTc2MQ==) blog post to the `CONTRIBUTING.md` to familiarise new contributors.
<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
