### PR TITLE
feat: allow async `generateSessionToken`

### DIFF
--- a/packages/next-auth/src/core/lib/callback-handler.ts
+++ b/packages/next-auth/src/core/lib/callback-handler.ts
@@ -113,7 +113,7 @@ export default async function callbackHandler(params: {
     session = useJwtSession
       ? {}
       : await createSession({
-          sessionToken: generateSessionToken(),
+          sessionToken: await generateSessionToken(),
           userId: user.id,
           expires: fromDate(options.session.maxAge),
         })
@@ -143,7 +143,7 @@ export default async function callbackHandler(params: {
       session = useJwtSession
         ? {}
         : await createSession({
-            sessionToken: generateSessionToken(),
+            sessionToken: await generateSessionToken(),
             userId: userByAccount.id,
             expires: fromDate(options.session.maxAge),
           })
@@ -216,7 +216,7 @@ export default async function callbackHandler(params: {
       session = useJwtSession
         ? {}
         : await createSession({
-            sessionToken: generateSessionToken(),
+            sessionToken: await generateSessionToken(),
             userId: user.id,
             expires: fromDate(options.session.maxAge),
           })


### PR DESCRIPTION
Some random string libraries are async (such as nanoid). It would be great if `generateSessionToken()` can be async. This is backwards compatible as await'ing a sync function will work without issues.