### PR TITLE
fix: typo on example resposne -> response

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,7 +61,7 @@ import { JWTOptions } from "./jwt.js"
  * import Auth from "@auth/core"
  *
  * const request = new Request("https://example.com")
- * const resposne = await AuthHandler(request, {
+ * const response = await AuthHandler(request, {
  *   providers: [...],
  *   secret: "...",
  *   trustHost: true,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,7 +157,7 @@ export async function Auth(
  * export const authConfig: AuthConfig = {...}
  *
  * const request = new Request("https://example.com")
- * const resposne = await AuthHandler(request, authConfig)
+ * const response = await AuthHandler(request, authConfig)
  * ```
  *
  * @see [Initiailzation](https://authjs.dev/reference/configuration/auth-options)


### PR DESCRIPTION
Nothing fancy just a typo I spotted in auth/core: resposne instead of response.