### PR TITLE
fix(next-auth): remove `engines` requirement on `openid-client`

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -67,12 +67,12 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@panva/hkdf": "^1.0.1",
+    "@babel/runtime": "^7.20.13",
+    "@panva/hkdf": "^1.0.2",
     "cookie": "^0.5.0",
-    "jose": "^4.9.3",
+    "jose": "^4.11.4",
     "oauth": "^0.9.15",
-    "openid-client": "^5.1.0",
+    "openid-client": "^5.4.0",
     "preact": "^10.6.3",
     "preact-render-to-string": "^5.1.19",
     "uuid": "^8.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,10 +447,10 @@ importers:
       '@babel/preset-env': ^7.18.2
       '@babel/preset-react': ^7.17.12
       '@babel/preset-typescript': ^7.17.12
-      '@babel/runtime': ^7.16.3
+      '@babel/runtime': ^7.20.13
       '@edge-runtime/jest-environment': 1.1.0-beta.35
       '@next-auth/tsconfig': workspace:*
-      '@panva/hkdf': ^1.0.1
+      '@panva/hkdf': ^1.0.2
       '@swc/core': ^1.2.198
       '@swc/jest': ^0.2.21
       '@testing-library/dom': ^8.13.0
@@ -473,11 +473,11 @@ importers:
       jest: ^28.1.1
       jest-environment-jsdom: ^28.1.1
       jest-watch-typeahead: ^1.1.0
-      jose: ^4.9.3
+      jose: ^4.11.4
       msw: ^0.42.3
       next: 13.0.6
       oauth: ^0.9.15
-      openid-client: ^5.1.0
+      openid-client: ^5.4.0
       postcss: ^8.4.14
       postcss-cli: ^9.1.0
       postcss-nested: ^5.0.6
@@ -488,12 +488,12 @@ importers:
       uuid: ^8.3.2
       whatwg-fetch: ^3.6.2
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
       '@panva/hkdf': 1.0.2
       cookie: 0.5.0
-      jose: 4.11.0
+      jose: 4.11.4
       oauth: 0.9.15
-      openid-client: 5.1.6
+      openid-client: 5.4.0
       preact: 10.8.2
       preact-render-to-string: 5.2.0_preact@10.8.2
       uuid: 8.3.2
@@ -4996,21 +4996,21 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       core-js-pure: 3.26.0
-      regenerator-runtime: 0.13.10
+      regenerator-runtime: 0.13.11
     dev: true
-
-  /@babel/runtime/7.18.3:
-    resolution: {integrity: sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.9
 
   /@babel/runtime/7.20.1:
     resolution: {integrity: sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.10
+      regenerator-runtime: 0.13.11
     dev: true
+
+  /@babel/runtime/7.20.13:
+    resolution: {integrity: sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
 
   /@babel/template/7.16.7:
     resolution: {integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==}
@@ -8245,7 +8245,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
       '@types/aria-query': 4.2.2
       aria-query: 5.0.0
       chalk: 4.1.2
@@ -8258,7 +8258,7 @@ packages:
     resolution: {integrity: sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==}
     engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
       '@types/testing-library__jest-dom': 5.14.5
       aria-query: 5.0.0
       chalk: 3.0.0
@@ -8285,7 +8285,7 @@ packages:
       react-test-renderer:
         optional: true
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
       '@types/react': 18.0.15
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -8299,7 +8299,7 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
       '@testing-library/dom': 8.14.0
       '@types/react-dom': 18.0.6
       react: 18.2.0
@@ -15236,7 +15236,7 @@ packages:
   /history/4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.2.0
@@ -17659,12 +17659,8 @@ packages:
       valid-url: 1.0.9
     dev: true
 
-  /jose/4.11.0:
-    resolution: {integrity: sha512-wLe+lJHeG8Xt6uEubS4x0LVjS/3kXXu9dGoj9BNnlhYq7Kts0Pbb2pvv5KiI0yaKH/eaiR0LUOBhOVo9ktd05A==}
-    dev: false
-
-  /jose/4.11.1:
-    resolution: {integrity: sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==}
+  /jose/4.11.4:
+    resolution: {integrity: sha512-94FdcR8felat4vaTJyL/WVdtlWLlsnLMZP8v+A0Vru18K3bQ22vn7TtpVh3JlgBFNIlYOUlGqwp/MjRPOnIyCQ==}
     dev: false
 
   /js-beautify/1.14.4:
@@ -18839,7 +18835,7 @@ packages:
       prop-types: ^15.0.0
       react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       prop-types: 15.8.1
       react: 18.2.0
       tiny-warning: 1.0.3
@@ -19214,7 +19210,7 @@ packages:
   /neo4j-driver/4.4.6:
     resolution: {integrity: sha512-KzTEQ/PYuaVkeEuQmr8jZm0cFLlK/zAAMe3IkhxWj56Tgwn2nT2RASPrqwvyEVfk8jg6xS4U1Fx2VABmkO4cdQ==}
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
       neo4j-driver-bolt-connection: 4.4.6
       neo4j-driver-core: 4.4.6
       rxjs: 6.6.7
@@ -19680,11 +19676,10 @@ packages:
     hasBin: true
     dev: true
 
-  /openid-client/5.1.6:
-    resolution: {integrity: sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==}
-    engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
+  /openid-client/5.4.0:
+    resolution: {integrity: sha512-hgJa2aQKcM2hn3eyVtN12tEA45ECjTJPXCgUh5YzTzy9qwapCvmDTVPWOcWVL0d34zeQoQ/hbG9lJhl3AYxJlQ==}
     dependencies:
-      jose: 4.11.1
+      jose: 4.11.4
       lru-cache: 6.0.0
       object-hash: 2.2.0
       oidc-token-hash: 5.0.1
@@ -21606,7 +21601,7 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
       react: 18.2.0
     dev: true
 
@@ -21624,7 +21619,7 @@ packages:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.2.0
@@ -21672,7 +21667,7 @@ packages:
       react-loadable: '*'
       webpack: '>=4.41.1 || 5.x'
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@18.2.0
       webpack: 5.73.0
     dev: true
@@ -21691,7 +21686,7 @@ packages:
       react: '>=15'
       react-router: '>=5'
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       react: 18.2.0
       react-router: 5.3.3_react@18.2.0
     dev: true
@@ -21701,7 +21696,7 @@ packages:
     peerDependencies:
       react: '>=15'
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -21716,7 +21711,7 @@ packages:
     peerDependencies:
       react: '>=15'
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -21735,7 +21730,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.13
       react: 18.2.0
       use-composed-ref: 1.3.0_react@18.2.0
       use-latest: 1.2.1_react@18.2.0
@@ -21882,17 +21877,13 @@ packages:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
     dev: true
 
-  /regenerator-runtime/0.13.10:
-    resolution: {integrity: sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==}
-    dev: true
-
-  /regenerator-runtime/0.13.9:
-    resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
+  /regenerator-runtime/0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   /regenerator-transform/0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.20.13
     dev: true
 
   /regexp.prototype.flags/1.4.3:


### PR DESCRIPTION
Fixes #6650