### PR TITLE
docs: update "guide deep-dive" link

### DIFF
--- a/docs/docs/reference/04-providers/04-email.md
+++ b/docs/docs/reference/04-providers/04-email.md
@@ -16,4 +16,4 @@ sidebar_label: Email options
 See our guides on magic links authentication for further tips on how to customize this provider:
 
 - [Tutorial](/getting-started/email-tutorial)
-- [Guide deep-dive](guides/providers/email)
+- [Guide deep-dive](/guides/providers/email)


### PR DESCRIPTION
## ☕️ Reasoning

Fixed broken link at https://authjs.dev/reference/providers/email for "Guide deep-dive".
The path was relative. Adding a '/' at the start fixed it.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes:  #6466

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
