### PR TITLE
fix(providers): conform Twitch provider to spec with escape hatch

### DIFF
--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -68,8 +68,6 @@ export async function handleOAuth(
   const client: o.Client = {
     client_id: provider.clientId,
     client_secret: provider.clientSecret,
-    token_endpoint_auth_method: as
-      .token_endpoint_auth_methods_supported?.[0] as o.ClientAuthenticationMethod,
     ...provider.client,
   }
 

--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -104,13 +104,19 @@ export async function handleOAuth(
     resCookies.push(nonce.cookie)
   }
 
-  const codeGrantResponse = await o.authorizationCodeGrantRequest(
+  let codeGrantResponse = await o.authorizationCodeGrantRequest(
     as,
     client,
     parameters,
     provider.callbackUrl,
     codeVerifier?.codeVerifier ?? "auth" // TODO: review fallback code verifier
   )
+
+  if (provider.token?.conform) {
+    codeGrantResponse =
+      (await provider.token.conform(codeGrantResponse.clone())) ??
+      codeGrantResponse
+  }
 
   let challenges: o.WWWAuthenticateChallenge[] | undefined
   if ((challenges = o.parseWwwAuthenticateChallenges(codeGrantResponse))) {

--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -68,6 +68,8 @@ export async function handleOAuth(
   const client: o.Client = {
     client_id: provider.clientId,
     client_secret: provider.clientSecret,
+    token_endpoint_auth_method: as
+      .token_endpoint_auth_methods_supported?.[0] as o.ClientAuthenticationMethod,
     ...provider.client,
   }
 

--- a/packages/core/src/lib/providers.ts
+++ b/packages/core/src/lib/providers.ts
@@ -96,5 +96,9 @@ function normalizeEndpoint(
   // NOTE: This need to be checked when constructing the URL
   // for the authorization, token and userinfo endpoints.
   const url = new URL(e?.url ?? "https://authjs.dev")
+  for (const k in e?.params) {
+    if (e?.params && k === "claims") e.params[k] = JSON.stringify(e.params[k])
+    url.searchParams.set(k, e?.params[k])
+  }
   return { url, request: e?.request, conform: e?.conform }
 }

--- a/packages/core/src/lib/providers.ts
+++ b/packages/core/src/lib/providers.ts
@@ -96,6 +96,5 @@ function normalizeEndpoint(
   // NOTE: This need to be checked when constructing the URL
   // for the authorization, token and userinfo endpoints.
   const url = new URL(e?.url ?? "https://authjs.dev")
-  for (const k in e?.params) url.searchParams.set(k, e?.params[k])
-  return { url, request: e?.request }
+  return { url, request: e?.request, conform: e?.conform }
 }

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -42,6 +42,8 @@ interface AdvancedEndpointHandler<P extends UrlParams, C, R> {
    * You should **try to avoid using advanced options** unless you are very comfortable using them.
    */
   request?: EndpointRequest<C, R, P>
+  /** @internal */
+  conform?: (response: Response) => Awaitable<Response | undefined>
 }
 
 /** Either an URL (containing all the parameters) or an object with more granular control. */
@@ -184,7 +186,11 @@ export type OAuthConfigInternal<Profile> = Omit<
   OAuthEndpointType
 > & {
   authorization?: { url: URL }
-  token?: { url: URL; request?: TokenEndpointHandler["request"] }
+  token?: {
+    url: URL
+    request?: TokenEndpointHandler["request"]
+    conform?: TokenEndpointHandler["conform"]
+  }
   userinfo?: { url: URL; request?: UserinfoEndpointHandler["request"] }
 } & Pick<Required<OAuthConfig<Profile>>, "clientId" | "checks" | "profile">
 

--- a/packages/core/src/providers/twitch.ts
+++ b/packages/core/src/providers/twitch.ts
@@ -1,4 +1,4 @@
-import type { OAuthConfig, OAuthUserConfig } from "./index.js"
+import type { OIDCConfig, OIDCUserConfig } from "./index.js"
 
 export interface TwitchProfile extends Record<string, any> {
   sub: string
@@ -7,9 +7,9 @@ export interface TwitchProfile extends Record<string, any> {
   picture: string
 }
 
-export default function Twitch<P extends TwitchProfile>(
-  options: OAuthUserConfig<P>
-): OAuthConfig<P> {
+export default function Twitch(
+  config: OIDCUserConfig<TwitchProfile>
+): OIDCConfig<TwitchProfile> {
   return {
     issuer: "https://id.twitch.tv/oauth2",
     id: "twitch",
@@ -19,12 +19,37 @@ export default function Twitch<P extends TwitchProfile>(
       params: {
         scope: "openid user:read:email",
         claims: {
-          id_token: {
-            email: null,
-            picture: null,
-            preferred_username: null,
-          },
+          id_token: { email: null, picture: null, preferred_username: null },
         },
+      },
+    },
+    token: {
+      async conform(response) {
+        const body = await response.json()
+        if (response.ok) {
+          if (typeof body.scope === "string") {
+            console.warn(
+              "'scope' is a string. Redundant workaround, please open an issue."
+            )
+          } else if (Array.isArray(body.scope)) {
+            body.scope = body.scope.join(" ")
+            return new Response(JSON.stringify(body), response)
+          } else if ("scope" in body) {
+            delete body.scope
+            return new Response(JSON.stringify(body), response)
+          }
+        } else {
+          const { message: error_description, error } = body
+          if (typeof error !== "string") {
+            return new Response(
+              JSON.stringify({ error: "invalid_request", error_description }),
+              response
+            )
+          }
+          console.warn(
+            "Response has 'error'. Redundant workaround, please open an issue."
+          )
+        }
       },
     },
     style: {
@@ -35,6 +60,6 @@ export default function Twitch<P extends TwitchProfile>(
       bgDark: "#65459B",
       textDark: "#fff",
     },
-    options,
+    options: config,
   }
 }

--- a/packages/core/src/providers/twitch.ts
+++ b/packages/core/src/providers/twitch.ts
@@ -15,6 +15,7 @@ export default function Twitch(
     id: "twitch",
     name: "Twitch",
     type: "oidc",
+    client: { token_endpoint_auth_method: "client_secret_post" },
     authorization: {
       params: {
         scope: "openid user:read:email",


### PR DESCRIPTION
Fixes #6363

This PR introduces a new `conform()` callback for the `token` OAuth config option. It's marked as internal for now, and not expected to be used in user-land. This is an escape hatch to work around non-conformities in our built-in providers in a way that does not require a full `request` override, but also does not add special handling to providers into the core.

This is a last resort, and ideally, such issues should be fixed on the Provider side. If you see this method and have the power, we encourage you to put pressure on the given provider so they fix the issue on their side.

Once a non-conformity is fixed, the `conform()` method will be pass-through and will show a warning. In this case, you can file an issue on this repo so we can remove the workaround.