### PR TITLE
fix: pass user-supplied provider.authorization.params.state to service provider and signIn callback (#5727)

### DIFF
--- a/packages/next-auth/src/core/lib/oauth/authorization-url.ts
+++ b/packages/next-auth/src/core/lib/oauth/authorization-url.ts
@@ -54,7 +54,7 @@ export default async function getAuthorizationUrl({
   const authorizationParams: AuthorizationParameters = params
   const cookies: Cookie[] = []
 
-  const state = await createState(options)
+  const state = await createState(options, authorizationParams.state)
   if (state) {
     authorizationParams.state = state.value
     cookies.push(state.cookie)

--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -56,7 +56,7 @@ export default async function oAuthCallback(params: {
       }
 
       const newProfile = await getProfile({ profile, tokens, provider, logger })
-      return { ...newProfile, cookies: [] }
+      return { ...newProfile, state: undefined, cookies: [] }
     } catch (error) {
       logger.error("OAUTH_V1_GET_ACCESS_TOKEN_ERROR", error as Error)
       throw error
@@ -142,7 +142,7 @@ export default async function oAuthCallback(params: {
       tokens,
       logger,
     })
-    return { ...profileResult, cookies: resCookies }
+    return { ...profileResult, state: state?.value, cookies: resCookies }
   } catch (error) {
     throw new OAuthCallbackError(error as Error)
   }

--- a/packages/next-auth/src/core/lib/oauth/state-handler.ts
+++ b/packages/next-auth/src/core/lib/oauth/state-handler.ts
@@ -7,7 +7,8 @@ const STATE_MAX_AGE = 60 * 15 // 15 minutes in seconds
 
 /** Returns state if the provider supports it */
 export async function createState(
-  options: InternalOptions<"oauth">
+  options: InternalOptions<"oauth">,
+  authorizationParamsState: string | undefined,
 ): Promise<{ cookie: Cookie; value: string } | undefined> {
   const { logger, provider, jwt, cookies } = options
 
@@ -16,7 +17,7 @@ export async function createState(
     return
   }
 
-  const state = generators.state()
+  const state = authorizationParamsState ?? generators.state()
   const maxAge = cookies.state.options.maxAge ?? STATE_MAX_AGE
 
   const encodedState = await jwt.encode({

--- a/packages/next-auth/src/core/routes/callback.ts
+++ b/packages/next-auth/src/core/routes/callback.ts
@@ -43,6 +43,7 @@ export default async function callback(params: {
         profile,
         account,
         OAuthProfile,
+        state,
         cookies: oauthCookies,
       } = await oAuthCallback({
         query,
@@ -94,6 +95,7 @@ export default async function callback(params: {
             user: userOrProfile,
             account,
             profile: OAuthProfile,
+            state,
           })
           if (!isAllowed) {
             return { redirect: `${url}/error?error=AccessDenied`, cookies }
@@ -156,7 +158,7 @@ export default async function callback(params: {
         }
 
         // @ts-expect-error
-        await events.signIn?.({ user, account, profile, isNewUser })
+        await events.signIn?.({ user, account, profile, state, isNewUser })
 
         // Handle first logins on new accounts
         // e.g. option to send users to a new account landing page on initial login

--- a/packages/next-auth/src/core/types.ts
+++ b/packages/next-auth/src/core/types.ts
@@ -291,6 +291,12 @@ export interface CallbacksOptions<P = Profile, A = Account> {
     }
     /** If Credentials provider is used, it contains the user credentials */
     credentials?: Record<string, CredentialInput>
+    /**
+     * If state check is enabled for the provider, it contains the value of the state.
+     * The state value may either be the user-supplied value for the `state` property
+     * in the provider's authorization params, or a dynamically generated value.
+    */
+    state?: string
   }) => Awaitable<string | boolean>
   /**
    * This callback is called anytime the user is redirected to a callback URL (e.g. on signin or signout).


### PR DESCRIPTION
## ☕️ Reasoning

* Value supplied in `[...nextauth].ts` `provider.authorization.params.state` is currently not supplied to the provider service
* PR based on suggestion in comment (https://github.com/nextauthjs/next-auth/issues/5727#issuecomment-1304666934)
* Allowing `state` parameter to be available in the `signIn` callback helps decide post-login steps (redirect to specific page based on state?)

## 🧢 Checklist

Documentation for the `signIn` callback will need to be updated for the additional `state` parameter. I'll update it if that change is acceptable, since this may need discussion.
Since the `state` parameter in that callback will only be available for OAuth providers, adding it there may be confusing?

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

- #5727 
- If I understand correctly, maybe #6716


Fixes: https://github.com/nextauthjs/next-auth/issues/5727

