### PR TITLE
Remove callback urls warning for GitHub provider

### DIFF
--- a/docs/docs/providers/github.md
+++ b/docs/docs/providers/github.md
@@ -37,10 +37,6 @@ providers: [
 ...
 ```
 
-:::warning
-Only allows one callback URL per Client ID / Client Secret.
-:::
-
 :::tip
 Email address is always returned, even if the user doesn't have a public email address on their profile.
 :::


### PR DESCRIPTION
## ☕️ Reasoning

GitHub has supported multiple callback URLs since 2020 
See: https://github.blog/changelog/2020-10-26-github-apps-api-updates-now-ga/#multiple-callback-urls

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged


