### PR TITLE
fix(sveltekit): avoid prefetch of non-existing routes

### DIFF
--- a/apps/examples/sveltekit/src/routes/+layout.svelte
+++ b/apps/examples/sveltekit/src/routes/+layout.svelte
@@ -20,10 +20,10 @@
                 $page.data.session.user?.name}</strong
             >
           </span>
-          <a href="/auth/signout" class="button">Sign out</a>
+          <a href="/auth/signout" class="button" data-sveltekit-preload-data="off">Sign out</a>
         {:else}
           <span class="notSignedInText">You are not signed in</span>
-          <a href="/auth/signin" class="buttonPrimary">Sign in</a>
+          <a href="/auth/signin" class="buttonPrimary" data-sveltekit-preload-data="off">Sign in</a>
         {/if}
       </p>
     </div>


### PR DESCRIPTION
This avoids prefetch of the /auth/signin and /auth/signout virtual links as they do not exist in sveltkit routes

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Hovering over signin and signout tries to prefetch data and gives the error:

client.js?t=1673349053920&v=e21ecb81:207 Uncaught (in promise) Error: Attempted to preload a URL that does not belong to this app: http://localhost:5173/auth/signin
    at preload_data (client.js?t=1673349053920&v=e21ecb81:207:10)
    at preload (client.js?t=1673349053920&v=e21ecb81:1184:6)
    at client.js?t=1673349053920&v=e21ecb81:1145:5


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes #6185

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
