### PR TITLE
fix(core): correct status code when returning redirects

### DIFF
--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -277,9 +277,12 @@ export async function AuthHandler(
   // If the request expects a return URL, send it as JSON
   // instead of doing an actual redirect.
   const redirect = response.headers.get("Location")
-  if (request.headers.get("X-Auth-Return-Redirect") && redirect) {
+  if (request.headers.has("X-Auth-Return-Redirect") && redirect) {
+    response.headers.delete("Location")
+    response.headers.set("Content-Type", "application/json")
     return new Response(JSON.stringify({ url: redirect }), {
-      headers: { "Content-Type": "application/json" },
+      headers: response.headers,
+      status: 200,
     })
   }
   return response

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -271,5 +271,16 @@ export async function AuthHandler(
 ): Promise<Response> {
   const req = await toInternalRequest(request)
   const internalResponse = await AuthHandlerInternal({ req, options })
-  return toResponse(internalResponse)
+
+  const response = await toResponse(internalResponse)
+
+  // If the request expects a return URL, send it as JSON
+  // instead of doing an actual redirect.
+  const redirect = response.headers.get("Location")
+  if (request.headers.get("X-Auth-Return-Redirect") && redirect) {
+    return new Response(JSON.stringify({ url: redirect }), {
+      headers: { "Content-Type": "application/json" },
+    })
+  }
+  return response
 }

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -282,7 +282,6 @@ export async function AuthHandler(
     response.headers.set("Content-Type", "application/json")
     return new Response(JSON.stringify({ url: redirect }), {
       headers: response.headers,
-      status: 200,
     })
   }
   return response

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -34,19 +34,9 @@ async function NextAuthHandler(
 
   options.secret ??= options.jwt?.secret ?? process.env.NEXTAUTH_SECRET
   const response = await AuthHandler(request, options)
-  const { status, headers } = response
-  res.status(status)
 
-  setHeaders(headers, res)
-
-  // If the request expects a return URL, send it as JSON
-  // instead of doing an actual redirect.
-  const redirect = headers.get("Location")
-
-  if (req.body?.json === "true" && redirect) {
-    res.removeHeader("Location")
-    return res.json({ url: redirect })
-  }
+  res.status(response.status)
+  setHeaders(response.headers, res)
 
   return res.send(await response.text())
 }

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -241,13 +241,13 @@ export async function signIn<
     method: "post",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
+      "X-Auth-Return-Redirect": "1",
     },
     // @ts-expect-error
     body: new URLSearchParams({
       ...options,
       csrfToken: await getCsrfToken(),
       callbackUrl,
-      json: true,
     }),
   })
 
@@ -291,12 +291,11 @@ export async function signOut<R extends boolean = true>(
     method: "post",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
+      "X-Auth-Return-Redirect": "1",
     },
-    // @ts-expect-error
     body: new URLSearchParams({
-      csrfToken: await getCsrfToken(),
+      csrfToken: (await getCsrfToken()) ?? "",
       callbackUrl,
-      json: true,
     }),
   }
   const res = await fetch(`${baseUrl}/signout`, fetchOptions)

--- a/packages/next-auth/tests/next.test.ts
+++ b/packages/next-auth/tests/next.test.ts
@@ -109,7 +109,15 @@ it("Returns redirect if `X-Auth-Return-Redirect` header is present", async () =>
 
   expect(res.status).toBeCalledWith(200)
   expect(res.setHeader).toBeCalledWith("content-type", "application/json")
-  expect(res.setHeader).toBeCalledTimes(1)
+  expect(res.setHeader).toBeCalledWith("set-cookie", [
+    expect.stringMatching(
+      /next-auth.csrf-token=.*; Path=\/; HttpOnly; SameSite=Lax/
+    ),
+    `next-auth.callback-url=${encodeURIComponent(
+      process.env.NEXTAUTH_URL
+    )}; Path=/; HttpOnly; SameSite=Lax`,
+  ])
+  expect(res.setHeader).toBeCalledTimes(2)
   expect(res.send).toBeCalledWith(
     JSON.stringify({ url: "http://localhost/api/auth/signin?csrf=true" })
   )

--- a/packages/next-auth/tests/next.test.ts
+++ b/packages/next-auth/tests/next.test.ts
@@ -82,12 +82,35 @@ it("Redirects if necessary", async () => {
     req: {
       method: "post",
       url: "/api/auth/signin/github",
-      body: { json: "true" },
     },
   })
   expect(res.status).toBeCalledWith(302)
-  expect(res.removeHeader).toBeCalledWith("Location")
-  expect(res.json).toBeCalledWith({
-    url: "http://localhost/api/auth/signin?csrf=true",
+  expect(res.setHeader).toBeCalledWith("set-cookie", [
+    expect.stringMatching(
+      /next-auth.csrf-token=.*; Path=\/; HttpOnly; SameSite=Lax/
+    ),
+    `next-auth.callback-url=${encodeURIComponent(
+      process.env.NEXTAUTH_URL
+    )}; Path=/; HttpOnly; SameSite=Lax`,
+  ])
+  expect(res.setHeader).toBeCalledTimes(2)
+  expect(res.send).toBeCalledWith("")
+})
+
+it("Returns redirect if `X-Auth-Return-Redirect` header is present", async () => {
+  process.env.NEXTAUTH_URL = "http://localhost"
+  const { res } = await nodeHandler({
+    req: {
+      method: "post",
+      url: "/api/auth/signin/github",
+      headers: { "X-Auth-Return-Redirect": "1" },
+    },
   })
+
+  expect(res.status).toBeCalledWith(200)
+  expect(res.setHeader).toBeCalledWith("content-type", "application/json")
+  expect(res.setHeader).toBeCalledTimes(1)
+  expect(res.send).toBeCalledWith(
+    JSON.stringify({ url: "http://localhost/api/auth/signin?csrf=true" })
+  )
 })


### PR DESCRIPTION
Continues #5991, Fixes #6001

The refactor in #4769 changes how we set status codes in the Node.js environment, and it set `302` instead of `200` even if the redirection was turned into a JSON response.

In this PR, I changed the way we handle redirection by relying on a `X-Auth-Return-Redirect` header rather than a `json: true` property in the request body.