### PR TITLE
chore: fix import statement for `next-auth/providers/email`

### DIFF
--- a/docs/docs/configuration/providers/email.md
+++ b/docs/docs/configuration/providers/email.md
@@ -13,7 +13,7 @@ Adding support for signing in via email in addition to one or more OAuth service
 Configuration is similar to other providers, but the options are different:
 
 ```js title="pages/api/auth/[...nextauth].js"
-import EmailProvider from `next-auth/providers/email`
+import EmailProvider from "next-auth/providers/email"
 ...
 providers: [
   EmailProvider({


### PR DESCRIPTION
## ☕️ Reasoning

This PR fixes/removes the string templating import example for `next-auth/providers/email`.

The example for `next-auth/providers/email` uses string templating instead of standard quotes.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
