### PR TITLE
fix: inaccurate discord types + misc

### DIFF
--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -203,7 +203,7 @@ async function getProfile(
     // If we didn't get a response either there was a problem with the provider
     // response *or* the user cancelled the action with the provider.
     //
-    // Unfortuately, we can't tell which - at least not in a way that works for
+    // Unfortunately, we can't tell which - at least not in a way that works for
     // all providers, so we return an empty object; the user should then be
     // redirected back to the sign up page. We log the error to help developers
     // who might be trying to debug this when configuring a new provider.

--- a/packages/core/src/providers/discord.ts
+++ b/packages/core/src/providers/discord.ts
@@ -97,7 +97,7 @@ export default function Discord<P extends DiscordProfile>(
         id: profile.id,
         name: profile.username,
         email: profile.email,
-        image: profile.image_url
+        image: profile.image_url,
       }
     },
     style: {

--- a/packages/core/src/providers/discord.ts
+++ b/packages/core/src/providers/discord.ts
@@ -1,21 +1,95 @@
 import type { OAuthConfig, OAuthUserConfig } from "./index.js"
 
+/**
+ * Corresponds to the user structure documented here:
+ * https://discord.com/developers/docs/resources/user#user-object-user-structure
+ */
 export interface DiscordProfile extends Record<string, any> {
-  accent_color: number
-  avatar: string
-  banner: string
-  banner_color: string
-  discriminator: string
-  email: string
-  flags: number
+  /** the user's id (i.e. the numerical snowflake) */
   id: string
-  image_url: string
-  locale: string
-  mfa_enabled: boolean
-  premium_type: number
-  public_flags: number
+
+  /** the user's username, not unique across the platform */
   username: string
+
+  /** the user's 4-digit discord-tag */
+  discriminator: string
+
+  /**
+   * the user's avatar hash:
+   * https://discord.com/developers/docs/reference#image-formatting
+   */
+  avatar: string | null
+
+  /** whether the user belongs to an OAuth2 application */
+  bot?: boolean
+
+  /**
+   * whether the user is an Official Discord System user (part of the urgent
+   * message system)
+   */
+  system?: boolean
+
+  /** whether the user has two factor enabled on their account */
+  mfa_enabled: boolean
+
+  /**
+   * the user's banner hash:
+   * https://discord.com/developers/docs/reference#image-formatting
+   */
+  banner: string | null
+
+  /** the user's banner color encoded as an integer representation of hexadecimal color code */
+  accent_color: number | null
+
+  /**
+   * the user's chosen language option:
+   * https://discord.com/developers/docs/reference#locales
+   */
+  locale: string
+
+  /** whether the email on this account has been verified */
   verified: boolean
+
+  /** the user's email */
+  email: string | null
+
+  /**
+   * the flags on a user's account:
+   * https://discord.com/developers/docs/resources/user#user-object-user-flags
+   */
+  flags: number
+
+  /**
+   * the type of Nitro subscription on a user's account:
+   * https://discord.com/developers/docs/resources/user#user-object-premium-types
+   */
+  premium_type: number
+
+  /**
+   * the public flags on a user's account:
+   * https://discord.com/developers/docs/resources/user#user-object-user-flags
+   */
+  public_flags: number
+
+  // --------------------------------------------------------------------------
+
+  /** undocumented field; corresponds to the user's custom nickname */
+  display_name: string | null
+
+  /**
+   * undocumented field; corresponds to the Discord feature where you can e.g.
+   * put your avatar inside of an ice cube
+   */
+  avatar_decoration: string | null
+
+  /**
+   * undocumented field; corresponds to the premium feature where you can
+   * select a custom banner color
+   */
+  banner_color: string | null
+
+  /** undocumented field; the CDN URL of their profile picture */
+  image_url: string
 }
 
 export default function Discord<P extends DiscordProfile>(
@@ -38,10 +112,18 @@ export default function Discord<P extends DiscordProfile>(
         profile.image_url = `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.${format}`
       }
       return {
+        // Default profile fields for all providers.
         id: profile.id,
         name: profile.username,
         email: profile.email,
         image: profile.image_url,
+
+        // Extended profile fields for specifically this Discord provider.
+        // (We use snake_case here to match the original fields from Discord.)
+        discriminator: profile.discriminator,
+        mfa_enabled: profile.mfa_enabled,
+        locale: profile.locale,
+        verified: profile.verified,
       }
     },
     style: {

--- a/packages/core/src/providers/discord.ts
+++ b/packages/core/src/providers/discord.ts
@@ -7,31 +7,24 @@ import type { OAuthConfig, OAuthUserConfig } from "./index.js"
 export interface DiscordProfile extends Record<string, any> {
   /** the user's id (i.e. the numerical snowflake) */
   id: string
-
   /** the user's username, not unique across the platform */
   username: string
-
   /** the user's 4-digit discord-tag */
   discriminator: string
-
   /**
    * the user's avatar hash:
    * https://discord.com/developers/docs/reference#image-formatting
    */
   avatar: string | null
-
   /** whether the user belongs to an OAuth2 application */
   bot?: boolean
-
   /**
    * whether the user is an Official Discord System user (part of the urgent
    * message system)
    */
   system?: boolean
-
   /** whether the user has two factor enabled on their account */
   mfa_enabled: boolean
-
   /**
    * the user's banner hash:
    * https://discord.com/developers/docs/reference#image-formatting
@@ -46,48 +39,37 @@ export interface DiscordProfile extends Record<string, any> {
    * https://discord.com/developers/docs/reference#locales
    */
   locale: string
-
   /** whether the email on this account has been verified */
   verified: boolean
-
   /** the user's email */
   email: string | null
-
   /**
    * the flags on a user's account:
    * https://discord.com/developers/docs/resources/user#user-object-user-flags
    */
   flags: number
-
   /**
    * the type of Nitro subscription on a user's account:
    * https://discord.com/developers/docs/resources/user#user-object-premium-types
    */
   premium_type: number
-
   /**
    * the public flags on a user's account:
    * https://discord.com/developers/docs/resources/user#user-object-user-flags
    */
   public_flags: number
-
-  // --------------------------------------------------------------------------
-
   /** undocumented field; corresponds to the user's custom nickname */
   display_name: string | null
-
   /**
    * undocumented field; corresponds to the Discord feature where you can e.g.
    * put your avatar inside of an ice cube
    */
   avatar_decoration: string | null
-
   /**
    * undocumented field; corresponds to the premium feature where you can
    * select a custom banner color
    */
   banner_color: string | null
-
   /** undocumented field; the CDN URL of their profile picture */
   image_url: string
 }
@@ -112,18 +94,10 @@ export default function Discord<P extends DiscordProfile>(
         profile.image_url = `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.${format}`
       }
       return {
-        // Default profile fields for all providers.
         id: profile.id,
         name: profile.username,
         email: profile.email,
-        image: profile.image_url,
-
-        // Extended profile fields for specifically this Discord provider.
-        // (We use snake_case here to match the original fields from Discord.)
-        discriminator: profile.discriminator,
-        mfa_enabled: profile.mfa_enabled,
-        locale: profile.locale,
-        verified: profile.verified,
+        image: profile.image_url
       }
     },
     style: {

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -66,7 +66,7 @@ export type TokenEndpointHandler = EndpointHandler<
     params: CallbackParamsType
     /**
      * When using this custom flow, make sure to do all the necessary security checks.
-     * Thist object contains parameters you have to match against the request to make sure it is valid.
+     * This object contains parameters you have to match against the request to make sure it is valid.
      */
     checks: OAuthChecks
   },

--- a/packages/frameworks-sveltekit/scripts/postbuild.js
+++ b/packages/frameworks-sveltekit/scripts/postbuild.js
@@ -1,8 +1,16 @@
 // After build, copy the files in ./package to the root directory, excluding the package.json file.
+
 import fs from "fs/promises"
 import path from "path"
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+let __dirname = path.dirname(new URL(import.meta.url).pathname)
+
+// The above hack to polyfill "__dirname" for ESM does not work on Windows computers,
+// so we might have to manually perform more steps.
+__dirname = __dirname.split(path.sep).join(path.posix.sep)
+if (__dirname.match(/^\/\w:\//)) {
+  __dirname = __dirname.slice(3) // Remove the drive prefix.
+}
 
 const root = path.join(__dirname, "..")
 const pkgDir = path.join(root, "package")


### PR DESCRIPTION
## ☕️ Reasoning

- Redid the types in the Discord object + added JSDoc comments to match the documentation.
- Fixed a few typos in code comments.
- Fixed the build on Windows computers.

Open questions:

1) Can someone explain how I can actually access the new fields provided in this PR?
2) Why is the discord.ts file completely duplicated in two separate places? Should I duplicate everything in the PR to both places? Seems like a mistake in the codebase.