### PR TITLE
Make next 12.1.X compatible

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -77,7 +77,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "next": "^12.2.5 || ^13",
+    "next": "^12.1.0 || ^13",
     "nodemailer": "^6.6.5",
     "react": "^17.0.2 || ^18",
     "react-dom": "^17.0.2 || ^18"


### PR DESCRIPTION
## ☕️ Reasoning

I'm using `next@12.1.x` and I would like to use the latest `next-auth` features. The current version of `next-auth` is compatible with it, so why not include it.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues

When installing with `next@12.1.x` throws an error because of the `peerDependencies`.
