### PR TITLE
fix(provider): modify response.name to response.nickname (Naver)

### DIFF
--- a/packages/next-auth/src/providers/naver.ts
+++ b/packages/next-auth/src/providers/naver.ts
@@ -31,7 +31,7 @@ export default function Naver<P extends NaverProfile>(
     profile(profile) {
       return {
         id: profile.response.id,
-        name: profile.response.name,
+        name: profile.response.nickname,
         email: profile.response.email,
         image: profile.response.profile_image,
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

```js
const { data: session } = useSession();
```

`session.user.name` is undefined. Because `profile.response`(naver.ts) has nickname not name. 

Here is profile object.
```js
// profile object
{
  resultcode: '00',
  message: 'success',
  response: {
    id: 'some-id',
    nickname: 'my nickname',
    profile_image: 'https://phinf.pstatic.net/contact/20221128_144/1669643453452gFEDI_PNG/image.png',
    email: 'mynickname@naver.com'
  }
}
```

So I modify from

```ts
name: profile.response.name
```

to

```ts
name: profile.response.nickname
```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: [Bug in Naver Provider](https://github.com/nextauthjs/next-auth/issues/5914)

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
