### PR TITLE
fix broken sudo pipe in hostname example

### DIFF
--- a/docs/docs/providers/apple.md
+++ b/docs/docs/providers/apple.md
@@ -64,7 +64,7 @@ Edit your host file and point your site to `127.0.0.1`.
 _Linux/macOS_
 
 ```
-sudo echo '127.0.0.1 dev.example.com' >> /etc/hosts
+echo '127.0.0.1 dev.example.com' | sudo tee -a /etc/hosts
 ```
 
 _Windows_ (run PowerShell as administrator)


### PR DESCRIPTION
## ☕️ Reasoning

`sudo echo > /etc/hosts` attempts to write to /etc/hosts as a non-priv user, which will fail. `echo | sudo tee /etc/hosts` works.

## 🧢 Checklist

- [X] Documentation
- [NA] Tests
- [X] Ready to be merged

## 🎫 Affected issues

None

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
