### PR TITLE
Fixes mistake in "Refresh Token Rotation" guide

### DIFF
--- a/docs/docs/tutorials/refresh-token-rotation.md
+++ b/docs/docs/tutorials/refresh-token-rotation.md
@@ -61,7 +61,7 @@ async function refreshAccessToken(token) {
     return {
       ...token,
       accessToken: refreshedTokens.access_token,
-      accessTokenExpires: Date.now() + refreshedTokens.expires_at * 1000,
+      accessTokenExpires: Date.now() + refreshedTokens.expires_in * 1000,
       refreshToken: refreshedTokens.refresh_token ?? token.refreshToken, // Fall back to old refresh token
     }
   } catch (error) {
@@ -88,7 +88,7 @@ export default NextAuth({
       if (account && user) {
         return {
           accessToken: account.access_token,
-          accessTokenExpires: Date.now() + account.expires_at * 1000,
+          accessTokenExpires: account.expires_at * 1000,
           refreshToken: account.refresh_token,
           user,
         }


### PR DESCRIPTION
The guide incorrectly suggests _adding_ the expires_at value to current timestamp. This is incorrect as expires_at refers to an actual time in the future and not a duration to append to current time.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
With reference to this guide: https://next-auth.js.org/tutorials/refresh-token-rotation

The guide currently does not seem to treat `expires_at` (upon initial login) and `expires_in` (upon refreshing token) correctly. 

Specifically, 
1. upon initial login, we get `expires_at` which is a point in time. It should not be added to current time to get the expiry time of the access token. 
2. upon refreshing tokens, we get `expires_in`. According to https://www.oauth.com/oauth2-servers/making-authenticated-requests/refreshing-an-access-token/ "The “expires_in” value is the number of seconds that the access token will be valid.". This value _should_ be appended to Date.now(). The current guide looks for `expires_at` rather than `expires_in` in the `refreshAccessToken()` function. 

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/5856

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
