### PR TITLE
Pass oauth_token_secret in OAuth 1.0 calls

### DIFF
--- a/packages/next-auth/src/core/lib/oauth/authorization-url.ts
+++ b/packages/next-auth/src/core/lib/oauth/authorization-url.ts
@@ -8,6 +8,7 @@ import type { AuthorizationParameters } from "openid-client"
 import type { InternalOptions } from "../../types"
 import type { RequestInternal } from "../.."
 import type { Cookie } from "../cookie"
+import oAuth1TokenStore from "./oauth1-token-store"
 
 /**
  *
@@ -44,7 +45,7 @@ export default async function getAuthorizationUrl({
       oauth_token_secret: tokens.oauth_token_secret,
       ...tokens.params,
     })}`
-
+    oAuth1TokenStore.setTokenSecret(tokens.oauth_token, tokens.oauth_token_secret);
     logger.debug("GET_AUTHORIZATION_URL", { url, provider })
     return { redirect: url }
   }

--- a/packages/next-auth/src/core/lib/oauth/oauth1-token-store.ts
+++ b/packages/next-auth/src/core/lib/oauth/oauth1-token-store.ts
@@ -1,0 +1,11 @@
+const _storage = new Map();
+
+const oAuth1TokenStore = {
+  setTokenSecret: (token, tokenSecret) => _storage.set(token, tokenSecret),
+  getTokenSecret: function (token) { 
+    return _storage.get(token); 
+  },
+  removeTokenSecret: (token) => _storage.delete(token),
+}
+
+export default oAuth1TokenStore;


### PR DESCRIPTION
## ☕️ Reasoning
Right now oauth_token_secret is being ignored in OAuth 1.0 calls made by Next Auth despite that this secret token is needed by some APIs, e.g. USOS API (University Study-Oriented System is an app used by Polish universities).

Our Computerization Comittee of Students' Council is moving from Google OAuth towards USOS OAuth and the lack of proper OAuth 1.0 support is a reason why we had to fork this repository.
