### PR TITLE
fix: alter getURL to utilise NEXTAUTH_URL_INTERNAL if defined

### DIFF
--- a/packages/next-auth/src/utils/node.ts
+++ b/packages/next-auth/src/utils/node.ts
@@ -32,8 +32,8 @@ export function getBody(
 export function getURL(url: string | undefined, headers: Headers): URL | Error {
   try {
     if (!url) throw new Error("Missing url")
-    if (process.env.NEXTAUTH_URL) {
-      const base = new URL(process.env.NEXTAUTH_URL)
+    if (process.env.NEXTAUTH_URL_INTERNAL ?? process.env.NEXTAUTH_URL) {
+      const base = new URL(process.env.NEXTAUTH_URL_INTERNAL ?? process.env.NEXTAUTH_URL)
       if (!["http:", "https:"].includes(base.protocol)) {
         throw new Error("Invalid protocol")
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
## ☕️ Reasoning

This will close out #6306 where `unstable_getServerSession` was not utilising the `NEXTAUTH_URL_INTERNAL` env variable even though the docs say all server side calls will use it. 

In an environment where the full canonical URL of the application cannot be resolved when server side, this causes issues if you utilise `unstable_getServerSession` for session information when rendering server side or in an API route. 

## 🧢 Checklist

- [X] Documentation => Existing documentation implies this is already the case!
- [ ] Tests
- [x] Ready to be merged => Subject toa  maintainer confirming they are happy 🙂

## 🎫 Affected issues

Fixes: #6306

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
