### PR TITLE
move common client types to core & rename callbackUrl

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -487,17 +487,16 @@ export type LiteralUnion<T extends U, U = string> =
   | T
   | (U & Record<never, never>)
 
-export interface SignInOptions extends Record<string, unknown> {
+export interface SignInParams extends Record<string, unknown> {
   returnTo?: string
   redirect?: boolean
 }
 
-/** Match `inputType` of `new URLSearchParams(inputType)` */
-export type SignInAuthorizationParams =
-  | string
-  | string[][]
-  | Record<string, string>
-  | URLSearchParams
+export type URLSearchParamsInit = typeof URLSearchParams extends new (
+  ...args: infer U
+) => URLSearchParams
+  ? U[0]
+  : never
 
 export interface SignOutParams<R extends boolean = true> {
   returnTo?: string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -488,7 +488,7 @@ export type LiteralUnion<T extends U, U = string> =
   | (U & Record<never, never>)
 
 export interface SignInOptions extends Record<string, unknown> {
-  redirectTo?: string
+  returnTo?: string
   redirect?: boolean
 }
 
@@ -500,6 +500,6 @@ export type SignInAuthorizationParams =
   | URLSearchParams
 
 export interface SignOutParams<R extends boolean = true> {
-  redirectTo?: string
+  returnTo?: string
   redirect?: R
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -478,3 +478,28 @@ export interface InternalOptions<TProviderType = ProviderType> {
   cookies: CookiesOptions
   callbackUrl: string
 }
+
+/**
+ * Util type that matches some strings literally, but allows any other string as well.
+ * @source https://github.com/microsoft/TypeScript/issues/29729#issuecomment-832522611
+ */
+export type LiteralUnion<T extends U, U = string> =
+  | T
+  | (U & Record<never, never>)
+
+export interface SignInOptions extends Record<string, unknown> {
+  redirectTo?: string
+  redirect?: boolean
+}
+
+/** Match `inputType` of `new URLSearchParams(inputType)` */
+export type SignInAuthorizationParams =
+  | string
+  | string[][]
+  | Record<string, string>
+  | URLSearchParams
+
+export interface SignOutParams<R extends boolean = true> {
+  redirectTo?: string
+  redirect?: R
+}

--- a/packages/frameworks-solid-start/package.json
+++ b/packages/frameworks-solid-start/package.json
@@ -33,7 +33,6 @@
     "@types/cookie": "0.5.1",
     "@types/node": "^18.7.14",
     "@types/set-cookie-parser": "^2.4.2",
-    "next-auth": "workspace:*",
     "solid-js": "^1.5.7",
     "solid-start": "^0.2.1",
     "tsup": "^6.5.0",

--- a/packages/frameworks-solid-start/src/client.ts
+++ b/packages/frameworks-solid-start/src/client.ts
@@ -3,7 +3,7 @@ import type {
   SignInOptions,
   SignInAuthorizationParams,
   SignOutParams,
-} from "next-auth/react"
+} from "@auth/core/types"
 import type {
   BuiltInProviderType,
   RedirectableProviderType,
@@ -27,7 +27,7 @@ export async function signIn<
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ) {
-  const { callbackUrl = window.location.href, redirect = true } = options ?? {}
+  const { redirectTo = window.location.href, redirect = true } = options ?? {}
 
   // TODO: Support custom providers
   const isCredentials = providerId === "credentials"
@@ -55,7 +55,7 @@ export async function signIn<
     body: new URLSearchParams({
       ...options,
       csrfToken,
-      callbackUrl,
+      callbackUrl: redirectTo,
     }),
   })
 
@@ -63,7 +63,7 @@ export async function signIn<
   const error = new URL(data.url).searchParams.get("error")
   if (redirect || !isSupportingReturn || !error) {
     // TODO: Do not redirect for Credentials and Email providers by default in next major
-    window.location.href = data.url ?? data.redirect ?? callbackUrl
+    window.location.href = data.url ?? data.redirect ?? redirectTo
     // If url contains a hash, the browser does not reload the page. We reload manually
     if (data.url.includes("#")) window.location.reload()
     return
@@ -78,7 +78,7 @@ export async function signIn<
  * [Documentation](https://next-auth.js.org/getting-started/client#signout)
  */
 export async function signOut(options?: SignOutParams) {
-  const { callbackUrl = window.location.href } = options ?? {}
+  const { redirectTo = window.location.href } = options ?? {}
   // TODO: Custom base path
   const csrfTokenResponse = await fetch("/api/auth/csrf")
   const { csrfToken } = await csrfTokenResponse.json()
@@ -90,12 +90,12 @@ export async function signOut(options?: SignOutParams) {
     },
     body: new URLSearchParams({
       csrfToken,
-      callbackUrl,
+      callbackUrl: redirectTo,
     }),
   })
   const data = await res.json()
 
-  const url = data.url ?? data.redirect ?? callbackUrl
+  const url = data.url ?? data.redirect ?? redirectTo
   window.location.href = url
   // If url contains a hash, the browser does not reload the page. We reload manually
   if (url.includes("#")) window.location.reload()

--- a/packages/frameworks-solid-start/src/client.ts
+++ b/packages/frameworks-solid-start/src/client.ts
@@ -1,7 +1,7 @@
 import type {
   LiteralUnion,
-  SignInOptions,
-  SignInAuthorizationParams,
+  SignInParams,
+  URLSearchParamsInit,
   SignOutParams,
 } from "@auth/core/types"
 import type {
@@ -24,8 +24,8 @@ export async function signIn<
       ? P | BuiltInProviderType
       : BuiltInProviderType
   >,
-  options?: SignInOptions,
-  authorizationParams?: SignInAuthorizationParams
+  options?: SignInParams,
+  authorizationParams?: URLSearchParamsInit
 ) {
   const { returnTo = window.location.href, redirect = true } = options ?? {}
 

--- a/packages/frameworks-solid-start/src/client.ts
+++ b/packages/frameworks-solid-start/src/client.ts
@@ -27,7 +27,7 @@ export async function signIn<
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ) {
-  const { redirectTo = window.location.href, redirect = true } = options ?? {}
+  const { returnTo = window.location.href, redirect = true } = options ?? {}
 
   // TODO: Support custom providers
   const isCredentials = providerId === "credentials"
@@ -55,7 +55,7 @@ export async function signIn<
     body: new URLSearchParams({
       ...options,
       csrfToken,
-      callbackUrl: redirectTo,
+      callbackUrl: returnTo,
     }),
   })
 
@@ -63,7 +63,7 @@ export async function signIn<
   const error = new URL(data.url).searchParams.get("error")
   if (redirect || !isSupportingReturn || !error) {
     // TODO: Do not redirect for Credentials and Email providers by default in next major
-    window.location.href = data.url ?? data.redirect ?? redirectTo
+    window.location.href = data.url ?? data.redirect ?? returnTo
     // If url contains a hash, the browser does not reload the page. We reload manually
     if (data.url.includes("#")) window.location.reload()
     return
@@ -78,7 +78,7 @@ export async function signIn<
  * [Documentation](https://next-auth.js.org/getting-started/client#signout)
  */
 export async function signOut(options?: SignOutParams) {
-  const { redirectTo = window.location.href } = options ?? {}
+  const { returnTo = window.location.href } = options ?? {}
   // TODO: Custom base path
   const csrfTokenResponse = await fetch("/api/auth/csrf")
   const { csrfToken } = await csrfTokenResponse.json()
@@ -90,12 +90,12 @@ export async function signOut(options?: SignOutParams) {
     },
     body: new URLSearchParams({
       csrfToken,
-      callbackUrl: redirectTo,
+      callbackUrl: returnTo,
     }),
   })
   const data = await res.json()
 
-  const url = data.url ?? data.redirect ?? redirectTo
+  const url = data.url ?? data.redirect ?? returnTo
   window.location.href = url
   // If url contains a hash, the browser does not reload the page. We reload manually
   if (url.includes("#")) window.location.reload()

--- a/packages/frameworks-sveltekit/package.json
+++ b/packages/frameworks-sveltekit/package.json
@@ -36,7 +36,6 @@
     "@sveltejs/adapter-auto": "^1.0.0",
     "@sveltejs/kit": "^1.0.0",
     "@sveltejs/package": "^1.0.0",
-    "next-auth": "workspace:*",
     "svelte": "^3.54.0",
     "svelte-check": "^2.9.2",
     "tslib": "^2.4.1",
@@ -48,8 +47,8 @@
     "@auth/core": "workspace:*"
   },
   "peerDependencies": {
-    "svelte": "^3.54.0",
-    "@sveltejs/kit": "^1.0.0"
+    "@sveltejs/kit": "^1.0.0",
+    "svelte": "^3.54.0"
   },
   "type": "module",
   "types": "./index.d.ts",

--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -3,7 +3,7 @@ import type {
   SignInOptions,
   SignInAuthorizationParams,
   SignOutParams,
-} from "next-auth/react"
+} from "@auth/core/types"
 import type {
   BuiltInProviderType,
   RedirectableProviderType,
@@ -27,7 +27,7 @@ export async function signIn<
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ) {
-  const { callbackUrl = window.location.href, redirect = true } = options ?? {}
+  const { redirectTo = window.location.href, redirect = true } = options ?? {}
 
   // TODO: Support custom providers
   const isCredentials = providerId === "credentials"
@@ -56,7 +56,7 @@ export async function signIn<
     body: new URLSearchParams({
       ...options,
       csrfToken,
-      callbackUrl,
+      callbackUrl: redirectTo,
     }),
   })
 
@@ -65,7 +65,7 @@ export async function signIn<
 
   if (redirect || !isSupportingReturn || !error) {
     // TODO: Do not redirect for Credentials and Email providers by default in next major
-    window.location.href = data.url ?? callbackUrl
+    window.location.href = data.url ?? redirectTo
     // If url contains a hash, the browser does not reload the page. We reload manually
     if (data.url.includes("#")) window.location.reload()
     return
@@ -81,7 +81,7 @@ export async function signIn<
  * [Documentation](https://authjs.dev/reference/utilities/#signout)
  */
 export async function signOut(options?: SignOutParams) {
-  const { callbackUrl = window.location.href } = options ?? {}
+  const { redirectTo = window.location.href } = options ?? {}
   // TODO: Custom base path
   // TODO: Remove this since Sveltekit offers the CSRF protection via origin check
   const csrfTokenResponse = await fetch("/auth/csrf")
@@ -94,12 +94,12 @@ export async function signOut(options?: SignOutParams) {
     },
     body: new URLSearchParams({
       csrfToken,
-      callbackUrl,
+      callbackUrl: redirectTo,
     }),
   })
   const data = await res.json()
 
-  const url = data.url ?? callbackUrl
+  const url = data.url ?? redirectTo
   window.location.href = url
   // If url contains a hash, the browser does not reload the page. We reload manually
   if (url.includes("#")) window.location.reload()

--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -1,7 +1,7 @@
 import type {
   LiteralUnion,
-  SignInOptions,
-  SignInAuthorizationParams,
+  SignInParams,
+  URLSearchParamsInit,
   SignOutParams,
 } from "@auth/core/types"
 import type {
@@ -24,8 +24,8 @@ export async function signIn<
       ? P | BuiltInProviderType
       : BuiltInProviderType
   >,
-  options?: SignInOptions,
-  authorizationParams?: SignInAuthorizationParams
+  options?: SignInParams,
+  authorizationParams?: URLSearchParamsInit
 ) {
   const { returnTo = window.location.href, redirect = true } = options ?? {}
 

--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -27,7 +27,7 @@ export async function signIn<
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ) {
-  const { redirectTo = window.location.href, redirect = true } = options ?? {}
+  const { returnTo = window.location.href, redirect = true } = options ?? {}
 
   // TODO: Support custom providers
   const isCredentials = providerId === "credentials"
@@ -56,7 +56,7 @@ export async function signIn<
     body: new URLSearchParams({
       ...options,
       csrfToken,
-      callbackUrl: redirectTo,
+      callbackUrl: returnTo,
     }),
   })
 
@@ -65,7 +65,7 @@ export async function signIn<
 
   if (redirect || !isSupportingReturn || !error) {
     // TODO: Do not redirect for Credentials and Email providers by default in next major
-    window.location.href = data.url ?? redirectTo
+    window.location.href = data.url ?? returnTo
     // If url contains a hash, the browser does not reload the page. We reload manually
     if (data.url.includes("#")) window.location.reload()
     return
@@ -81,7 +81,7 @@ export async function signIn<
  * [Documentation](https://authjs.dev/reference/utilities/#signout)
  */
 export async function signOut(options?: SignOutParams) {
-  const { redirectTo = window.location.href } = options ?? {}
+  const { returnTo = window.location.href } = options ?? {}
   // TODO: Custom base path
   // TODO: Remove this since Sveltekit offers the CSRF protection via origin check
   const csrfTokenResponse = await fetch("/auth/csrf")
@@ -94,12 +94,12 @@ export async function signOut(options?: SignOutParams) {
     },
     body: new URLSearchParams({
       csrfToken,
-      callbackUrl: redirectTo,
+      callbackUrl: returnTo,
     }),
   })
   const data = await res.json()
 
-  const url = data.url ?? redirectTo
+  const url = data.url ?? returnTo
   window.location.href = url
   // If url contains a hash, the browser does not reload the page. We reload manually
   if (url.includes("#")) window.location.reload()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,7 +543,6 @@ importers:
       '@types/cookie': 0.5.1
       '@types/node': ^18.7.14
       '@types/set-cookie-parser': ^2.4.2
-      next-auth: workspace:*
       set-cookie-parser: ^2.5.1
       solid-js: ^1.5.7
       solid-start: ^0.2.1
@@ -557,7 +556,6 @@ importers:
       '@types/cookie': 0.5.1
       '@types/node': 18.11.10
       '@types/set-cookie-parser': 2.4.2
-      next-auth: link:../next-auth
       solid-js: 1.6.6
       solid-start: 0.2.8_ol5sfeg2xpjsxxfgzadulo7fdi
       tsup: 6.5.0_typescript@4.9.4
@@ -570,7 +568,6 @@ importers:
       '@sveltejs/adapter-auto': ^1.0.0
       '@sveltejs/kit': ^1.0.0
       '@sveltejs/package': ^1.0.0
-      next-auth: workspace:*
       svelte: ^3.54.0
       svelte-check: ^2.9.2
       tslib: ^2.4.1
@@ -584,7 +581,6 @@ importers:
       '@sveltejs/adapter-auto': 1.0.0_@sveltejs+kit@1.0.1
       '@sveltejs/kit': 1.0.1_svelte@3.54.0+vite@4.0.1
       '@sveltejs/package': 1.0.1_gf4dcx76vtk2o62ixxeqx7chra
-      next-auth: link:../next-auth
       svelte: 3.54.0
       svelte-check: 2.10.1_svelte@3.54.0
       tslib: 2.4.1


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)

i'm going to split https://github.com/nextauthjs/next-auth/pull/6248 into different prs, this is the first pr

This is going to remove the `next-auth` dep from both solid-start and svelte.
This is also going to rename the `callbackUrl` to `redirectTo` as suggested by @balazsorban44  in the above pr:
```ts
signIn("provider", { returnTo: "" })
```

instead of 

```ts
signIn("provider", { callbackUrl: "" })
```

