### PR TITLE
Fixed the broken link of  Contributing Guide in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ And thats all! Now you should have a local copy of this docs site running at [lo
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please first read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/docs/docs/contributors.md).
+We're open to all community contributions! If you'd like to contribute in any way, please first read our [Contributing Guide](https://github.com/nextauthjs/.github/blob/63cd813065552b522785c7a07980366178634ecf/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ And thats all! Now you should have a local copy of this docs site running at [lo
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please first read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please first read our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/docs/docs/contributors.md).
 
 ## License
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](../Security.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Here I changed the broken link of the homepage README file [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md) into [Contributing Guide](https://github.com/nextauthjs/.github/blob/63cd813065552b522785c7a07980366178634ecf/CONTRIBUTING.md).

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Here is the issue https://github.com/nextauthjs/next-auth/issues/6190

## 📌 Resources

- [Security guidelines](../Security.md)
- [Contributing guidelines](../CONTRIBUTING.md)
- [Code of conduct](../CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
