### PR TITLE
Update index.ts

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -71,7 +71,7 @@
  * ## Managing the session
  *
  * The above example checks for a session available in `$page.data.session`, however that needs to be set by us somewhere.
- * If you want this data to be available to all your routes you can add this to your root `+page.server.ts` file.
+ * If you want this data to be available to all your routes you can add this to your root `+layout.server.ts` file.
  * The following code sets the session data in the `$page` store to be available to all routes.
  *
  * ```ts


### PR DESCRIPTION
Fix documentation mistake - page.server.ts -> layout.server.ts

## ☕️ Reasoning

Current documentation suggests adding to +page.server.ts which doesn't provide the desired functionality and is contradicted by the type hinting in the following code snippet. +layout.server.ts is the correct filename.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

None

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
