### PR TITLE
fix: incorrect signin redirect url on session required

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -124,7 +124,8 @@ export function useSession<R extends boolean>(options?: UseSessionOptions<R>) {
 
   React.useEffect(() => {
     if (requiredAndNotLoading) {
-      const url = `/api/auth/signin?${new URLSearchParams({
+      const baseUrl = apiBaseUrl(__NEXTAUTH)
+      const url = `${baseUrl}/signin?${new URLSearchParams({
         error: "SessionRequired",
         callbackUrl: window.location.href,
       })}`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

When session is required but not loaded, the signin url used to redirect to had a hardcoded root `/api/auth` instead of using the set `baseUrl`, this can lead to unexpected behaviour as mentioned in the issue linked below when setting a different `NEXTAUTH_URL` env variable.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #5296 

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
