### PR TITLE
support baseUrl from client SessionProvider

### DIFF
--- a/packages/next-auth/src/client/_utils.ts
+++ b/packages/next-auth/src/client/_utils.ts
@@ -15,6 +15,8 @@ export interface AuthClientConfig {
    * trigger session updates from places like `signIn` or `signOut`
    */
   _getSession: (...args: any[]) => any
+
+  credentials?: RequestCredentials
 }
 
 export interface CtxOrReq {
@@ -40,7 +42,10 @@ export async function fetchData<T = any>(
     const options = req?.headers.cookie
       ? { headers: { cookie: req.headers.cookie } }
       : {}
-    const res = await fetch(url, options)
+    const res = await fetch(url, {
+      ...options,
+      credentials: __NEXTAUTH.credentials || "same-origin",
+    })
     const data = await res.json()
     if (!res.ok) throw data
     return Object.keys(data).length > 0 ? data : null // Return null if data empty
@@ -56,7 +61,7 @@ export function apiBaseUrl(__NEXTAUTH: AuthClientConfig) {
     return `${__NEXTAUTH.baseUrlServer}${__NEXTAUTH.basePathServer}`
   }
   // Return relative path when called client side
-  return __NEXTAUTH.basePath
+  return `${__NEXTAUTH.baseUrl}${__NEXTAUTH.basePath}`
 }
 
 /** Returns the number of seconds elapsed since January 1, 1970 00:00:00 UTC. */

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -329,9 +329,18 @@ export function SessionProvider(props: SessionProviderProps) {
     throw new Error("React Context is unavailable in Server Components")
   }
 
-  const { children, basePath, refetchInterval, refetchWhenOffline } = props
+  const {
+    children,
+    basePath,
+    baseUrl,
+    credentials,
+    refetchInterval,
+    refetchWhenOffline,
+  } = props
 
   if (basePath) __NEXTAUTH.basePath = basePath
+  if (baseUrl) __NEXTAUTH.baseUrl = baseUrl
+  if (credentials) __NEXTAUTH.credentials = credentials
 
   /**
    * If session was `null`, there was an attempt to fetch it,

--- a/packages/next-auth/src/react/types.ts
+++ b/packages/next-auth/src/react/types.ts
@@ -66,6 +66,7 @@ export interface SessionProviderProps {
   session?: Session | null
   baseUrl?: string
   basePath?: string
+  credentials?: RequestCredentials
   /**
    * A time interval (in seconds) after which the session will be re-fetched.
    * If set to `0` (default), the session is not polled.


### PR DESCRIPTION
## ☕️ Reasoning

Support the baseUrl prop of SessionProvider (it's already being provided but not working currently), so that we can depoly our auth service standalone using a differnt subdomain from our other service, which mean we can share one auth server with multi sites.

I also add a `credentials` option which represents the fetch option `credentials`, we need to pass it as `include` when making cross-site request otherwise fetch will not take the cookies.

## 🧢 Checklist

**This is an early preview PR for maintainers to give some feedback if we should support this feature. I tried to add unit tests but the old test can not run on my computer either so I may need more time to figure out the reason. So I will spend time for tests and documentation after we confirm that we will support this feature.**

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: Only a dicussion right now (and no feedback) https://github.com/nextauthjs/next-auth/discussions/6385

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
