### PR TITLE
fix: don't delete userInfo.request

### DIFF
--- a/packages/core/src/lib/providers.ts
+++ b/packages/core/src/lib/providers.ts
@@ -97,5 +97,5 @@ function normalizeEndpoint(
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   for (const k in e.params) url.searchParams.set(k, e.params[k] as any)
 
-  return { url }
+  return { ...e, url }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

The `normalizeEndpoint` function in `packages/core/src/lib/providers.ts` removes the `request` key from a provider's `userInfo` object. Same thing happens with `authorization.params`. It's causing some issues like not being able to get user's email in GitHub provider.

I know I should have opened an issue first but since I tracked it down to the source it is probably easier for you to identify the issue this way (and fix it if my fix isn't appropriate :))

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
