### PR TITLE
feat(core): introduce `AuthRequest` and `AuthResponse` web extensions (RFC)

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,6 +9,7 @@ module.exports = {
       files: [
         "apps/dev/pages/api/auth/[...nextauth].ts",
         "docs/{sidebars,docusaurus.config}.js",
+        "packages/core/src/index.ts",
       ],
       options: { printWidth: 150 },
     },

--- a/apps/dev/nextjs/pages/api/examples/session.js
+++ b/apps/dev/nextjs/pages/api/examples/session.js
@@ -1,8 +1,0 @@
-// This is an example of how to access a session from an API route
-import { unstable_getServerSession } from "next-auth/next"
-import { authOptions } from "../auth/[...nextauth]"
-
-export default async (req, res) => {
-  const session = await unstable_getServerSession(req, res, authOptions)
-  res.json(session)
-}

--- a/apps/dev/nextjs/pages/api/examples/session.ts
+++ b/apps/dev/nextjs/pages/api/examples/session.ts
@@ -1,0 +1,21 @@
+import { Auth, SessionRequest } from "@auth/core"
+import { authConfig } from "../auth/[...nextauth]"
+
+export default async function handle(req: Request) {
+  authConfig.secret = process.env.AUTH_SECRET
+
+  const response = await Auth(new SessionRequest(req), authConfig)
+  const session = await response.session()
+  if (!session) {
+    return new Response("Not authenticated", { status: 401 })
+  }
+
+  console.log(session.user) // Do something with the session
+  // Pass the original headers to set cookies (eg.: updating the session expiry)
+  response.headers.set("content-type", "text/plain")
+  return new Response("Authenticated", { headers: response.headers })
+}
+
+export const config = {
+  runtime: "experimental-edge",
+}

--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -293,6 +293,6 @@ html[data-theme="dark"] #carbonads .carbon-poweredby {
  See: https://github.com/TypeStrong/typedoc/issues/2006
 */
 /* h3.anchor + p:has(code, strong), */ /** hack did not work as it hides property types elsewhere */
-#classes {
+/* #classes {
   display: none;
-}
+} */

--- a/packages/core/src/lib/web-extension.ts
+++ b/packages/core/src/lib/web-extension.ts
@@ -1,0 +1,95 @@
+import type { AuthAction, Session } from "../types.js"
+import { PublicProvider } from "./routes/providers.js"
+
+/** @internal */
+export abstract class AuthRequest extends Request {
+  abstract action: AuthAction
+}
+
+/**
+ * Extends the standard {@link Request} to add a `session()` method on the response
+ * for retrieving the {@link Session} object.
+ */
+export class SessionRequest extends AuthRequest {
+  action = "session" as const
+  constructor(req: Request) {
+    super(req.url, req)
+  }
+}
+
+export class SessionResponse extends Response {
+  action = "session" as const
+
+  /**
+   * Returns the {@link Session} object from the response, or `null`
+   * if the session is unavailable (config error, not authenticated, etc.).
+   *
+   * @example
+   * ```ts
+   * export default async function handle(req: Request) {
+   *   const response = await Auth(new SessionRequest(req), authConfig)
+   *   const session = await response.session()
+   *
+   *   if (!session) {
+   *     return new Response("Not authenticated", { status: 401 })
+   *   }
+   *
+   *   console.log(session.user) // Do something with the session
+   *   return response // or return whatever you want.
+   * }
+   * ```
+   */
+  async session(): Promise<Session | null> {
+    try {
+      const data = await this.clone().json()
+      if (!this.ok || !data || !Object.keys(data).length) {
+        return null
+      }
+      return data
+    } catch {
+      return null
+    }
+  }
+}
+
+/**
+ * Extends the standard {@link Request} to add a `providers()` method on the response
+ * for retrieving a list of client-safe provider configuration. Useful for
+ * rendering a list of sign-in options.
+ */
+export class ProvidersRequest extends AuthRequest {
+  action = "providers" as const
+  constructor(req: Request) {
+    super(req.url, req)
+  }
+}
+
+export class ProvidersResponse extends Response {
+  action = "providers" as const
+
+  /**
+   * Returns the list of providers from the response, or `null`
+   * if the providers are unavailable (config error, etc.).
+   * @example
+   * ```ts
+   * export default async function handle(req: Request) {
+   *  const response = await Auth(new ProvidersRequest(req), authConfig)
+   * const providers = await response.providers()
+   * if (!providers) {
+   *  return new Response("Providers unavailable", { status: 500 })
+   *
+   *
+   * console.log(providers) // Do something with the providers
+   * return response // or return whatever you want.
+   * }
+   * ```
+   */
+  async providers(): Promise<PublicProvider[]> {
+    try {
+      if (!this.ok) return []
+      return Object.values(await this.clone().json())
+    } catch {
+      return []
+    }
+  }
+}

--- a/packages/core/src/lib/web.ts
+++ b/packages/core/src/lib/web.ts
@@ -2,6 +2,7 @@ import { parse as parseCookie, serialize } from "cookie"
 import { AuthError, UnknownAction } from "../errors.js"
 
 import type { AuthAction, RequestInternal, ResponseInternal } from "../types.js"
+import { ProvidersRequest, SessionRequest } from "./web-extension.js"
 
 async function getBody(req: Request): Promise<Record<string, any> | undefined> {
   if (!("body" in req) || !req.body || req.method !== "POST") return
@@ -34,8 +35,11 @@ export async function toInternalRequest(
     // see init.ts
     const url = new URL(req.url.replace(/\/$/, ""))
     const { pathname } = url
+    let action: AuthAction | undefined
+    if (req instanceof SessionRequest || req instanceof ProvidersRequest) {
+      action = req.action
+    } else action = actions.find((a) => pathname.includes(a))
 
-    const action = actions.find((a) => pathname.includes(a))
     if (!action) {
       throw new UnknownAction("Cannot detect action.")
     }


### PR DESCRIPTION
Implements this RFC: https://github.com/nextauthjs/next-auth/discussions/6246

The following extensions are added:

- `SessionRequest`/`SessionResponse`
- `ProvidersRequest`/`ProvidersResponse`