### PR TITLE
set next-auth and added @auth/core as optionalPeerDependencies, conve…

### DIFF
--- a/packages/adapter-xata/package.json
+++ b/packages/adapter-xata/package.json
@@ -29,8 +29,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "@xata.io/client": ">=0.13.0",
-    "next-auth": "^4"
+    "@xata.io/client": ">=0.13.0"
+  },
+  "optionalPeerDependencies": {
+    "next-auth": "^4",
+		"@auth/core": "^0.4.0"
+
   },
   "devDependencies": {
     "@next-auth/adapter-test": "workspace:^0.0.0",

--- a/packages/adapter-xata/src/index.ts
+++ b/packages/adapter-xata/src/index.ts
@@ -1,4 +1,15 @@
-import type { Adapter } from "next-auth/adapters"
+/**
+ * @todo - Temporary workaround for unnecessary dependency
+ * of @auth/core or next-auth
+ */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-ignore - @auth/core/adapters dynamic import
+import type { Adapter as CoreAdapter } from '@auth/core/adapters';
+// @ts-ignore - next-auth/adapters dynamic import
+import type { Adapter as NextAuthAdapter } from 'next-auth/adapters';
+
+export interface Adapter extends CoreAdapter, NextAuthAdapter {}
 
 import type { XataClient } from "./xata"
 


### PR DESCRIPTION
…rted type Adapter import to "dynamic"


## ☕️ Reasoning
**Next-auth** is an optional dependency for projects using [**Authjs**](https://authjs.dev/).
the Xata adapter works with @auth-core too, so added both as `optionalPeerDependencies`

check https://github.com/nextauthjs/next-auth/issues/6772#issuecomment-1439337337 by @balazsorban44 and https://github.com/nextauthjs/next-auth/issues/6772#issuecomment-1440311502


## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Fixes: #6772

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
