### PR TITLE
fix: Allow adding own logo to provider

### DIFF
--- a/packages/next-auth/src/core/pages/signin.tsx
+++ b/packages/next-auth/src/core/pages/signin.tsx
@@ -118,13 +118,15 @@ export default function SigninPage(props: SignInServerPageParams) {
                   {provider.style?.logo && (
                     <img
                       id="provider-logo"
-                      src={`https://authjs.dev/img/providers/${provider.style.logo}`}
+                      src={(provider.style.logo.startsWith('https://') || provider.style.logo.startsWith('http://'))
+                        ? provider.style.logo : `https://authjs.dev/img/providers/${provider.style.logo}`}
                     />
                   )}
                   {provider.style?.logoDark && (
                     <img
                       id="provider-logo-dark"
-                      src={`https://authjs.dev/img/providers/${provider.style.logoDark}`}
+                      src={(provider.style.logoDark.startsWith('https://') || provider.style.logoDark.startsWith('http://'))
+                        ? provider.style.logoDark : `https://authjs.dev/img/providers/${provider.style.logoDark}`}
                     />
                   )}
                   <span>Sign in with {provider.name}</span>


### PR DESCRIPTION
## ☕️ Reasoning

Right now next-auth doesn't support adding own logo to provider. 