### PR TITLE
docs: fix typo on 'nextjs#getserversession' page

### DIFF
--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -6,7 +6,7 @@ This method was renamed to `getServerSession`. See the documentation below.
 
 ## `getServerSession`
 
-When calling from server-side i.e. in API routes or in `getServerSideProps`, we recommend using this function instead of `getSession` to retrieve the `session` object. This method is especially useful when you are using NextAuth.js with a database. This method can _drastically_ reduce response time when used over `getSession` server-side, due to avoiding an extra `fetch` to an API Route (this is generally [not recommended in Next.js](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props#getserversideprops-or-api-routes)). In addition, `getServerSession` will correctly update the cookie expiry time and update the session content if `callbacks.jwt` or `callbacks.session` changed something.
+When calling from server-side i.e. in API routes or in `getServerSideProps`, we recommend using this function instead of `getSession` to retrieve the `session` object. This method is especially useful when you are using NextAuth.js with a database. This method can _drastically_ reduce response time when used over `getSession` on server-side, due to avoiding an extra `fetch` to an API Route (this is generally [not recommended in Next.js](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props#getserversideprops-or-api-routes)). In addition, `getServerSession` will correctly update the cookie expiry time and update the session content if `callbacks.jwt` or `callbacks.session` changed something.
 
 Otherwise, if you only want to get the session token, see [`getToken`](/tutorials/securing-pages-and-api-routes#using-gettoken).
 


### PR DESCRIPTION
Completed sentence with missing imperative preposition '**on**'.

I believe the sentence is states that `getServerSession` reduces response time when used over `getSession` on the server-side (API route or `getServerSideProps`), hence the correction.

Thanks in anticipation of a merge.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
