### PR TITLE
docs: remove warning about single callback for github

### DIFF
--- a/docs/docs/reference/05-oauth-providers/github.md
+++ b/docs/docs/reference/05-oauth-providers/github.md
@@ -37,10 +37,6 @@ providers: [
 ...
 ```
 
-:::warning
-Only allows one callback URL per Client ID / Client Secret.
-:::
-
 :::tip
 Email address is always returned, even if the user doesn't have a public email address on their profile.
 :::


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

Github doesn't appear to limit apps to a single callback anymore. Here's a screenshot from my settings.

![image](https://user-images.githubusercontent.com/2946748/215280201-207d75fb-34d7-4a7b-9f09-29bd04c257fe.png)

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
