### PR TITLE
feat: remove `unstable_` prefix `getServerSession`

### DIFF
--- a/apps/dev/app/server-component/page.tsx
+++ b/apps/dev/app/server-component/page.tsx
@@ -1,6 +1,6 @@
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 
 export default async function Page() {
-  const session = await unstable_getServerSession()
+  const session = await getServerSession()
   return <pre>{JSON.stringify(session, null, 2)}</pre>
 }

--- a/apps/dev/pages/api/examples/protected.js
+++ b/apps/dev/pages/api/examples/protected.js
@@ -1,9 +1,9 @@
 // This is an example of to protect an API route
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 
 export default async (req, res) => {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
 
   if (session) {
     res.send({

--- a/apps/dev/pages/api/examples/session.js
+++ b/apps/dev/pages/api/examples/session.js
@@ -1,8 +1,8 @@
 // This is an example of how to access a session from an API route
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 
 export default async (req, res) => {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
   res.json(session)
 }

--- a/apps/dev/pages/api/examples/supabase-rls.js
+++ b/apps/dev/pages/api/examples/supabase-rls.js
@@ -1,11 +1,11 @@
 // This is an example of how to query data from Supabase with RLS.
 // Learn more about Row Levele Security (RLS): https://supabase.com/docs/guides/auth/row-level-security
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 import { createClient } from "@supabase/supabase-js"
 
 export default async (req, res) => {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
 
   if (!session)
     return res.send(JSON.stringify({ error: "No session!" }, null, 2))

--- a/apps/dev/pages/protected-ssr.js
+++ b/apps/dev/pages/protected-ssr.js
@@ -1,5 +1,5 @@
 // This is an example of how to protect content using server rendering
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "./api/auth/[...nextauth]"
 import Layout from "../components/layout"
 import AccessDenied from "../components/access-denied"
@@ -26,11 +26,7 @@ export default function Page({ content, session }) {
 }
 
 export async function getServerSideProps(context) {
-  const session = await unstable_getServerSession(
-    context.req,
-    context.res,
-    authOptions
-  )
+  const session = await getServerSession(context.req, context.res, authOptions)
   let content = null
 
   if (session) {

--- a/apps/dev/pages/server.js
+++ b/apps/dev/pages/server.js
@@ -1,6 +1,6 @@
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import Layout from "../components/layout"
-import { authOptions } from './api/auth/[...nextauth]';
+import { authOptions } from "./api/auth/[...nextauth]"
 
 export default function Page() {
   // As this page uses Server Side Rendering, the `session` will be already
@@ -12,11 +12,11 @@ export default function Page() {
     <Layout>
       <h1>Server Side Rendering</h1>
       <p>
-        This page uses the <strong>unstable_getServerSession()</strong> method
-        in <strong>getServerSideProps()</strong>.
+        This page uses the <strong>getServerSession()</strong> method in{" "}
+        <strong>getServerSideProps()</strong>.
       </p>
       <p>
-        Using <strong>unstable_getServerSession()</strong> in{" "}
+        Using <strong>getServerSession()</strong> in{" "}
         <strong>getServerSideProps()</strong> is currently the recommended
         approach, although the API may still change, if you need to support
         Server Side Rendering with authentication.
@@ -40,11 +40,7 @@ export default function Page() {
 export async function getServerSideProps(context) {
   return {
     props: {
-      session: await unstable_getServerSession(
-        context.req,
-        context.res,
-        authOptions
-      ),
+      session: await getServerSession(context.req, context.res, authOptions),
     },
   }
 }

--- a/apps/dev/pages/supabase-ssr.js
+++ b/apps/dev/pages/supabase-ssr.js
@@ -1,6 +1,6 @@
 // This is an example of how to protect content using server rendering
 // and fetching data from Supabase with RLS enabled.
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "./api/auth/[...nextauth]"
 import { createClient } from "@supabase/supabase-js"
 import Layout from "../components/layout"
@@ -27,11 +27,7 @@ export default function Page({ data, session }) {
 }
 
 export async function getServerSideProps(context) {
-  const session = await unstable_getServerSession(
-    context.req,
-    context.res,
-    authOptions
-  )
+  const session = await getServerSession(context.req, context.res, authOptions)
 
   if (!session)
     return {

--- a/apps/example-nextjs/pages/api/examples/protected.ts
+++ b/apps/example-nextjs/pages/api/examples/protected.ts
@@ -1,5 +1,5 @@
 // This is an example of to protect an API route
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 
 import type { NextApiRequest, NextApiResponse } from "next"
@@ -8,7 +8,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
 
   if (session) {
     return res.send({

--- a/apps/example-nextjs/pages/api/examples/session.ts
+++ b/apps/example-nextjs/pages/api/examples/session.ts
@@ -1,5 +1,5 @@
 // This is an example of how to access a session from an API route
-import { unstable_getServerSession } from "next-auth"
+import { getServerSession } from "next-auth"
 import { authOptions } from "../auth/[...nextauth]"
 
 import type { NextApiRequest, NextApiResponse } from "next"
@@ -8,6 +8,6 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
   res.send(JSON.stringify(session, null, 2))
 }

--- a/apps/example-nextjs/pages/server.tsx
+++ b/apps/example-nextjs/pages/server.tsx
@@ -1,4 +1,4 @@
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "./api/auth/[...nextauth]"
 import Layout from "../components/layout"
 
@@ -12,11 +12,11 @@ export default function ServerSidePage({ session }: { session: Session }) {
     <Layout>
       <h1>Server Side Rendering</h1>
       <p>
-        This page uses the <strong>unstable_getServerSession()</strong> method
-        in <strong>getServerSideProps()</strong>.
+        This page uses the <strong>getServerSession()</strong> method in{" "}
+        <strong>getServerSideProps()</strong>.
       </p>
       <p>
-        Using <strong>unstable_getServerSession()</strong> in{" "}
+        Using <strong>getServerSession()</strong> in{" "}
         <strong>getServerSideProps()</strong> is the recommended approach if you
         need to support Server Side Rendering with authentication.
       </p>
@@ -37,11 +37,7 @@ export default function ServerSidePage({ session }: { session: Session }) {
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   return {
     props: {
-      session: await unstable_getServerSession(
-        context.req,
-        context.res,
-        authOptions
-      ),
+      session: await getServerSession(context.req, context.res, authOptions),
     },
   }
 }

--- a/docs/docs/adapters/supabase.md
+++ b/docs/docs/adapters/supabase.md
@@ -254,7 +254,7 @@ The `supabaseAccessToken` is now available on the `session` object and can be pa
 
 ```js
 // ...
-// Use `useSession()` or `unstable_getServerSession()` to get the NextAuth session.
+// Use `useSession()` or `getServerSession()` to get the NextAuth session.
 
 const { supabaseAccessToken } = session
 

--- a/docs/docs/configuration/callbacks.md
+++ b/docs/docs/configuration/callbacks.md
@@ -107,7 +107,7 @@ The redirect callback may be invoked more than once in the same flow.
 This callback is called whenever a JSON Web Token is created (i.e. at sign
 in) or updated (i.e whenever a session is accessed in the client). The returned value will be [encrypted](/configuration/options#jwt), and it is stored in a cookie.
 
-Requests to `/api/auth/signin`, `/api/auth/session` and calls to `getSession()`, `unstable_getServerSession()`, `useSession()` will invoke this function, but only if you are using a [JWT session](/configuration/options#session). This method is not invoked when you persist sessions in a database.
+Requests to `/api/auth/signin`, `/api/auth/session` and calls to `getSession()`, `getServerSession()`, `useSession()` will invoke this function, but only if you are using a [JWT session](/configuration/options#session). This method is not invoked when you persist sessions in a database.
 
 - As with database persisted session expiry times, token expiry time is extended whenever a session is active.
 - The arguments _user_, _account_, _profile_ and _isNewUser_ are only passed the first time this callback is called on a new session, after the user signs in. In subsequent calls, only `token` will be available.

--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -2,15 +2,15 @@
 
 ## `unstable_getServerSession`
 
-:::warning
-This feature is experimental and may be removed or changed in the future.
-:::
+This method was renamed to `getServerSession`. See the documentation below.
 
-When calling from server-side i.e. in API routes or in `getServerSideProps`, we recommend using this function instead of `getSession` to retrieve the `session` object. This method is especially useful when you are using NextAuth.js with a database. This method can _drastically_ reduce response time when used over `getSession` server-side, due to avoiding an extra `fetch` to an API Route (this is generally [not recommended in Next.js](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props#getserversideprops-or-api-routes)). In addition, `unstable_getServerSession` will correctly update the cookie expiry time and update the session content if `callbacks.jwt` or `callbacks.session` changed something.
+## `getServerSession`
+
+When calling from server-side i.e. in API routes or in `getServerSideProps`, we recommend using this function instead of `getSession` to retrieve the `session` object. This method is especially useful when you are using NextAuth.js with a database. This method can _drastically_ reduce response time when used over `getSession` server-side, due to avoiding an extra `fetch` to an API Route (this is generally [not recommended in Next.js](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props#getserversideprops-or-api-routes)). In addition, `getServerSession` will correctly update the cookie expiry time and update the session content if `callbacks.jwt` or `callbacks.session` changed something.
 
 Otherwise, if you only want to get the session token, see [`getToken`](/tutorials/securing-pages-and-api-routes#using-gettoken).
 
-`unstable_getServerSession` requires passing the same object you would pass to `NextAuth` when initializing NextAuth.js. To do so, you can export your NextAuth.js options in the following way:
+`getServerSession` requires passing the same object you would pass to `NextAuth` when initializing NextAuth.js. To do so, you can export your NextAuth.js options in the following way:
 
 In `[...nextauth].ts`:
 ```ts
@@ -27,10 +27,10 @@ export default NextAuth(authOptions);
 ### In `getServerSideProps`:
 ```js
 import { authOptions } from 'pages/api/auth/[...nextauth]'
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 
 export async function getServerSideProps(context) {
-  const session = await unstable_getServerSession(context.req, context.res, authOptions)
+  const session = await getServerSession(context.req, context.res, authOptions)
 
   if (!session) {
     return {
@@ -52,11 +52,11 @@ export async function getServerSideProps(context) {
 ### In API Routes:
 ```js
 import { authOptions } from 'pages/api/auth/[...nextauth]'
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 
 
 export async function handler(req, res) {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
 
   if (!session) {
     res.status(401).json({ message: "You must be logged in." });
@@ -71,14 +71,14 @@ export async function handler(req, res) {
 
 ### In `app/` directory:
 
-You can also use `unstable_getServerSession` in Next.js' server components:
+You can also use `getServerSession` in Next.js' server components:
 
 ```tsx
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "pages/api/auth/[...nextauth]"
 
 export default async function Page() {
-  const session = await unstable_getServerSession(authOptions)
+  const session = await getServerSession(authOptions)
   return <pre>{JSON.stringify(session, null, 2)}</pre>
 }
 ```

--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -157,14 +157,14 @@ You can create your own session management solution using data fetching librarie
 ## getSession()
 
 - Client Side: **Yes**
-- Server Side: **No** (See: [`unstable_getServerSession()`](/configuration/nextjs#unstable_getserversession)
+- Server Side: **No** (See: [`getServerSession()`](/configuration/nextjs#unstable_getserversession)
 
 NextAuth.js provides a `getSession()` helper which should be called **client side only** to return the current active session.
 
-On the server side, **this is still available to use**, however, we recommend using `unstable_getServerSession` going forward. The idea behind this is to avoid an additional unnecessary `fetch` call on the server side. For more information, please check out [this issue](https://github.com/nextauthjs/next-auth/issues/1535).
+On the server side, **this is still available to use**, however, we recommend using `getServerSession` going forward. The idea behind this is to avoid an additional unnecessary `fetch` call on the server side. For more information, please check out [this issue](https://github.com/nextauthjs/next-auth/issues/1535).
 
 :::note
-The `unstable_getServerSession` only has the prefix `unstable_` at the moment, because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any issues, please do report them as a [GitHub Issue](https://github.com/nextauthjs/next-auth/issues) and we will patch them as soon as possible.
+The `getServerSession` only has the prefix `unstable_` at the moment, because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any issues, please do report them as a [GitHub Issue](https://github.com/nextauthjs/next-auth/issues) and we will patch them as soon as possible.
 :::
 
 This helper is helpful in case you want to read the session outside of the context of React.
@@ -178,7 +178,7 @@ async function myFunction() {
 }
 ```
 
-Read the tutorial [securing pages and API routes](/tutorials/securing-pages-and-api-routes) to know how to fetch the session in server side calls using `unstable_getServerSession()`.
+Read the tutorial [securing pages and API routes](/tutorials/securing-pages-and-api-routes) to know how to fetch the session in server side calls using `getServerSession()`.
 
 ---
 
@@ -422,7 +422,7 @@ If you pass the `session` page prop to the `<SessionProvider>` – as in the exa
 This only works on pages where you provide the correct `pageProps`, however. This is normally done in `getInitialProps` or `getServerSideProps` on an individual page basis like so:
 
 ```js title="pages/index.js"
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from './api/auth/[...nextauth]'
 
 ...
@@ -430,7 +430,7 @@ import { authOptions } from './api/auth/[...nextauth]'
 export async function getServerSideProps({ req, res }) {
   return {
     props: {
-      session: await unstable_getServerSession(req, res, authOptions)
+      session: await getServerSession(req, res, authOptions)
     }
   }
 }

--- a/docs/docs/getting-started/example.md
+++ b/docs/docs/getting-started/example.md
@@ -106,14 +106,14 @@ You can use the `useSession` hook from anywhere in your application (e.g. in a h
 
 ### Backend - API Route
 
-To protect an API Route, you can use the [`unstable_getServerSession()`](/configuration/nextjs#unstable_getserversession) method.
+To protect an API Route, you can use the [`getServerSession()`](/configuration/nextjs#unstable_getserversession) method.
 
 ```javascript title="pages/api/restricted.js" showLineNumbers
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "./auth/[...nextauth]"
 
 export default async (req, res) => {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
 
   if (session) {
     res.send({

--- a/docs/docs/tutorials/securing-pages-and-api-routes.md
+++ b/docs/docs/tutorials/securing-pages-and-api-routes.md
@@ -68,12 +68,12 @@ For other patterns check out the [Next.js Middleware documentation](https://next
 
 ### Server Side
 
-You can protect server side rendered pages using the `unstable_getServerSession` method. This is different from the old `getSession()` method, in that it does not do an extra fetch out over the internet to confirm data from itself, increasing performance significantly.
+You can protect server side rendered pages using the `getServerSession` method. This is different from the old `getSession()` method, in that it does not do an extra fetch out over the internet to confirm data from itself, increasing performance significantly.
 
-You need to add this to every server rendered page you want to protect. Be aware, `unstable_getServerSession` takes slightly different arguments than the method it is replacing, `getSession`.
+You need to add this to every server rendered page you want to protect. Be aware, `getServerSession` takes slightly different arguments than the method it is replacing, `getSession`.
 
 ```js title="pages/server-side-example.js"
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "./api/auth/[...nextauth]"
 import { useSession } from "next-auth/react"
 
@@ -96,7 +96,7 @@ export default function Page() {
 export async function getServerSideProps(context) {
   return {
     props: {
-      session: await unstable_getServerSession(
+      session: await getServerSession(
         context.req,
         context.res,
         authOptions
@@ -128,16 +128,16 @@ export default function App({
 
 ## Securing API Routes
 
-### Using unstable_getServerSession()
+### Using getServerSession()
 
-You can protect API routes using the `unstable_getServerSession()` method.
+You can protect API routes using the `getServerSession()` method.
 
 ```js title="pages/api/get-session-example.js"
-import { unstable_getServerSession } from "next-auth/next"
+import { getServerSession } from "next-auth/next"
 import { authOptions } from "./auth/[...nextauth]"
 
 export default async (req, res) => {
-  const session = await unstable_getServerSession(req, res, authOptions)
+  const session = await getServerSession(req, res, authOptions)
   if (session) {
     // Signed in
     console.log("Session", JSON.stringify(session, null, 2))

--- a/packages/next-auth/src/core/lib/assert.ts
+++ b/packages/next-auth/src/core/lib/assert.ts
@@ -61,7 +61,7 @@ export function assertConfig(params: {
     return new MissingSecret("Please define a `secret` in production.")
   }
 
-  // req.query isn't defined when asserting `unstable_getServerSession` for example
+  // req.query isn't defined when asserting `getServerSession` for example
   if (!req.query?.nextauth && !req.action) {
     return new MissingAPIRoute(
       "Cannot find [...nextauth].{js,ts} in `/pages/api/auth`. Make sure the filename is written correctly."

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -82,7 +82,6 @@ function NextAuth(
 
 export default NextAuth
 
-let experimentalWarningShown = false
 let experimentalRSCWarningShown = false
 
 type GetServerSessionOptions = Partial<Omit<AuthOptions, "callbacks">> & {
@@ -91,7 +90,7 @@ type GetServerSessionOptions = Partial<Omit<AuthOptions, "callbacks">> & {
   }
 }
 
-export async function unstable_getServerSession<
+export async function getServerSession<
   O extends GetServerSessionOptions,
   R = O["callbacks"] extends { session: (...args: any[]) => infer U }
     ? U
@@ -103,16 +102,6 @@ export async function unstable_getServerSession<
     | [O]
     | []
 ): Promise<R | null> {
-  if (!experimentalWarningShown && process.env.NODE_ENV !== "production") {
-    console.warn(
-      "[next-auth][warn][EXPERIMENTAL_API]",
-      "\n`unstable_getServerSession` is experimental and may be removed or changed in the future, as the name suggested.",
-      `\nhttps://next-auth.js.org/configuration/nextjs#unstable_getServerSession}`,
-      `\nhttps://next-auth.js.org/warnings#EXPERIMENTAL_API`
-    )
-    experimentalWarningShown = true
-  }
-
   const isRSC = args.length === 0 || args.length === 1
   if (
     !experimentalRSCWarningShown &&
@@ -121,8 +110,8 @@ export async function unstable_getServerSession<
   ) {
     console.warn(
       "[next-auth][warn][EXPERIMENTAL_API]",
-      "\n`unstable_getServerSession` is used in a React Server Component.",
-      `\nhttps://next-auth.js.org/configuration/nextjs#unstable_getServerSession}`,
+      "\n`getServerSession` is used in a React Server Component.",
+      `\nhttps://next-auth.js.org/configuration/nextjs#getServerSession}`,
       `\nhttps://next-auth.js.org/warnings#EXPERIMENTAL_API`
     )
     experimentalRSCWarningShown = true
@@ -176,6 +165,22 @@ export async function unstable_getServerSession<
   }
 
   return null
+}
+
+let deprecatedWarningShown = false
+
+/** @deprecated renamed to `getServerSession` */
+export function unstable_getServerSession(
+  ...args: Parameters<typeof getServerSession>
+): ReturnType<typeof getServerSession> {
+  if (!deprecatedWarningShown && process.env.NODE_ENV !== "production") {
+    console.warn(
+      "`unstable_getServerSession` has been renamed to `getServerSession`."
+    )
+    deprecatedWarningShown = true
+  }
+
+  return getServerSession(...args)
 }
 
 declare global {

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -170,7 +170,7 @@ export async function getServerSession<
 let deprecatedWarningShown = false
 
 /** @deprecated renamed to `getServerSession` */
-export function unstable_getServerSession(
+export async function unstable_getServerSession(
   ...args: Parameters<typeof getServerSession>
 ): ReturnType<typeof getServerSession> {
   if (!deprecatedWarningShown && process.env.NODE_ENV !== "production") {
@@ -180,7 +180,7 @@ export function unstable_getServerSession(
     deprecatedWarningShown = true
   }
 
-  return getServerSession(...args)
+  return await getServerSession(...args)
 }
 
 declare global {

--- a/packages/next-auth/tests/getServerSession.test.ts
+++ b/packages/next-auth/tests/getServerSession.test.ts
@@ -57,24 +57,6 @@ describe("Treat secret correctly", () => {
     expect(logger.error).toBeCalledTimes(1)
     expect(logger.error).toBeCalledWith("NO_SECRET", expect.any(MissingSecret))
   })
-
-  it("Only logs warning once and in development", async () => {
-    process.env.NEXTAUTH_SECRET = "secret"
-    // Expect console.warn to NOT be called due to NODE_ENV=production
-    await getServerSession(req, res, { providers: [], logger })
-    expect(console.warn).toBeCalledTimes(0)
-
-    // Expect console.warn to be called ONCE due to NODE_ENV=development
-    // @ts-expect-error
-    process.env.NODE_ENV = "development"
-    await getServerSession(req, res, { providers: [], logger })
-    expect(console.warn).toBeCalledTimes(1)
-
-    // Expect console.warn to be still only be called ONCE
-    await getServerSession(req, res, { providers: [], logger })
-    expect(console.warn).toBeCalledTimes(1)
-    delete process.env.NEXTAUTH_SECRET
-  })
 })
 
 describe("Return correct data", () => {

--- a/packages/next-auth/tests/getServerSession.test.ts
+++ b/packages/next-auth/tests/getServerSession.test.ts
@@ -1,6 +1,6 @@
 import * as core from "../src/core"
 import { MissingSecret } from "../src/core/errors"
-import { unstable_getServerSession } from "../src/next"
+import { getServerSession } from "../src/next"
 import { mockLogger } from "./lib"
 
 const originalWarn = console.warn
@@ -27,7 +27,7 @@ afterEach(() => {
 describe("Treat secret correctly", () => {
   it("Read from NEXTAUTH_SECRET", async () => {
     process.env.NEXTAUTH_SECRET = "secret"
-    await unstable_getServerSession(req, res, { providers: [], logger })
+    await getServerSession(req, res, { providers: [], logger })
 
     expect(logger.error).toBeCalledTimes(0)
     expect(logger.error).not.toBeCalledWith("NO_SECRET")
@@ -36,7 +36,7 @@ describe("Treat secret correctly", () => {
   })
 
   it("Read from options.secret", async () => {
-    await unstable_getServerSession(req, res, {
+    await getServerSession(req, res, {
       providers: [],
       logger,
       secret: "secret",
@@ -51,7 +51,7 @@ describe("Treat secret correctly", () => {
       "There is a problem with the server configuration. Check the server logs for more information."
     )
     await expect(
-      unstable_getServerSession(req, res, { providers: [], logger })
+      getServerSession(req, res, { providers: [], logger })
     ).rejects.toThrowError(configError)
 
     expect(logger.error).toBeCalledTimes(1)
@@ -61,17 +61,17 @@ describe("Treat secret correctly", () => {
   it("Only logs warning once and in development", async () => {
     process.env.NEXTAUTH_SECRET = "secret"
     // Expect console.warn to NOT be called due to NODE_ENV=production
-    await unstable_getServerSession(req, res, { providers: [], logger })
+    await getServerSession(req, res, { providers: [], logger })
     expect(console.warn).toBeCalledTimes(0)
 
     // Expect console.warn to be called ONCE due to NODE_ENV=development
     // @ts-expect-error
     process.env.NODE_ENV = "development"
-    await unstable_getServerSession(req, res, { providers: [], logger })
+    await getServerSession(req, res, { providers: [], logger })
     expect(console.warn).toBeCalledTimes(1)
 
     // Expect console.warn to be still only be called ONCE
-    await unstable_getServerSession(req, res, { providers: [], logger })
+    await getServerSession(req, res, { providers: [], logger })
     expect(console.warn).toBeCalledTimes(1)
     delete process.env.NEXTAUTH_SECRET
   })
@@ -87,7 +87,7 @@ describe("Return correct data", () => {
     // @ts-expect-error
     spy.mockReturnValue({ body: {} })
 
-    const session = await unstable_getServerSession(req, res, {
+    const session = await getServerSession(req, res, {
       providers: [],
       logger,
       secret: "secret",
@@ -113,7 +113,7 @@ describe("Return correct data", () => {
     // @ts-expect-error
     spy.mockReturnValue(mockedResponse)
 
-    const session = await unstable_getServerSession(req, res, {
+    const session = await getServerSession(req, res, {
       providers: [],
       logger,
       secret: "secret",


### PR DESCRIPTION
The API has been working well in production for a while. This PR removes the warning. We do not remove the `unstable_gerServerSession` yet for backwards compatibility, but it is now shown as deprecated.