### PR TITLE
Remove Demo Identity server

### DIFF
--- a/docs/docs/providers/identity-server4.md
+++ b/docs/docs/providers/identity-server4.md
@@ -35,27 +35,3 @@ providers: [
 ]
 ...
 ```
-
-## Demo IdentityServer
-
-The configuration below is for the demo server at https://demo.identityserver.io/
-
-If you want to try it out, you can copy and paste the configuration below.
-
-You can sign in to the demo service with either <b>bob/bob</b> or <b>alice/alice</b>.
-
-```js
-import IdentityServer4Provider from `next-auth/providers/identity-server4`
-...
-providers: [
-  IdentityServer4Provider({
-    id: "demo-identity-server",
-    name: "Demo IdentityServer4",
-    authorization: { params: { scope: "openid profile email api offline_access" } },
-    issuer:  "https://demo.identityserver.io/",
-    clientId: "interactive.confidential",
-    clientSecret: "secret",
-  })
-}
-...
-```


### PR DESCRIPTION
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Since the demo is not working anymore (removed), we should remove the demo identity server from the docs
## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: [Demo link in ID4 not working](https://github.com/nextauthjs/next-auth/issues/6349?notification_referrer_id=NT_kwDOAsN8lLM1Mjg2MDc5MTQ1OjQ2MzY1ODQ0#event-8191176486)
