### PR TITLE
fix: pass default protocol when parsing url from request host

### DIFF
--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -101,6 +101,7 @@ async function AuthHandlerInternal<
     csrfToken: req.body?.csrfToken,
     cookies: req.cookies,
     isPost: method === "POST",
+    isHttps: req.headers?.["x-forwarded-proto"] as unknown as string === "https"
   })
 
   const sessionStore = new SessionStore(

--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -26,6 +26,7 @@ interface InitParams {
   /** Is the incoming request a POST request? */
   isPost: boolean
   cookies: RequestInternal["cookies"]
+  isHttps: boolean
 }
 
 /** Initialize all internal options and cookies. */
@@ -38,11 +39,12 @@ export async function init({
   callbackUrl: reqCallbackUrl,
   csrfToken: reqCsrfToken,
   isPost,
+  isHttps,
 }: InitParams): Promise<{
   options: InternalOptions
   cookies: cookie.Cookie[]
 }> {
-  const url = parseUrl(host)
+  const url = parseUrl(host, isHttps ? "https" : "http")
 
   const secret = createSecret({ userOptions, url })
 

--- a/packages/next-auth/src/utils/parse-url.ts
+++ b/packages/next-auth/src/utils/parse-url.ts
@@ -12,11 +12,11 @@ export interface InternalUrl {
 }
 
 /** Returns an `URL` like object to make requests/redirects from server-side */
-export default function parseUrl(url?: string | URL): InternalUrl {
+export default function parseUrl(url?: string | URL, defaultProtocol: "http" | "https" = "https"): InternalUrl {
   const defaultUrl = new URL("http://localhost:3000/api/auth")
 
   if (url && !url.toString().startsWith("http")) {
-    url = `https://${url}`
+    url = `${defaultProtocol}://${url}`
   }
 
   const _url = new URL(url ?? defaultUrl)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

by default, `parseUrl(req.host)` assumes we're using `https`, this is not the case when running dev server locally.

for example:
```
http://localhost/api/auth/callback/email?token=1c02c18fd2eb405fd627a7beb7b46109cfa1544ccea1d46db6f4fdc03d76253d&email=test@example.com
```
gets redirected to:
```
https://localhost/api/auth/error?error=Callback
```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
