### PR TITLE
feat: add optional onSignIn and onSignOut callback options to useSession

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -118,7 +118,9 @@ export function useSession<R extends boolean>(options?: UseSessionOptions<R>) {
     )
   }
 
-  const { required, onUnauthenticated } = options ?? {}
+  const prevStatus = React.useRef<SessionContextValue["status"]>(value.status)
+
+  const { required, onUnauthenticated, onSignIn, onSignOut } = options ?? {}
 
   const requiredAndNotLoading = required && value.status === "unauthenticated"
 
@@ -132,6 +134,26 @@ export function useSession<R extends boolean>(options?: UseSessionOptions<R>) {
       else window.location.href = url
     }
   }, [requiredAndNotLoading, onUnauthenticated])
+
+  React.useEffect(() => {
+    if (value.status === prevStatus.current) return
+
+    if (
+      onSignIn &&
+      prevStatus.current === "unauthenticated" &&
+      value.status === "authenticated"
+    )
+      onSignIn()
+
+    if (
+      onSignOut &&
+      prevStatus.current === "authenticated" &&
+      value.status === "unauthenticated"
+    )
+      onSignOut()
+
+    prevStatus.current = value.status
+  }, [value.status, onSignIn, onSignOut])
 
   if (requiredAndNotLoading) {
     return { data: value.data, status: "loading" } as const

--- a/packages/next-auth/src/react/types.ts
+++ b/packages/next-auth/src/react/types.ts
@@ -5,6 +5,8 @@ export interface UseSessionOptions<R extends boolean> {
   required: R
   /** Defaults to `signIn` */
   onUnauthenticated?: () => void
+  onSignIn?: () => void
+  onSignOut?: () => void
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

Adding `onSignIn` and `onSignOut` callback options to the `useSession` hook to allow for developers to take actions when a user authenticates or signs out when using the `redirect: false` option.

I understand there is potential confusion with the existing `required` and `onUnauthenticated` options, so happy to hear feedback or ideas from the maintainers. 

## 🧢 Checklist

- [ ] Documentation **(Will add following feedback on the approach)**
- [ ] Tests **(Will add following feedback on the approach)**
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/rainbow-me/rainbowkit/pull/965
Fixes: https://github.com/rainbow-me/rainbowkit/discussions/904


## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
