### PR TITLE
docs: enhance prisma mongodb doc to prevent warning

### DIFF
--- a/docs/docs/reference/06-adapters/prisma.md
+++ b/docs/docs/reference/06-adapters/prisma.md
@@ -139,9 +139,10 @@ Prisma supports MongoDB, and so does Auth.js. Following the instructions of the 
 id  String  @id @default(auto()) @map("_id") @db.ObjectId
 ```
 
-2. The Native database type attribute to `@db.String` from `@db.Text`.
+2. The Native database type attribute to `@db.String` from `@db.Text` and userId to `@db.ObjectId`.
 
 ```prisma
+user_id            String   @db.ObjectId
 refresh_token      String?  @db.String
 access_token       String?  @db.String
 id_token           String?  @db.String


### PR DESCRIPTION
## ☕️ Reasoning

Prisma member recommended adding `@db.ObjectId` for userId field to fix this waring problem. [link](https://github.com/prisma/prisma/discussions/17624#discussioncomment-4820223)

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes #6597

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
