### PR TITLE
fix: documentation maxAge typo

### DIFF
--- a/packages/next-auth/src/jwt/types.ts
+++ b/packages/next-auth/src/jwt/types.ts
@@ -21,7 +21,7 @@ export interface JWTEncodeParams {
   secret: string | Buffer
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 24 * 30 * 60 // 30 days
    */
   maxAge?: number
 }
@@ -42,7 +42,7 @@ export interface JWTOptions {
   secret: string
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 24 * 30 * 60 // 30 days
    */
   maxAge: number
   /** Override this method to control the NextAuth.js issued JWT encoding. */


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
fix documentation maxAge typo.
maxAge is measured in seconds, so, 30 days should be: 60 * 24 * 30, instead of 60 * 24 * 30 * 30.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
