### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/docs/reference/05-oauth-providers/battlenet.md
+++ b/docs/docs/reference/05-oauth-providers/battlenet.md
@@ -15,7 +15,7 @@ https://develop.battle.net/access/clients
 
 The **Battle.net Provider** comes with a set of default options:
 
-- [Battle.net Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/battlenet.js)
+- [Battle.net Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/battlenet.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/docs/reference/05-oauth-providers/github.md
+++ b/docs/docs/reference/05-oauth-providers/github.md
@@ -19,7 +19,7 @@ https://github.com/settings/apps
 
 The **GitHub Provider** comes with a set of default options:
 
-- [GitHub Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/github.js)
+- [GitHub Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/github.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/docs/reference/05-oauth-providers/gitlab.md
+++ b/docs/docs/reference/05-oauth-providers/gitlab.md
@@ -15,7 +15,7 @@ https://gitlab.com/-/profile/applications
 
 The **Gitlab Provider** comes with a set of default options:
 
-- [Gitlab Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/gitlab.js)
+- [Gitlab Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/gitlab.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/docs/reference/05-oauth-providers/kakao.md
+++ b/docs/docs/reference/05-oauth-providers/kakao.md
@@ -15,7 +15,7 @@ https://developers.kakao.com/docs/latest/en/kakaologin/common
 
 The **Kakao Provider** comes with a set of default options:
 
-- [Kakao Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/kakao.js)
+- [Kakao Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/kakao.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/docs/reference/05-oauth-providers/salesforce.md
+++ b/docs/docs/reference/05-oauth-providers/salesforce.md
@@ -11,7 +11,7 @@ https://help.salesforce.com/articleView?id=remoteaccess_authenticate.htm&type=5
 
 The **Salesforce Provider** comes with a set of default options:
 
-- [Salesforce Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/salesforce.js)
+- [Salesforce Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/salesforce.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/docs/reference/05-oauth-providers/vk.md
+++ b/docs/docs/reference/05-oauth-providers/vk.md
@@ -15,7 +15,7 @@ https://vk.com/apps?act=manage
 
 The **VK Provider** comes with a set of default options:
 
-- [VK Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/vk.js)
+- [VK Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/vk.ts)
 
 You can override any of the options to suit your own use case.
 


### PR DESCRIPTION

## ☕️ Reasoning
- Fix broken link in the new documentation .
- Documentation refers to files that are written in vanilla  `.js`, but the files are actually written in typescript `.ts`

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] ~Tests~
- [ ] Ready to be merged

## 🎫 Affected issues

NONE

