### PR TITLE
fix(ts): correctly type `unstable_getServerSession`

### DIFF
--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -176,12 +176,8 @@ export async function unstable_getServerSession<
     ? U
     : Session
 >(
-  ...args:
-    | [GetServerSidePropsContext["req"], GetServerSidePropsContext["res"], O]
-    | [NextApiRequest, NextApiResponse, O]
-    | [O]
-    | []
-): Promise<R | null> {
+  ...args: Parameters<typeof getServerSession<O, R>>
+): ReturnType<typeof getServerSession<O, R>> {
   if (!deprecatedWarningShown && process.env.NODE_ENV !== "production") {
     console.warn(
       "`unstable_getServerSession` has been renamed to `getServerSession`."

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -170,9 +170,18 @@ export async function getServerSession<
 let deprecatedWarningShown = false
 
 /** @deprecated renamed to `getServerSession` */
-export async function unstable_getServerSession(
-  ...args: Parameters<typeof getServerSession>
-): ReturnType<typeof getServerSession> {
+export async function unstable_getServerSession<
+  O extends GetServerSessionOptions,
+  R = O["callbacks"] extends { session: (...args: any[]) => infer U }
+    ? U
+    : Session
+>(
+  ...args:
+    | [GetServerSidePropsContext["req"], GetServerSidePropsContext["res"], O]
+    | [NextApiRequest, NextApiResponse, O]
+    | [O]
+    | []
+): Promise<R | null> {
   if (!deprecatedWarningShown && process.env.NODE_ENV !== "production") {
     console.warn(
       "`unstable_getServerSession` has been renamed to `getServerSession`."


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

Fix the type of `unstable_getServerSession` which was incorrect in v4.19.0.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #6556.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
