### PR TITLE
fix(providers): add default user agent for GitHub

### DIFF
--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -129,14 +129,14 @@ export default function GitHub(
       url: "https://api.github.com/user",
       async request({ tokens, provider }) {
         const profile = await fetch(provider.userinfo?.url as URL, {
-          headers: { Authorization: `Bearer ${tokens.access_token}`, 'User-Agent': 'undici' },
+          headers: { Authorization: `Bearer ${tokens.access_token}`, 'User-Agent': 'authjs' },
         }).then(async (res) => await res.json())
 
         if (!profile.email) {
           // If the user does not have a public email, get another via the GitHub API
           // See https://docs.github.com/en/rest/users/emails#list-public-email-addresses-for-the-authenticated-user
           const res = await fetch("https://api.github.com/user/emails", {
-            headers: { Authorization: `Bearer ${tokens.access_token}`, 'User-Agent': 'undici' },
+            headers: { Authorization: `Bearer ${tokens.access_token}`, 'User-Agent': 'authjs' },
           })
 
           if (res.ok) {

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -129,14 +129,14 @@ export default function GitHub(
       url: "https://api.github.com/user",
       async request({ tokens, provider }) {
         const profile = await fetch(provider.userinfo?.url as URL, {
-          headers: { Authorization: `Bearer ${tokens.access_token}` },
+          headers: { Authorization: `Bearer ${tokens.access_token}`, 'User-Agent': 'undici' },
         }).then(async (res) => await res.json())
 
         if (!profile.email) {
           // If the user does not have a public email, get another via the GitHub API
           // See https://docs.github.com/en/rest/users/emails#list-public-email-addresses-for-the-authenticated-user
           const res = await fetch("https://api.github.com/user/emails", {
-            headers: { Authorization: `Bearer ${tokens.access_token}` },
+            headers: { Authorization: `Bearer ${tokens.access_token}`, 'User-Agent': 'undici' },
           })
 
           if (res.ok) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
This PR adds user-agent headers for the GitHub provider because certain `fetch()` implementations don't provide a default and GitHub rest apis require it.   This specifically will fix the provider for running the svelte examples on the cloudflare platform.  It should fix it for other platforms with similar `fetch()` implementations.

## 🧢 Checklist

- [ x] Documentation (no doc changes needed)
- [ ] Tests (see test information in the linked [Issue](https://github.com/nextauthjs/next-auth/issues/6741)
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: [Issue](https://github.com/nextauthjs/next-auth/issues/6741)

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
