### PR TITLE
DOCS: Fixing the wrong closing tag on oauth-tutorial

### DIFF
--- a/docs/docs/getting-started/02-oauth-tutorial.mdx
+++ b/docs/docs/getting-started/02-oauth-tutorial.mdx
@@ -112,7 +112,7 @@ export default function CamperVanPage() {
         <p>Signed in as {userEmail}</p>
         <button onClick={() => signOut()}>Sign out</button>
         <img src="https://cdn.pixabay.com/photo/2017/08/11/19/36/vw-2632486_1280.png" />
-      </img>
+      </>
     )
   }
 


### PR DESCRIPTION
Changed closing tag on pages/overview.tsx from `</img>` to `</>`

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
On the Oauth Tutorial docs page under the "Consuming the session via hooks" section the code block for `status === "authenticated"` closes with `</img>` when it should be `</>`

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

