### PR TITLE
fix(ts): mark `options` provider config option internal

### DIFF
--- a/apps/dev/sveltekit/package.json
+++ b/apps/dev/sveltekit/package.json
@@ -19,8 +19,8 @@
     "vite": "4.0.1"
   },
   "dependencies": {
-    "@auth/core": "0.2.5",
-    "@auth/sveltekit": "0.1.12"
+    "@auth/core": "workspace:*",
+    "@auth/sveltekit": "workspace:*"
   },
   "type": "module"
 }

--- a/packages/core/src/providers/credentials.ts
+++ b/packages/core/src/providers/credentials.ts
@@ -49,10 +49,6 @@ export interface CredentialsConfig<
 
 export type CredentialsProviderType = "Credentials"
 
-export type CredentialsConfigInternal<
-  C extends Record<string, CredentialInput> = Record<string, CredentialInput>
-> = CredentialsConfig<C> & { options: CredentialsConfig<C> }
-
 /**
  * The Credentials provider allows you to handle signing in with arbitrary credentials,
  * such as a username and password, domain, or two factor authentication or hardware device (e.g. YubiKey U2F / FIDO).

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -65,12 +65,16 @@ export type Provider<P extends Profile = Profile> = (
   | EmailConfig
   | CredentialsConfig
 ) & {
+  /**
+   * Used to deep merge user-provided config with the default config
+   * @internal
+   */
   options: Record<string, unknown>
 }
 
 export type BuiltInProviders = Record<
   OAuthProviderType,
-  (options: Partial<OAuthConfig<any>>) => OAuthConfig<any>
+  (config: Partial<OAuthConfig<any>>) => OAuthConfig<any>
 > &
   Record<CredentialsProviderType, typeof CredentialsProvider> &
   Record<EmailProviderType, typeof EmailProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
 
   apps/dev/sveltekit:
     specifiers:
-      '@auth/core': 0.2.5
-      '@auth/sveltekit': 0.1.12
+      '@auth/core': workspace:*
+      '@auth/sveltekit': workspace:*
       '@sveltejs/adapter-auto': next
       '@sveltejs/kit': next
       svelte: 3.55.0
@@ -123,8 +123,8 @@ importers:
       typescript: 4.9.4
       vite: 4.0.1
     dependencies:
-      '@auth/core': 0.2.5
-      '@auth/sveltekit': 0.1.12_bzkxp32pqvunv6braeh76ugwhu
+      '@auth/core': link:../../../packages/core
+      '@auth/sveltekit': link:../../../packages/frameworks-sveltekit
     devDependencies:
       '@sveltejs/adapter-auto': 1.0.0-next.91_l5ueyfihz3gpzzvvyo2ean5u3e
       '@sveltejs/kit': 1.0.0-next.589_svelte@3.55.0+vite@4.0.1
@@ -143,7 +143,7 @@ importers:
       vercel: ^23.1.2
     dependencies:
       dotenv: 16.0.3
-      gatsby: 5.6.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby: 5.6.0-next.2_biqbaboplfbrettd7655fr4n2y
       next-auth: link:../../../packages/next-auth
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -866,35 +866,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
-
-  /@auth/core/0.2.5:
-    resolution: {integrity: sha512-e9jQOW6kSnxa0gfeR5neqLIDAUvZtyGTh3YpO2eN5F/5gBybE582M5e34rXlJKj+/tAgf+oYBJAY5CUxGTY9tw==}
-    peerDependencies:
-      nodemailer: 6.8.0
-    peerDependenciesMeta:
-      nodemailer:
-        optional: true
-    dependencies:
-      '@panva/hkdf': 1.0.2
-      cookie: 0.5.0
-      jose: 4.11.1
-      oauth4webapi: 2.0.6
-      preact: 10.11.3
-      preact-render-to-string: 5.2.3_preact@10.11.3
-    dev: false
-
-  /@auth/sveltekit/0.1.12_bzkxp32pqvunv6braeh76ugwhu:
-    resolution: {integrity: sha512-nQyOXOaVRl+70XSIsgQCpU0BFkOb52DqsRmfNUOIm4/EtGTERLLsKVCRaPXXCYp6t22I2pu4E2gD79r74gPyZA==}
-    peerDependencies:
-      '@sveltejs/kit': ^1.0.0
-      svelte: ^3.54.0
-    dependencies:
-      '@auth/core': 0.2.5
-      '@sveltejs/kit': 1.0.0-next.589_svelte@3.55.0+vite@4.0.1
-      svelte: 3.55.0
-    transitivePeerDependencies:
-      - nodemailer
     dev: false
 
   /@aws-crypto/ie11-detection/2.0.0:
@@ -2906,7 +2877,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-AHrP9jadvH7qlOj6PINbgSuphjQUAK7AOT7DPjBo9EHoLhQTnnK5u45e1Hd4DbSQEO9nqPWtQ89r+XEOWFScKg==}
@@ -2917,7 +2888,7 @@ packages:
       '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.2
     dev: true
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.20.5:
@@ -2929,7 +2900,7 @@ packages:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.5
+      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.5
     dev: true
 
   /@babel/plugin-proposal-async-generator-functions/7.17.12:
@@ -3652,7 +3623,30 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.12
-    dev: false
+
+  /@babel/plugin-proposal-optional-chaining/7.20.7_@babel+core@7.20.2:
+    resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.2
+    dev: true
+
+  /@babel/plugin-proposal-optional-chaining/7.20.7_@babel+core@7.20.5:
+    resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.5
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.5
+    dev: true
 
   /@babel/plugin-proposal-private-methods/7.17.12:
     resolution: {integrity: sha512-SllXoxo19HmxhDWm3luPz+cPhtoTSKLJE9PXshsfrOzBqs60QP0r8OaJItrPhAj0d7mZMnNF0Y1UUggCDgMz1A==}
@@ -8359,6 +8353,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm64/0.16.4:
@@ -8367,6 +8362,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64/0.16.4:
@@ -8375,6 +8371,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64/0.16.4:
@@ -8383,6 +8380,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64/0.16.4:
@@ -8391,6 +8389,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64/0.16.4:
@@ -8399,6 +8398,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64/0.16.4:
@@ -8407,6 +8407,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm/0.16.4:
@@ -8415,6 +8416,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64/0.16.4:
@@ -8423,6 +8425,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32/0.16.4:
@@ -8431,6 +8434,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64/0.14.54:
@@ -8457,6 +8461,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el/0.16.4:
@@ -8465,6 +8470,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64/0.16.4:
@@ -8473,6 +8479,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64/0.16.4:
@@ -8481,6 +8488,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x/0.16.4:
@@ -8489,6 +8497,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64/0.16.4:
@@ -8497,6 +8506,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64/0.16.4:
@@ -8505,6 +8515,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64/0.16.4:
@@ -8513,6 +8524,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64/0.16.4:
@@ -8521,6 +8533,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64/0.16.4:
@@ -8529,6 +8542,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32/0.16.4:
@@ -8537,6 +8551,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64/0.16.4:
@@ -8545,6 +8560,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@eslint/eslintrc/0.4.3:
@@ -11422,6 +11438,7 @@ packages:
 
   /@polka/url/1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
 
   /@prisma/client/3.15.2_prisma@3.15.2:
     resolution: {integrity: sha512-ErqtwhX12ubPhU4d++30uFY/rPcyvjk+mdifaZO5SeM21zS3t4jQrscy8+6IyB0GIYshl5ldTq6JSBo1d63i8w==}
@@ -11840,6 +11857,7 @@ packages:
       vite: 4.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@sveltejs/kit/1.0.1_svelte@3.54.0+vite@4.0.1:
     resolution: {integrity: sha512-C41aCaDjA7xoUdsrc/lSdU1059UdLPIRE1vEIRRynzpMujNgp82bTMHkDosb6vykH6LrLf3tT2w2/5NYQhKYGQ==}
@@ -11921,6 +11939,7 @@ packages:
       vitefu: 0.2.4_vite@4.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@svgr/babel-plugin-add-jsx-attribute/6.0.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==}
@@ -12447,6 +12466,7 @@ packages:
 
   /@types/cookie/0.5.1:
     resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
+    dev: true
 
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
@@ -14047,8 +14067,10 @@ packages:
       indent-string: 4.0.0
     dev: true
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -14555,14 +14577,14 @@ packages:
   /axios/0.21.4_debug@4.3.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
 
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: true
@@ -14949,7 +14971,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-remove-graphql-queries/5.6.0-next.0_34zmit57noivsgqvgdpgpcttx4:
+  /babel-plugin-remove-graphql-queries/5.6.0-next.0_x3fnz3zp5bgltr62wwyqvgm7l4:
     resolution: {integrity: sha512-hrxx7U73x6TUL+x/h2/OrQT4hdeGkYjK39oiYtt6erSVz8q1iOYl4tfCYN0wuHyrvpRdXJ7UBrAhLgBFIPn8Gw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -14959,7 +14981,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/runtime': 7.20.7
       '@babel/types': 7.20.7
-      gatsby: 5.6.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby: 5.6.0-next.2_biqbaboplfbrettd7655fr4n2y
       gatsby-core-utils: 4.6.0-next.0
     dev: false
 
@@ -16500,8 +16522,8 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
-  /create-gatsby/3.6.0-next.0:
-    resolution: {integrity: sha512-eeTIlCWsSWhQkfbcRstHO8n7I6kkf/tWkyjHt5nEGoIn2HW1457Qt4QMLhMyowhNBw/nXHiU+QuUvg+1oY8z9g==}
+  /create-gatsby/3.6.0-next.1:
+    resolution: {integrity: sha512-7PSTSNLa1w0LZ81WXZ09IBVcE+SCuOk8QOPJC3tK2D50iTeKo1rBp2mZEX0ao5sC5q/N869HuLBPkzdvP5Lvig==}
     hasBin: true
     dependencies:
       '@babel/runtime': 7.20.7
@@ -17850,6 +17872,7 @@ packages:
 
   /devalue/4.2.0:
     resolution: {integrity: sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==}
+    dev: true
 
   /devcert/1.2.2:
     resolution: {integrity: sha512-UsLqvtJGPiGwsIZnJINUnFYaWgK7CroreGRndWHZkRD58tPFr3pVbbSyHR8lbh41+azR4jKvuNZ+eCoBZGA5kA==}
@@ -18914,6 +18937,7 @@ packages:
       '@esbuild/win32-arm64': 0.16.4
       '@esbuild/win32-ia32': 0.16.4
       '@esbuild/win32-x64': 0.16.4
+    dev: true
 
   /esbuild/0.8.57:
     resolution: {integrity: sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==}
@@ -19562,6 +19586,7 @@ packages:
 
   /esm-env/1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
+    dev: true
 
   /esm/3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
@@ -19710,7 +19735,7 @@ packages:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.0.9
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       body-parser: 1.20.0
       content-type: 1.0.4
       deep-freeze: 0.0.1
@@ -20360,15 +20385,6 @@ packages:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
     dev: true
 
-  /follow-redirects/1.15.1:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   /follow-redirects/1.15.1_debug@4.3.4:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
     engines: {node: '>=4.0'}
@@ -20379,7 +20395,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
-    dev: true
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -20636,8 +20651,8 @@ packages:
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  /gatsby-cli/5.6.0-next.0:
-    resolution: {integrity: sha512-B38HOsNXQ1r8EAap/J0E6CRv2QYxuf8J+Uc+aASbbDgEmfZw8A95ayT6JM8rqYaf9mambUmzot/QF/hKQBY1uA==}
+  /gatsby-cli/5.6.0-next.1:
+    resolution: {integrity: sha512-tFrTZlEezIxFKMkCXXKu3tKBrjqpZt+PykNABkSgOdMGO1pT/xysSClCbKOMockWosrpgaNup+1rP8sjVRdIsw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     requiresBuild: true
@@ -20658,7 +20673,7 @@ packages:
       clipboardy: 2.3.0
       common-tags: 1.8.2
       convert-hrtime: 3.0.0
-      create-gatsby: 3.6.0-next.0
+      create-gatsby: 3.6.0-next.1
       envinfo: 7.8.1
       execa: 5.1.1
       fs-exists-cached: 1.0.0
@@ -20773,8 +20788,8 @@ packages:
       '@parcel/transformer-json': 2.8.2_@parcel+core@2.8.2
     dev: false
 
-  /gatsby-plugin-page-creator/5.6.0-next.0_4kofk2l43xwpw753oec5pxbv5e:
-    resolution: {integrity: sha512-zNfm0f5wpVhlwDnvGwkfQtIcIHJeRJBeYQCkUYUPwoA1s4AJFY6+wbYSRYHcM8r2K5aDfE1/t32YEY43UNIzGA==}
+  /gatsby-plugin-page-creator/5.6.0-next.1_wxxlwg4kb5uwyfjvsdo3jviy2e:
+    resolution: {integrity: sha512-9yE2C4Xbc+llNRzzC9MbpgSM1GQCi4lUqlNy8Hq/C25S0wTTRW+FQZxuWTiR+AUTUL8MK9wJsNF5f0bZc8hfJw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       gatsby: ^5.0.0-next
@@ -20785,10 +20800,10 @@ packages:
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
       fs-extra: 11.1.0
-      gatsby: 5.6.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby: 5.6.0-next.2_biqbaboplfbrettd7655fr4n2y
       gatsby-core-utils: 4.6.0-next.0
       gatsby-page-utils: 3.6.0-next.0
-      gatsby-plugin-utils: 4.6.0-next.0_4kofk2l43xwpw753oec5pxbv5e
+      gatsby-plugin-utils: 4.6.0-next.1_wxxlwg4kb5uwyfjvsdo3jviy2e
       gatsby-telemetry: 4.6.0-next.0
       globby: 11.1.0
       lodash: 4.17.21
@@ -20798,7 +20813,7 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby-plugin-typescript/5.6.0-next.0_gatsby@5.6.0-next.0:
+  /gatsby-plugin-typescript/5.6.0-next.0_gatsby@5.6.0-next.2:
     resolution: {integrity: sha512-CUguJx8GjTQHymcfBOcwUXZtetfhLYtgUehkM8ovvNlscgavGxmbGD90gXMmo5JgrLPhdx8krtMsdIeCOOvo4w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -20810,14 +20825,14 @@ packages:
       '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       '@babel/runtime': 7.20.7
-      babel-plugin-remove-graphql-queries: 5.6.0-next.0_34zmit57noivsgqvgdpgpcttx4
-      gatsby: 5.6.0-next.0_biqbaboplfbrettd7655fr4n2y
+      babel-plugin-remove-graphql-queries: 5.6.0-next.0_x3fnz3zp5bgltr62wwyqvgm7l4
+      gatsby: 5.6.0-next.2_biqbaboplfbrettd7655fr4n2y
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /gatsby-plugin-utils/4.6.0-next.0_4kofk2l43xwpw753oec5pxbv5e:
-    resolution: {integrity: sha512-3xidC+kpOz9xtsG5yv4UGB87pA0bo3YEHBTtUf5kshNEycMeTeh6xgb6gnD56kCVQ4DFrUBAe5U95hWH8n65Aw==}
+  /gatsby-plugin-utils/4.6.0-next.1_wxxlwg4kb5uwyfjvsdo3jviy2e:
+    resolution: {integrity: sha512-RhM2cQ6RYmdGQkXKs4d+KfG5ovGjvbF4fps/H4Sk81nJ1AnlPGbUlMaCdgFhhTJL1ID8l4rYdpQKXM87THJosQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       gatsby: ^5.0.0-next
@@ -20826,7 +20841,7 @@ packages:
       '@babel/runtime': 7.20.7
       fastq: 1.15.0
       fs-extra: 11.1.0
-      gatsby: 5.6.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby: 5.6.0-next.2_biqbaboplfbrettd7655fr4n2y
       gatsby-core-utils: 4.6.0-next.0
       gatsby-sharp: 1.6.0-next.0
       graphql: 16.6.0
@@ -20905,8 +20920,8 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby/5.6.0-next.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-QwM9R3JtRo7Qk1A0v5Hgpo45SXtRYh7OzZntOaj8VsDk7HebITZ5eLrdTq/wPYNYn3Jlng2bG+bObcIEjjqcyw==}
+  /gatsby/5.6.0-next.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-cXyyDjlA2V3NhnfJtLhcrShrYU6k/FB67el5MZIqzrHjb7sg77lJztMpoy4PvXs4MlNvhRupSclIO+o9+G0pyg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     requiresBuild: true
@@ -20952,7 +20967,7 @@ packages:
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
       babel-plugin-lodash: 3.3.4
-      babel-plugin-remove-graphql-queries: 5.6.0-next.0_34zmit57noivsgqvgdpgpcttx4
+      babel-plugin-remove-graphql-queries: 5.6.0-next.0_x3fnz3zp5bgltr62wwyqvgm7l4
       babel-preset-gatsby: 3.6.0-next.0_pp2vm42zn6vfmnpuhar3irht7i
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -20994,16 +21009,16 @@ packages:
       find-cache-dir: 3.3.2
       fs-exists-cached: 1.0.0
       fs-extra: 11.1.0
-      gatsby-cli: 5.6.0-next.0
+      gatsby-cli: 5.6.0-next.1
       gatsby-core-utils: 4.6.0-next.0
       gatsby-graphiql-explorer: 3.6.0-next.0
       gatsby-legacy-polyfills: 3.6.0-next.0
       gatsby-link: 5.6.0-next.0_y2kppt6lrltqk6wasg3eswwzsa
       gatsby-page-utils: 3.6.0-next.0
       gatsby-parcel-config: 1.6.0-next.0_@parcel+core@2.8.2
-      gatsby-plugin-page-creator: 5.6.0-next.0_4kofk2l43xwpw753oec5pxbv5e
-      gatsby-plugin-typescript: 5.6.0-next.0_gatsby@5.6.0-next.0
-      gatsby-plugin-utils: 4.6.0-next.0_4kofk2l43xwpw753oec5pxbv5e
+      gatsby-plugin-page-creator: 5.6.0-next.1_wxxlwg4kb5uwyfjvsdo3jviy2e
+      gatsby-plugin-typescript: 5.6.0-next.0_gatsby@5.6.0-next.2
+      gatsby-plugin-utils: 4.6.0-next.1_wxxlwg4kb5uwyfjvsdo3jviy2e
       gatsby-react-router-scroll: 6.6.0-next.0_y2kppt6lrltqk6wasg3eswwzsa
       gatsby-script: 2.6.0-next.0_y2kppt6lrltqk6wasg3eswwzsa
       gatsby-telemetry: 4.6.0-next.0
@@ -21457,6 +21472,7 @@ packages:
 
   /globalyzer/0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+    dev: true
 
   /globby/11.0.4:
     resolution: {integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==}
@@ -21506,6 +21522,7 @@ packages:
 
   /globrex/0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: true
 
   /glur/1.1.2:
     resolution: {integrity: sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==}
@@ -22176,7 +22193,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -24999,6 +25016,7 @@ packages:
   /kleur/4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /klona/2.0.5:
     resolution: {integrity: sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==}
@@ -25648,6 +25666,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /mailparser/2.8.1:
     resolution: {integrity: sha512-H/CYAO9dsw6SFNbEGGpZsejVSWDcFlyHjb1OkHUWg0wggUekva1tNc28trB155nSqM8rhtbwTKt//orX0AmJxQ==}
@@ -26329,10 +26348,12 @@ packages:
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+    dev: true
 
   /mrmime/1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
     engines: {node: '>=10'}
+    dev: true
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -30298,6 +30319,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /route-sort/1.0.0:
     resolution: {integrity: sha512-SFgmvjoIhp5S4iBEDW3XnbT+7PRuZ55oRuNjY+CDB1SGZkyCG9bqQ3/dhaZTctTBYMAvDxd2Uy9dStuaUfgJqQ==}
@@ -30369,6 +30391,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mri: 1.2.0
+    dev: true
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -30455,7 +30478,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: true
 
@@ -30817,6 +30840,7 @@ packages:
       '@polka/url': 1.0.0-next.21
       mrmime: 1.0.1
       totalist: 3.0.0
+    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -31838,6 +31862,7 @@ packages:
       svelte: '>=3.19.0'
     dependencies:
       svelte: 3.55.0
+    dev: true
 
   /svelte-preprocess/4.10.7_niwyv7xychq2ag6arq5eqxbomm:
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
@@ -31949,6 +31974,7 @@ packages:
   /svelte/3.55.0:
     resolution: {integrity: sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==}
     engines: {node: '>= 8'}
+    dev: true
 
   /svelte2tsx/0.5.22_gf4dcx76vtk2o62ixxeqx7chra:
     resolution: {integrity: sha512-OytIql7Bv53oFuL0jjsnp/gNvR4ngAUdAjswgibmIQT2Lj2OIQYn2J3gKqRd+wSj/n3M/wrz4zJpudQRSfncZw==}
@@ -32297,6 +32323,7 @@ packages:
     dependencies:
       globalyzer: 0.1.0
       globrex: 0.1.2
+    dev: true
 
   /tiny-invariant/1.2.0:
     resolution: {integrity: sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==}
@@ -32386,6 +32413,7 @@ packages:
   /totalist/3.0.0:
     resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
     engines: {node: '>=6'}
+    dev: true
 
   /tough-cookie/2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
@@ -33075,6 +33103,7 @@ packages:
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0
+    dev: true
 
   /unenv/1.0.1:
     resolution: {integrity: sha512-08MoQ5+Edg9ckEP5y6vT8R6sOgCsNPxwPA1mKIOyergTtPOOuSyyJnbmF8CdnUplO2TUqSm0s1IysCkylxmndw==}
@@ -33796,6 +33825,7 @@ packages:
       rollup: 3.7.4
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vite/4.0.1_@types+node@18.11.10:
     resolution: {integrity: sha512-kZQPzbDau35iWOhy3CpkrRC7It+HIHtulAzBhMqzGHKRf/4+vmh8rPDDdv98SWQrFWo6//3ozwsRmwQIPZsK9g==}
@@ -33849,6 +33879,7 @@ packages:
         optional: true
     dependencies:
       vite: 4.0.1
+    dev: true
 
   /vitest/0.25.7:
     resolution: {integrity: sha512-lJ+Ue+v8kHl2JzjaKHJ9u5Yo/loU7zrWK2/Whn8OKQjtq5G7nkeWfXuq3elZaC8xKdkdIuWiiIicaNBG1F5yzg==}


### PR DESCRIPTION
We use a property called `options` for providers to be able to take a user config and merge it with our defaults. This `option` property should not be exposed to the user. In this PR, it is now marked as `@internal`, so its type gets stripped at build-time.

Fixes #6561