### PR TITLE
Add sveltekit specific callback URL pattern

### DIFF
--- a/docs/docs/reference/03-sveltekit/index.md
+++ b/docs/docs/reference/03-sveltekit/index.md
@@ -26,6 +26,11 @@ export const handle = SvelteKitAuth({
 })
 ```
 
+The callback URL used should have the following pattern:
+```
+[origin]/auth/callback/[provider]
+``` 
+
 Don't forget to set the `AUTH_SECRET` [environment variable](https://kit.svelte.dev/docs/modules#$env-static-private). This should be a random 32 character string. On unix systems you can use `openssl rand -hex 32` or check out `https://generate-secret.vercel.app/32`.
 
 When deploying your app outside Vercel, set the `AUTH_TRUST_HOST` variable to `true` for other hosting providers like Cloudflare Pages or Netlify.


### PR DESCRIPTION
## ☕️ Reasoning

Currently the callback URL is missing from the docs. The only reference I could find was here: https://authjs.dev/getting-started/oauth-tutorial. There the pattern is described as [origin]/api/auth/callback/[provider]. This is wrong for the SvelteKit package.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
