### PR TITLE
fix: dont mutate authOptions when calling unstable_getServerSession(req, res, authOptions)

### DIFF
--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -139,7 +139,7 @@ export async function unstable_getServerSession<
   } else {
     req = args[0]
     res = args[1]
-    options = Object.assign(args[2], { providers: [] })
+    options = Object.assign({}, args[2], { providers: [] })
   }
 
   const urlOrError = getURL(


### PR DESCRIPTION
Looks like next-auth@4.18.0 introduced a bug where the `authOptions` object is getting mutated when calling `unstable_getServerSession` with `req`, `res`, and `authOptions`.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: No open issue, but issue was mentioned [here](https://github.com/nextauthjs/next-auth/pull/5792/files#r1041317909).

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
