### PR TITLE
fix: compatibility with edge runtimes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@panva/hkdf": "^1.0.2",
+    "@panva/hkdf": "^1.0.3",
     "cookie": "0.5.0",
     "jose": "^4.11.1",
     "oauth4webapi": "^2.0.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@panva/hkdf": "^1.0.3",
+    "@panva/hkdf": "^1.0.4",
     "cookie": "0.5.0",
     "jose": "^4.11.1",
     "oauth4webapi": "^2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ importers:
       vercel: ^23.1.2
     dependencies:
       dotenv: 16.0.3
-      gatsby: 5.7.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby: 5.8.0-next.0_biqbaboplfbrettd7655fr4n2y
       next-auth: link:../../../packages/next-auth
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -506,7 +506,7 @@ importers:
   packages/core:
     specifiers:
       '@next-auth/tsconfig': workspace:*
-      '@panva/hkdf': ^1.0.2
+      '@panva/hkdf': ^1.0.4
       '@types/cookie': 0.5.1
       '@types/node': 18.11.10
       '@types/nodemailer': 6.4.6
@@ -520,7 +520,7 @@ importers:
       preact: 10.11.3
       preact-render-to-string: 5.2.3
     dependencies:
-      '@panva/hkdf': 1.0.2
+      '@panva/hkdf': 1.0.4
       cookie: 0.5.0
       jose: 4.11.1
       oauth4webapi: 2.0.6
@@ -1911,13 +1911,13 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.5
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helpers': 7.20.7
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       convert-source-map: 1.8.0
       debug: 4.3.4
@@ -1984,6 +1984,7 @@ packages:
       '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: false
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -2420,7 +2421,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -2636,6 +2637,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.7
+    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.17.12:
     resolution: {integrity: sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==}
@@ -4045,8 +4047,8 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-jsx/7.17.12_@babel+core@7.18.5:
-    resolution: {integrity: sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==}
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.5:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -5878,7 +5880,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.5
-      '@babel/plugin-transform-react-jsx': 7.17.12_@babel+core@7.18.5
+      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.18.5
     dev: true
 
   /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.20.12:
@@ -5910,7 +5912,21 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.17.12_@babel+core@7.18.5
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.5
+      '@babel/types': 7.20.7
+    dev: true
+
+  /@babel/plugin-transform-react-jsx/7.19.0_@babel+core@7.18.5:
+    resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.5
       '@babel/types': 7.20.7
     dev: true
 
@@ -7159,13 +7175,6 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  /@babel/runtime/7.20.7:
-    resolution: {integrity: sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.11
-    dev: true
-
   /@babel/standalone/7.20.12:
     resolution: {integrity: sha512-hK/X+m1il3w1tYS4H8LDaGCEdiT47SVqEXY8RiEAgou26BystipSU8ZL6EvBR6t5l7lTv0ilBiChXWblKJ5iUA==}
     engines: {node: '>=6.9.0'}
@@ -7176,7 +7185,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
     dev: true
 
@@ -7185,7 +7194,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
     dev: true
 
@@ -7202,24 +7211,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/traverse/7.20.1:
-    resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
       '@babel/generator': 7.20.14
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
@@ -7233,8 +7224,8 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/traverse/7.20.12:
-    resolution: {integrity: sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==}
+  /@babel/traverse/7.20.1:
+    resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
@@ -8515,14 +8506,14 @@ packages:
     dev: true
     optional: true
 
-  /@gatsbyjs/parcel-namer-relative-to-cwd/2.7.0-next.0_@parcel+core@2.8.3:
-    resolution: {integrity: sha512-9Zg4XkxOgsOUWgrc7RmsietgvH6wesildPtpdT2Z9R45Q05i6OcgBUhX+qQoniQJzci8IEBM2vSkU9E8x6E74Q==}
+  /@gatsbyjs/parcel-namer-relative-to-cwd/2.8.0-next.0_@parcel+core@2.8.3:
+    resolution: {integrity: sha512-7dFoiBdxJ9McFMF3P0I7pVD2hMfXypWbYuClXATJ16y+fCtJhtVRGCYrBpfWPQqBs67DibAKno4StLwuYEyrew==}
     engines: {node: '>=18.0.0', parcel: 2.x}
     dependencies:
       '@babel/runtime': 7.20.13
       '@parcel/namer-default': 2.8.3_@parcel+core@2.8.3
       '@parcel/plugin': 2.8.3_@parcel+core@2.8.3
-      gatsby-core-utils: 4.7.0-next.0
+      gatsby-core-utils: 4.8.0-next.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
@@ -10685,6 +10676,10 @@ packages:
 
   /@panva/hkdf/1.0.2:
     resolution: {integrity: sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==}
+    dev: false
+
+  /@panva/hkdf/1.0.4:
+    resolution: {integrity: sha512-003xWiCuvePbLaPHT+CRuaV4GlyCAVm6XYSbBZDHoWZGn1mNkVKFaDbGJjjxmEFvizUwlCoM6O18FCBMMky2zQ==}
     dev: false
 
   /@parcel/bundler-default/2.8.3_@parcel+core@2.8.3:
@@ -13750,8 +13745,10 @@ packages:
       indent-string: 4.0.0
     dev: true
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -14693,8 +14690,8 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-remove-graphql-queries/5.7.0-next.0_kwfgdicz63ldiwfqlkadmrpj4y:
-    resolution: {integrity: sha512-dguL6QCS9duTt22QZYlu4ZY/DW/EjCkUc/43YDkfR/lbx32OqKwg1+zKYAE67bJ5PKhdK7PP+dh0486dt4iavQ==}
+  /babel-plugin-remove-graphql-queries/5.8.0-next.0_osdpouujtlfd2op5ubueuc4aqi:
+    resolution: {integrity: sha512-emjOEAt/rnb1eGC1ximT3/Rs1i6U6DT2K385uteLPsGsZ8s6fCPvmzm8TLjRM3iWT4LTVc9OBGghkFPCJ8C6Vg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -14703,8 +14700,8 @@ packages:
       '@babel/core': 7.20.12
       '@babel/runtime': 7.20.13
       '@babel/types': 7.20.7
-      gatsby: 5.7.0-next.0_biqbaboplfbrettd7655fr4n2y
-      gatsby-core-utils: 4.7.0-next.0
+      gatsby: 5.8.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby-core-utils: 4.8.0-next.0
     dev: false
 
   /babel-plugin-styled-components/2.0.7_styled-components@5.3.6:
@@ -14788,8 +14785,8 @@ packages:
       - supports-color
     dev: false
 
-  /babel-preset-gatsby/3.7.0-next.0_pp2vm42zn6vfmnpuhar3irht7i:
-    resolution: {integrity: sha512-nf7aujMeM4gWtiIsdSlap6XaM8zI3pxfTWtIv3LBYN64T59Fi0sDLlDPOicGPrZQxtRWP7zqJBBbnSuy0P3oDA==}
+  /babel-preset-gatsby/3.8.0-next.0_pp2vm42zn6vfmnpuhar3irht7i:
+    resolution: {integrity: sha512-TLa6W4nEsjLEYcNv/vdUC/mas35bJsmPVfMkMafUJWoPPCC1Yk0HDHd2nvYCr/2YO81g94xfgh9QEXoKB7dZng==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@babel/core': ^7.11.6
@@ -14810,8 +14807,8 @@ packages:
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
       core-js: 3.26.0
-      gatsby-core-utils: 4.7.0-next.0
-      gatsby-legacy-polyfills: 3.7.0-next.0
+      gatsby-core-utils: 4.8.0-next.0
+      gatsby-legacy-polyfills: 3.8.0-next.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -16234,8 +16231,8 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
-  /create-gatsby/3.7.0-next.0:
-    resolution: {integrity: sha512-9Ywci5zGlfvXKId+tIZdBRN1X1Y2UPgEjEafiCkHgD4+oQX4+xUYp46abQMhTJZOqokz4zMY16Y9JIhp1eAjQw==}
+  /create-gatsby/3.8.0-next.0:
+    resolution: {integrity: sha512-hIAqq4j4rEeblEfGMXhu25tQRjlmJlwJ1xxRmFFIGVHp2rBF2ruCfj8TfW1Iv+29q881bUzx0sg1GmHSIKl1rQ==}
     hasBin: true
     dependencies:
       '@babel/runtime': 7.20.13
@@ -16292,22 +16289,13 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /css-declaration-sorter/6.3.0_postcss@8.4.14:
-    resolution: {integrity: sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==}
+  /css-declaration-sorter/6.3.1_postcss@8.4.14:
+    resolution: {integrity: sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
       postcss: 8.4.14
-    dev: true
-
-  /css-declaration-sorter/6.3.0_postcss@8.4.20:
-    resolution: {integrity: sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==}
-    engines: {node: ^10 || ^12 || >=14}
-    peerDependencies:
-      postcss: ^8.0.9
-    dependencies:
-      postcss: 8.4.20
     dev: true
 
   /css-declaration-sorter/6.3.1_postcss@8.4.20:
@@ -16490,21 +16478,21 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.3.0_postcss@8.4.14
+      css-declaration-sorter: 6.3.1_postcss@8.4.14
       cssnano-utils: 3.1.0_postcss@8.4.14
       postcss: 8.4.14
       postcss-calc: 8.2.4_postcss@8.4.14
       postcss-colormin: 5.3.0_postcss@8.4.14
-      postcss-convert-values: 5.1.2_postcss@8.4.14
+      postcss-convert-values: 5.1.3_postcss@8.4.14
       postcss-discard-comments: 5.1.2_postcss@8.4.14
       postcss-discard-duplicates: 5.1.0_postcss@8.4.14
       postcss-discard-empty: 5.1.1_postcss@8.4.14
       postcss-discard-overridden: 5.1.0_postcss@8.4.14
-      postcss-merge-longhand: 5.1.6_postcss@8.4.14
-      postcss-merge-rules: 5.1.2_postcss@8.4.14
+      postcss-merge-longhand: 5.1.7_postcss@8.4.14
+      postcss-merge-rules: 5.1.3_postcss@8.4.14
       postcss-minify-font-values: 5.1.0_postcss@8.4.14
       postcss-minify-gradients: 5.1.1_postcss@8.4.14
-      postcss-minify-params: 5.1.3_postcss@8.4.14
+      postcss-minify-params: 5.1.4_postcss@8.4.14
       postcss-minify-selectors: 5.2.1_postcss@8.4.14
       postcss-normalize-charset: 5.1.0_postcss@8.4.14
       postcss-normalize-display-values: 5.1.0_postcss@8.4.14
@@ -16512,11 +16500,11 @@ packages:
       postcss-normalize-repeat-style: 5.1.1_postcss@8.4.14
       postcss-normalize-string: 5.1.0_postcss@8.4.14
       postcss-normalize-timing-functions: 5.1.0_postcss@8.4.14
-      postcss-normalize-unicode: 5.1.0_postcss@8.4.14
+      postcss-normalize-unicode: 5.1.1_postcss@8.4.14
       postcss-normalize-url: 5.1.0_postcss@8.4.14
       postcss-normalize-whitespace: 5.1.1_postcss@8.4.14
       postcss-ordered-values: 5.1.3_postcss@8.4.14
-      postcss-reduce-initial: 5.1.0_postcss@8.4.14
+      postcss-reduce-initial: 5.1.1_postcss@8.4.14
       postcss-reduce-transforms: 5.1.0_postcss@8.4.14
       postcss-svgo: 5.1.0_postcss@8.4.14
       postcss-unique-selectors: 5.1.1_postcss@8.4.14
@@ -16528,21 +16516,21 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.3.0_postcss@8.4.20
+      css-declaration-sorter: 6.3.1_postcss@8.4.20
       cssnano-utils: 3.1.0_postcss@8.4.20
       postcss: 8.4.20
       postcss-calc: 8.2.4_postcss@8.4.20
       postcss-colormin: 5.3.0_postcss@8.4.20
-      postcss-convert-values: 5.1.2_postcss@8.4.20
+      postcss-convert-values: 5.1.3_postcss@8.4.20
       postcss-discard-comments: 5.1.2_postcss@8.4.20
       postcss-discard-duplicates: 5.1.0_postcss@8.4.20
       postcss-discard-empty: 5.1.1_postcss@8.4.20
       postcss-discard-overridden: 5.1.0_postcss@8.4.20
-      postcss-merge-longhand: 5.1.6_postcss@8.4.20
-      postcss-merge-rules: 5.1.2_postcss@8.4.20
+      postcss-merge-longhand: 5.1.7_postcss@8.4.20
+      postcss-merge-rules: 5.1.3_postcss@8.4.20
       postcss-minify-font-values: 5.1.0_postcss@8.4.20
       postcss-minify-gradients: 5.1.1_postcss@8.4.20
-      postcss-minify-params: 5.1.3_postcss@8.4.20
+      postcss-minify-params: 5.1.4_postcss@8.4.20
       postcss-minify-selectors: 5.2.1_postcss@8.4.20
       postcss-normalize-charset: 5.1.0_postcss@8.4.20
       postcss-normalize-display-values: 5.1.0_postcss@8.4.20
@@ -16550,11 +16538,11 @@ packages:
       postcss-normalize-repeat-style: 5.1.1_postcss@8.4.20
       postcss-normalize-string: 5.1.0_postcss@8.4.20
       postcss-normalize-timing-functions: 5.1.0_postcss@8.4.20
-      postcss-normalize-unicode: 5.1.0_postcss@8.4.20
+      postcss-normalize-unicode: 5.1.1_postcss@8.4.20
       postcss-normalize-url: 5.1.0_postcss@8.4.20
       postcss-normalize-whitespace: 5.1.1_postcss@8.4.20
       postcss-ordered-values: 5.1.3_postcss@8.4.20
-      postcss-reduce-initial: 5.1.0_postcss@8.4.20
+      postcss-reduce-initial: 5.1.1_postcss@8.4.20
       postcss-reduce-transforms: 5.1.0_postcss@8.4.20
       postcss-svgo: 5.1.0_postcss@8.4.20
       postcss-unique-selectors: 5.1.1_postcss@8.4.20
@@ -19542,7 +19530,7 @@ packages:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.0.9
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       body-parser: 1.20.0
       content-type: 1.0.4
       deep-freeze: 0.0.1
@@ -20466,8 +20454,8 @@ packages:
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  /gatsby-cli/5.7.0-next.0:
-    resolution: {integrity: sha512-hhBRqmXNuMx0bMaPvkmAJ1nZRzKkr4K7V19OhFD6iLFuDucN35bU9lTiyJ22Ctvhe0JU93a0ZQW1jrMxNScyyg==}
+  /gatsby-cli/5.8.0-next.0:
+    resolution: {integrity: sha512-oyWlvplp6N9KHHHGKTzqLyKtzB6KOFyS+88Z4kj2QHvRKWPX0KitO7MOp4Xmc6G8Zqrl8JWNqH9+uyVh0m3+BA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     requiresBuild: true
@@ -20488,13 +20476,13 @@ packages:
       clipboardy: 2.3.0
       common-tags: 1.8.2
       convert-hrtime: 3.0.0
-      create-gatsby: 3.7.0-next.0
+      create-gatsby: 3.8.0-next.0
       envinfo: 7.8.1
       execa: 5.1.1
       fs-exists-cached: 1.0.0
       fs-extra: 11.1.0
-      gatsby-core-utils: 4.7.0-next.0
-      gatsby-telemetry: 4.7.0-next.0
+      gatsby-core-utils: 4.8.0-next.0
+      gatsby-telemetry: 4.8.0-next.0
       hosted-git-info: 3.0.8
       is-valid-path: 0.1.1
       joi: 17.7.0
@@ -20518,8 +20506,8 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby-core-utils/4.7.0-next.0:
-    resolution: {integrity: sha512-lBZA6akCHFPsR2TuOmyMQaskeyv3bKzgdvIG1KPF5Lgztf4Rs07Z8WvqVGq6lVYMM0rCJCDoO6dfy9pJdHFuUQ==}
+  /gatsby-core-utils/4.8.0-next.0:
+    resolution: {integrity: sha512-T6Q0DeY6Vz+IxHhegmyfS6R5scNE2lnYzF1It2B3AEM7WoIGYh6+K3qRF6tW/H3s1j8/lsJpvF7/WLTtBRgK8Q==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@babel/runtime': 7.20.13
@@ -20540,20 +20528,20 @@ packages:
       xdg-basedir: 4.0.0
     dev: false
 
-  /gatsby-graphiql-explorer/3.7.0-next.0:
-    resolution: {integrity: sha512-ZgtnZqz4jSuYMp6Mr7QICpRfsjG9QwsT/HS8nxezGP5p8/hBK5N2kJcvonWAwJnhmuViRiWITrWsaXthBVBmeQ==}
+  /gatsby-graphiql-explorer/3.8.0-next.0:
+    resolution: {integrity: sha512-X+/rXixt/PcW6l3yabgBZkNxfVuLsUy071buYhevwdUi6bA4frG74nOToa7LduiYRrdIoRmuD/W5F9QjWL/uow==}
     engines: {node: '>=18.0.0'}
     dev: false
 
-  /gatsby-legacy-polyfills/3.7.0-next.0:
-    resolution: {integrity: sha512-6HMpm8T76gHKo/uw7xrWVMOd8O4YPcuP7UVeeMkJIZG68gzqFjQfEHJo4kMDWMXuMlFgi5Brvz6nGRNFrAQL8A==}
+  /gatsby-legacy-polyfills/3.8.0-next.0:
+    resolution: {integrity: sha512-AcfU7iegcw74Cl3G1INilse/XmR0bHT9DM1UVgQ4/+by7tnCcGoGXamkP+586A/KozlmAnqgC9njC6w8AQQ+kQ==}
     dependencies:
       '@babel/runtime': 7.20.13
       core-js-compat: 3.9.0
     dev: false
 
-  /gatsby-link/5.7.0-next.0_uxzdzcrcylloub4rxar25ny6ra:
-    resolution: {integrity: sha512-BWmj6VytpVyCI8LREDs27PQN5r41mpCXwQ8jVky6h8gHOuMjfVk+O3Q5DGzHBylxJxs6+3ijHVSOVox1fLmRtA==}
+  /gatsby-link/5.8.0-next.0_uxzdzcrcylloub4rxar25ny6ra:
+    resolution: {integrity: sha512-sBOehr2zuFxS3dMFa+WIEhQw8TCTPh/iqsZ4VWqYjFti8F9gS/weL9sDK5vuaQ/HqnjvBITy7uNXVEOjbTX6bg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@gatsbyjs/reach-router': ^2.0.0
@@ -20562,33 +20550,33 @@ packages:
     dependencies:
       '@gatsbyjs/reach-router': 2.0.1_biqbaboplfbrettd7655fr4n2y
       '@types/reach__router': 1.3.11
-      gatsby-page-utils: 3.7.0-next.0
+      gatsby-page-utils: 3.8.0-next.0
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /gatsby-page-utils/3.7.0-next.0:
-    resolution: {integrity: sha512-4heFJsjOPxHjzOmik5Kd4PzDlyZ2U1fOj6JZyppjOa+PZI0jrbsb1O2BeIOkTlB+2MNoG4Zv/aj3UpCnEC1SVg==}
+  /gatsby-page-utils/3.8.0-next.0:
+    resolution: {integrity: sha512-/HsHDb0oE7o3fPm9DOL1U5t0wBwHsuGlojzCOsXQu5UWS8N41LNOv8YEqG9s1gYAOTZtEzEjX1aX/u2B9yIj4Q==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@babel/runtime': 7.20.13
       bluebird: 3.7.2
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
-      gatsby-core-utils: 4.7.0-next.0
+      gatsby-core-utils: 4.8.0-next.0
       glob: 7.2.3
       lodash: 4.17.21
       micromatch: 4.0.5
     dev: false
 
-  /gatsby-parcel-config/1.7.0-next.0_@parcel+core@2.8.3:
-    resolution: {integrity: sha512-cE4ltBaE9kWJ5EsUHSpcudp9dYSd29+VRR7gXdHEo/UxuNkLtcrlKwsPu/2553CX6aBdxt6Xyqcd7YwOs0RQ6w==}
+  /gatsby-parcel-config/1.8.0-next.0_@parcel+core@2.8.3:
+    resolution: {integrity: sha512-rk7sLGf4c4cHQoPHUaOIb8BW2CuJRg/jS5f7y70NiCFuDTPipDwEVDEhsJKoE+5/uUy2dieWkrddxj6mgyYivw==}
     engines: {parcel: 2.x}
     peerDependencies:
       '@parcel/core': ^2.0.0
     dependencies:
-      '@gatsbyjs/parcel-namer-relative-to-cwd': 2.7.0-next.0_@parcel+core@2.8.3
+      '@gatsbyjs/parcel-namer-relative-to-cwd': 2.8.0-next.0_@parcel+core@2.8.3
       '@parcel/bundler-default': 2.8.3_@parcel+core@2.8.3
       '@parcel/compressor-raw': 2.8.3_@parcel+core@2.8.3
       '@parcel/core': 2.8.3
@@ -20603,8 +20591,8 @@ packages:
       '@parcel/transformer-json': 2.8.3_@parcel+core@2.8.3
     dev: false
 
-  /gatsby-plugin-page-creator/5.7.0-next.0_5qnviuipb4fcbildeubwcez6ia:
-    resolution: {integrity: sha512-Lq7lyHBNiHvgjTXeybUo+cn/QjOjoN1PnoZlKyM0wGpJOX9nn6hrED+C5FylOKf4hS/RjLPaGf4OnYzeOAkWtQ==}
+  /gatsby-plugin-page-creator/5.8.0-next.0_irjlgbbmdc6sbwac5pl62frsae:
+    resolution: {integrity: sha512-G3NxUJOTZQFt+b2OO0A9yOxfKGiwnUdvpBymob9kJ/YyxLX82ri3xlXPTxp7imQDIbv1BbVRVFV45EVWrWJWKg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       gatsby: ^5.0.0-next
@@ -20615,11 +20603,11 @@ packages:
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
       fs-extra: 11.1.0
-      gatsby: 5.7.0-next.0_biqbaboplfbrettd7655fr4n2y
-      gatsby-core-utils: 4.7.0-next.0
-      gatsby-page-utils: 3.7.0-next.0
-      gatsby-plugin-utils: 4.7.0-next.0_5qnviuipb4fcbildeubwcez6ia
-      gatsby-telemetry: 4.7.0-next.0
+      gatsby: 5.8.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby-core-utils: 4.8.0-next.0
+      gatsby-page-utils: 3.8.0-next.0
+      gatsby-plugin-utils: 4.8.0-next.0_irjlgbbmdc6sbwac5pl62frsae
+      gatsby-telemetry: 4.8.0-next.0
       globby: 11.1.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -20628,8 +20616,8 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby-plugin-typescript/5.7.0-next.0_gatsby@5.7.0-next.0:
-    resolution: {integrity: sha512-r60b1a2SOAZRYmV+rpPCW58QgeutbCHpOeaG7mDBHSNU3nnL2WWjvSmJFpbvwYRsTUhd54k1EXYENB7nX4Sw/w==}
+  /gatsby-plugin-typescript/5.8.0-next.0_gatsby@5.8.0-next.0:
+    resolution: {integrity: sha512-ofnAJ/oR0VctV8QqKxYPhLWJPO1iz0Ek4U4mZb2YkknRTPKLnQdeAbohucst66BuHcY8zlZTTwZ2cUw+UW1dnQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       gatsby: ^5.0.0-next
@@ -20640,14 +20628,14 @@ packages:
       '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       '@babel/runtime': 7.20.13
-      babel-plugin-remove-graphql-queries: 5.7.0-next.0_kwfgdicz63ldiwfqlkadmrpj4y
-      gatsby: 5.7.0-next.0_biqbaboplfbrettd7655fr4n2y
+      babel-plugin-remove-graphql-queries: 5.8.0-next.0_osdpouujtlfd2op5ubueuc4aqi
+      gatsby: 5.8.0-next.0_biqbaboplfbrettd7655fr4n2y
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /gatsby-plugin-utils/4.7.0-next.0_5qnviuipb4fcbildeubwcez6ia:
-    resolution: {integrity: sha512-yWgUlqItsOST/cmqxAYuzZKoLv/lnmztQn5Pk7jtJup/jnISqzq1LVYKS027ZFIRDTp1u0flRwlC3vlhH4kd8Q==}
+  /gatsby-plugin-utils/4.8.0-next.0_irjlgbbmdc6sbwac5pl62frsae:
+    resolution: {integrity: sha512-Uzj8sP0tzpMF1wvgW7uct7LiSzkIl2bUpWhuJ9BS63mtWohYPAJIgc+kmeCS501C/SZtUz+Iipk5DKp9mjOV1Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       gatsby: ^5.0.0-next
@@ -20656,9 +20644,9 @@ packages:
       '@babel/runtime': 7.20.13
       fastq: 1.15.0
       fs-extra: 11.1.0
-      gatsby: 5.7.0-next.0_biqbaboplfbrettd7655fr4n2y
-      gatsby-core-utils: 4.7.0-next.0
-      gatsby-sharp: 1.7.0-next.0
+      gatsby: 5.8.0-next.0_biqbaboplfbrettd7655fr4n2y
+      gatsby-core-utils: 4.8.0-next.0
+      gatsby-sharp: 1.8.0-next.0
       graphql: 16.6.0
       graphql-compose: 9.0.10_graphql@16.6.0
       import-from: 4.0.0
@@ -20666,8 +20654,8 @@ packages:
       mime: 3.0.0
     dev: false
 
-  /gatsby-react-router-scroll/6.7.0-next.0_uxzdzcrcylloub4rxar25ny6ra:
-    resolution: {integrity: sha512-OFKePAMF6n8DseaIIsuuQ4GTadl91m9i1GIj8fUhaInQr4y6fADSvWIR6W+ZxDjKksUm+DNalz+FE8UzGcVDtw==}
+  /gatsby-react-router-scroll/6.8.0-next.0_uxzdzcrcylloub4rxar25ny6ra:
+    resolution: {integrity: sha512-PtQC8tj00Gz6GmR9M7v8n4/ChNlC+RxTUf5c0W3tX0fcrCXYqrK5/D1xBB2qkhNGOrTaVVMRVIkk7SO4L6R6LA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@gatsbyjs/reach-router': ^2.0.0
@@ -20681,8 +20669,8 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /gatsby-script/2.7.0-next.0_uxzdzcrcylloub4rxar25ny6ra:
-    resolution: {integrity: sha512-ycmGRe7exnLXf0iL6+W3pyJn/tjCwcZHLI56eV0siWUiixxZMWLRZ5Ysigk+O3WitFCax083/WbpH3TiT9rfnA==}
+  /gatsby-script/2.8.0-next.0_uxzdzcrcylloub4rxar25ny6ra:
+    resolution: {integrity: sha512-MtHnRnE42Zmfb1+6mNS3ZIoJO8DWrIkVUcYAdqbzE6F9CzrfdkP9K7TXBsOpiI8PC04qyzQgxajwlv9d1qCGSg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@gatsbyjs/reach-router': ^2.0.0
@@ -20694,16 +20682,16 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /gatsby-sharp/1.7.0-next.0:
-    resolution: {integrity: sha512-BzvqeCKt424YChZmb2p4sw1moPeE0SGfzr2IbhM/kkb8Ks3fH+mLy/FUQi/dJ317oa1+AHc8mAjezzxGAFHSsA==}
+  /gatsby-sharp/1.8.0-next.0:
+    resolution: {integrity: sha512-5hW6EqCWxWWWk6Hk3QwCOhr4GcjWtDCriKFBlzcKMKuY/DxBk5Xs/5Q2jrEEetTDhXeX+8y6+TpbRAEdByq/qA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@types/sharp': 0.31.1
       sharp: 0.31.3
     dev: false
 
-  /gatsby-telemetry/4.7.0-next.0:
-    resolution: {integrity: sha512-Gnn6g6cYo4YR7bx9CET0k/2/VwO/AMbVkyO4p4jdxUSuNNY1CCFhH4hTD8oc4ln9KTxnyO1AqoT/ArNzL0G1Xw==}
+  /gatsby-telemetry/4.8.0-next.0:
+    resolution: {integrity: sha512-3YemwxntujXz2XMwp4/mtb6SsOj3avQXDx2bf9KyLGotAbHBybIqm1KWd9c1cpE6iwO6gEa/Mu267IuKDMsPsQ==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
@@ -20714,7 +20702,7 @@ packages:
       boxen: 5.1.2
       configstore: 5.0.1
       fs-extra: 11.1.0
-      gatsby-core-utils: 4.7.0-next.0
+      gatsby-core-utils: 4.8.0-next.0
       git-up: 7.0.0
       is-docker: 2.2.1
       lodash: 4.17.21
@@ -20723,8 +20711,8 @@ packages:
       - encoding
     dev: false
 
-  /gatsby-worker/2.7.0-next.0:
-    resolution: {integrity: sha512-LKGhWzjadmaciZ7KBBebcS+Pi5WrgSRaRiyzogdFHXTRE0WNCGWOrMQVH1nF0ppMEO2vN11GZKb3TZxDu0ho6g==}
+  /gatsby-worker/2.8.0-next.0:
+    resolution: {integrity: sha512-w9Y2Q0IZ/1w480amywbSURA/L+RPFIuaAm5brovju2p7rteFAY9H3ArSJ7cgZUMO5AvUtet/9Biu5pp0HYGc0Q==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@babel/core': 7.20.12
@@ -20735,8 +20723,8 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby/5.7.0-next.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-QBYsyxuct7qhGLkl1jdU0zJS5C5B6wDaxUnReaI9qD+R898cc0KZgGcxhWFzXTk3c6mKGXebW0BBcRBMZ8f3+A==}
+  /gatsby/5.8.0-next.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-9C7q/Nl8lEIyatk1hryDlUw/TVLsKsJoJ+ZR8Z0t0eE2ulRjpFI3vMFuJLnLQFGfdrWtETrnhZha4NJvTo8Pbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     requiresBuild: true
@@ -20782,8 +20770,8 @@ packages:
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
       babel-plugin-lodash: 3.3.4
-      babel-plugin-remove-graphql-queries: 5.7.0-next.0_kwfgdicz63ldiwfqlkadmrpj4y
-      babel-preset-gatsby: 3.7.0-next.0_pp2vm42zn6vfmnpuhar3irht7i
+      babel-plugin-remove-graphql-queries: 5.8.0-next.0_osdpouujtlfd2op5ubueuc4aqi
+      babel-preset-gatsby: 3.8.0-next.0_pp2vm42zn6vfmnpuhar3irht7i
       better-opn: 2.1.1
       bluebird: 3.7.2
       browserslist: 4.21.4
@@ -20824,20 +20812,20 @@ packages:
       find-cache-dir: 3.3.2
       fs-exists-cached: 1.0.0
       fs-extra: 11.1.0
-      gatsby-cli: 5.7.0-next.0
-      gatsby-core-utils: 4.7.0-next.0
-      gatsby-graphiql-explorer: 3.7.0-next.0
-      gatsby-legacy-polyfills: 3.7.0-next.0
-      gatsby-link: 5.7.0-next.0_uxzdzcrcylloub4rxar25ny6ra
-      gatsby-page-utils: 3.7.0-next.0
-      gatsby-parcel-config: 1.7.0-next.0_@parcel+core@2.8.3
-      gatsby-plugin-page-creator: 5.7.0-next.0_5qnviuipb4fcbildeubwcez6ia
-      gatsby-plugin-typescript: 5.7.0-next.0_gatsby@5.7.0-next.0
-      gatsby-plugin-utils: 4.7.0-next.0_5qnviuipb4fcbildeubwcez6ia
-      gatsby-react-router-scroll: 6.7.0-next.0_uxzdzcrcylloub4rxar25ny6ra
-      gatsby-script: 2.7.0-next.0_uxzdzcrcylloub4rxar25ny6ra
-      gatsby-telemetry: 4.7.0-next.0
-      gatsby-worker: 2.7.0-next.0
+      gatsby-cli: 5.8.0-next.0
+      gatsby-core-utils: 4.8.0-next.0
+      gatsby-graphiql-explorer: 3.8.0-next.0
+      gatsby-legacy-polyfills: 3.8.0-next.0
+      gatsby-link: 5.8.0-next.0_uxzdzcrcylloub4rxar25ny6ra
+      gatsby-page-utils: 3.8.0-next.0
+      gatsby-parcel-config: 1.8.0-next.0_@parcel+core@2.8.3
+      gatsby-plugin-page-creator: 5.8.0-next.0_irjlgbbmdc6sbwac5pl62frsae
+      gatsby-plugin-typescript: 5.8.0-next.0_gatsby@5.8.0-next.0
+      gatsby-plugin-utils: 4.8.0-next.0_irjlgbbmdc6sbwac5pl62frsae
+      gatsby-react-router-scroll: 6.8.0-next.0_uxzdzcrcylloub4rxar25ny6ra
+      gatsby-script: 2.8.0-next.0_uxzdzcrcylloub4rxar25ny6ra
+      gatsby-telemetry: 4.8.0-next.0
+      gatsby-worker: 2.8.0-next.0
       glob: 7.2.3
       globby: 11.1.0
       got: 11.8.6
@@ -20911,7 +20899,7 @@ packages:
       xstate: 4.35.4
       yaml-loader: 0.8.0
     optionalDependencies:
-      gatsby-sharp: 1.7.0-next.0
+      gatsby-sharp: 1.8.0-next.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/webpack'
@@ -28164,25 +28152,14 @@ packages:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
 
-  /postcss-convert-values/5.1.2_postcss@8.4.14:
-    resolution: {integrity: sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==}
+  /postcss-convert-values/5.1.3_postcss@8.4.14:
+    resolution: {integrity: sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       browserslist: 4.21.4
       postcss: 8.4.14
-      postcss-value-parser: 4.2.0
-    dev: true
-
-  /postcss-convert-values/5.1.2_postcss@8.4.20:
-    resolution: {integrity: sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      browserslist: 4.21.4
-      postcss: 8.4.20
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -28419,8 +28396,8 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-merge-longhand/5.1.6_postcss@8.4.14:
-    resolution: {integrity: sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==}
+  /postcss-merge-longhand/5.1.7_postcss@8.4.14:
+    resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
@@ -28428,17 +28405,6 @@ packages:
       postcss: 8.4.14
       postcss-value-parser: 4.2.0
       stylehacks: 5.1.1_postcss@8.4.14
-    dev: true
-
-  /postcss-merge-longhand/5.1.6_postcss@8.4.20:
-    resolution: {integrity: sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      postcss: 8.4.20
-      postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1_postcss@8.4.20
     dev: true
 
   /postcss-merge-longhand/5.1.7_postcss@8.4.20:
@@ -28462,8 +28428,8 @@ packages:
       postcss-value-parser: 4.2.0
       stylehacks: 5.1.1_postcss@8.4.21
 
-  /postcss-merge-rules/5.1.2_postcss@8.4.14:
-    resolution: {integrity: sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==}
+  /postcss-merge-rules/5.1.3_postcss@8.4.14:
+    resolution: {integrity: sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
@@ -28472,19 +28438,6 @@ packages:
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0_postcss@8.4.14
       postcss: 8.4.14
-      postcss-selector-parser: 6.0.10
-    dev: true
-
-  /postcss-merge-rules/5.1.2_postcss@8.4.20:
-    resolution: {integrity: sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      browserslist: 4.21.4
-      caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0_postcss@8.4.20
-      postcss: 8.4.20
       postcss-selector-parser: 6.0.10
     dev: true
 
@@ -28577,8 +28530,8 @@ packages:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
 
-  /postcss-minify-params/5.1.3_postcss@8.4.14:
-    resolution: {integrity: sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==}
+  /postcss-minify-params/5.1.4_postcss@8.4.14:
+    resolution: {integrity: sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
@@ -28586,18 +28539,6 @@ packages:
       browserslist: 4.21.4
       cssnano-utils: 3.1.0_postcss@8.4.14
       postcss: 8.4.14
-      postcss-value-parser: 4.2.0
-    dev: true
-
-  /postcss-minify-params/5.1.3_postcss@8.4.20:
-    resolution: {integrity: sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      browserslist: 4.21.4
-      cssnano-utils: 3.1.0_postcss@8.4.20
-      postcss: 8.4.20
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -28881,25 +28822,14 @@ packages:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
 
-  /postcss-normalize-unicode/5.1.0_postcss@8.4.14:
-    resolution: {integrity: sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==}
+  /postcss-normalize-unicode/5.1.1_postcss@8.4.14:
+    resolution: {integrity: sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       browserslist: 4.21.4
       postcss: 8.4.14
-      postcss-value-parser: 4.2.0
-    dev: true
-
-  /postcss-normalize-unicode/5.1.0_postcss@8.4.20:
-    resolution: {integrity: sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      browserslist: 4.21.4
-      postcss: 8.4.20
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -29027,8 +28957,8 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-reduce-initial/5.1.0_postcss@8.4.14:
-    resolution: {integrity: sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==}
+  /postcss-reduce-initial/5.1.1_postcss@8.4.14:
+    resolution: {integrity: sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
@@ -29036,17 +28966,6 @@ packages:
       browserslist: 4.21.4
       caniuse-api: 3.0.0
       postcss: 8.4.14
-    dev: true
-
-  /postcss-reduce-initial/5.1.0_postcss@8.4.20:
-    resolution: {integrity: sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      browserslist: 4.21.4
-      caniuse-api: 3.0.0
-      postcss: 8.4.20
     dev: true
 
   /postcss-reduce-initial/5.1.1_postcss@8.4.20:
@@ -30044,7 +29963,7 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.20.13
       react: 18.2.0
     dev: true
 
@@ -30982,7 +30901,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: true
 


### PR DESCRIPTION
## ☕️ Reasoning

The underlying change in @panva/hkdf is adding a `worker` entry to `package.json#exports`, so it does not fall back to `imports` which points to a node module.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #6736 
