### PR TITLE
fix(sveltekit): correctly reference SvelteKit as peer dependency

### DIFF
--- a/packages/frameworks-sveltekit/package.json
+++ b/packages/frameworks-sveltekit/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "svelte": "^3.54.0",
-    "svelte-kit": "^1.0.0"
+    "@sveltejs/kit": "^1.0.0"
   },
   "type": "module",
   "types": "./index.d.ts",


### PR DESCRIPTION
You added wrong peer dependency svelte-kit@^1.0.0  instead of @sveltejs/kit": "^1.0.0
