### PR TITLE
Respect callbackUrl if provided to signIn

### DIFF
--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -55,6 +55,7 @@ export async function init({
   const { providers, provider } = parseProviders({
     providers: authOptions.providers,
     url,
+    callbackUrl: reqCallbackUrl,
     providerId,
   })
 

--- a/packages/core/src/lib/providers.ts
+++ b/packages/core/src/lib/providers.ts
@@ -16,12 +16,13 @@ import type {
 export default function parseProviders(params: {
   providers: Provider[]
   url: URL
+  callbackUrl: string | undefined
   providerId?: string
 }): {
   providers: InternalProvider[]
   provider?: InternalProvider
 } {
-  const { url, providerId } = params
+  const { url, callbackUrl, providerId } = params
 
   const providers = params.providers.map((provider) => {
     const { options: userOptions, ...defaults } = provider
@@ -29,7 +30,7 @@ export default function parseProviders(params: {
     const id = (userOptions?.id ?? defaults.id) as string
     const merged = merge(defaults, userOptions, {
       signinUrl: `${url}/signin/${id}`,
-      callbackUrl: `${url}/callback/${id}`,
+      callbackUrl: callbackUrl || `${url}/callback/${id}`,
     })
 
     if (provider.type === "oauth" || provider.type === "oidc") {

--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -54,6 +54,7 @@ export async function init({
   const { providers, provider } = parseProviders({
     providers: authOptions.providers,
     url,
+    callbackUrl: reqCallbackUrl,
     providerId,
   })
 

--- a/packages/next-auth/src/core/lib/providers.ts
+++ b/packages/next-auth/src/core/lib/providers.ts
@@ -14,12 +14,13 @@ import type {
 export default function parseProviders(params: {
   providers: Provider[]
   url: URL
+  callbackUrl: string | undefined
   providerId?: string
 }): {
   providers: InternalProvider[]
   provider?: InternalProvider
 } {
-  const { url, providerId } = params
+  const { url, callbackUrl, providerId } = params
 
   const providers = params.providers.map<InternalProvider>(
     ({ options: userOptions, ...rest }) => {
@@ -30,14 +31,14 @@ export default function parseProviders(params: {
         return merge(normalizedOptions, {
           ...normalizedUserOptions,
           signinUrl: `${url}/signin/${id}`,
-          callbackUrl: `${url}/callback/${id}`,
+          callbackUrl: callbackUrl || `${url}/callback/${id}`,
         })
       }
       const id = (userOptions?.id as string) ?? rest.id
       return merge(rest, {
         ...userOptions,
         signinUrl: `${url}/signin/${id}`,
-        callbackUrl: `${url}/callback/${id}`,
+        callbackUrl: callbackUrl || `${url}/callback/${id}`,
       })
     }
   )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

I am using auth.js with sveltekit. When I call `signIn(providerId, { callbackUrl })` (https://github.com/nextauthjs/next-auth/blob/main/packages/frameworks-sveltekit/src/lib/client.ts#L19-L30)with an oauth provider, I expect the user to be redirected to `callbackUrl`  after provider authn.

Currently, the actual behavior is that they always get redirected to `${request.url}/callback/${providerId}`: https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/lib/providers.ts#L32.

The `redirect_uri` controls where redirect after provider authn goes, and it is set equal to the `provider.callbackUrl` https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/lib/oauth/authorization-url.ts#L49. The root cause is that the `provider.callbackUrl`  is lost during `AuthInternal` handler initialization because `parseProviders` ignores `callbackUrl` when instantiating providers (https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/lib/init.ts#L55-L59).

One fix is suggested by this PR: when a `callbackUrl` is passed to `init()`, thread it through to `parseProviders` so that it is ultimately used for `redirect_uri`. When it is `undefined`, default back to previous behavior to maintain backwards compatibility.


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
