### PR TITLE
Add success handler to getServerSideProps

### DIFF
--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -79,6 +79,8 @@ In order to get the available authentication providers and the URLs to use for t
 
 ```jsx title="pages/auth/signin.js"
 import { getProviders, signIn } from "next-auth/react"
+import { getServerSession } from "next-auth/next"
+import { authOptions } from "../../pages/api/auth/[...nextauth]";
 
 export default function SignIn({ providers }) {
   return (
@@ -95,8 +97,8 @@ export default function SignIn({ providers }) {
 }
 
 export async function getServerSideProps(context) {
-  const { req } = context;
-  const session = await getSession({ req });
+  const session = await getServerSession(context.req, context.res, authOptions);
+  
   // If sign in is successful, redirect to homepage
   if (session) {
     return {

--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -95,7 +95,17 @@ export default function SignIn({ providers }) {
 }
 
 export async function getServerSideProps(context) {
-  const providers = await getProviders()
+  const { req } = context;
+  const session = await getSession({ req });
+  const providers = await getProviders(context);
+
+  // If sign in is successful, redirect to homepage
+  if (session) {
+    return {
+      redirect: { destination: "/" },
+    };
+  }
+  
   return {
     props: { providers },
   }

--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -99,13 +99,11 @@ export default function SignIn({ providers }) {
 export async function getServerSideProps(context) {
   const session = await getServerSession(context.req, context.res, authOptions);
   
-  // If the user is already logged in, redirect,
-  // unless the destination is on the same page,
-  // to prevent infinite redirects
-  const destination = "/"
-  // Note, this does not check hash (#) or search params (?)
-  if (session && destination !== authOptions.pages?.signIn) {
-    return { redirect: { destination } };
+  // If the user is already logged in, redirect.
+  // Note: Make sure not to redirect to the same page
+  // To avoid an infinite loop!
+  if (session) {
+    return { redirect: { destination: "/" } };
   }
 
   const providers = await getProviders(context);

--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -97,14 +97,14 @@ export default function SignIn({ providers }) {
 export async function getServerSideProps(context) {
   const { req } = context;
   const session = await getSession({ req });
-  const providers = await getProviders(context);
-
   // If sign in is successful, redirect to homepage
   if (session) {
     return {
       redirect: { destination: "/" },
     };
   }
+
+  const providers = await getProviders(context);
   
   return {
     props: { providers },

--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -99,11 +99,13 @@ export default function SignIn({ providers }) {
 export async function getServerSideProps(context) {
   const session = await getServerSession(context.req, context.res, authOptions);
   
-  // If sign in is successful, redirect to homepage
-  if (session) {
-    return {
-      redirect: { destination: "/" },
-    };
+  // If the user is already logged in, redirect,
+  // unless the destination is on the same page,
+  // to prevent infinite redirects
+  const destination = "/"
+  // Note, this does not check hash (#) or search params (?)
+  if (session && destination !== authOptions.pages?.signIn) {
+    return { redirect: { destination } };
   }
 
   const providers = await getProviders(context);

--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -80,7 +80,7 @@ In order to get the available authentication providers and the URLs to use for t
 ```jsx title="pages/auth/signin.js"
 import { getProviders, signIn } from "next-auth/react"
 import { getServerSession } from "next-auth/next"
-import { authOptions } from "../../pages/api/auth/[...nextauth]";
+import { authOptions } from "../api/auth/[...nextauth]";
 
 export default function SignIn({ providers }) {
   return (


### PR DESCRIPTION

## ☕️ Reasoning

When implementing OAuth sign in with multiple providers. The documentation did show how to map all the providers and render it in the signin page, which is great.
After the user clicks on a provider to sign in, it did not state how the user will know if the sign in was successful. Hence, I added a code that checks for that in the getServerSideProps. It gives the user (especially a new user) a better sense of direction.


## 🧢 Checklist

- [✔️ ] Documentation


## 🎫 Affected issues

None.
