### PR TITLE
fix: set isNewUser to false when oauth login and account linking is e…

### DIFF
--- a/packages/core/src/lib/callback-handler.ts
+++ b/packages/core/src/lib/callback-handler.ts
@@ -223,7 +223,7 @@ export async function handleLogin(
             expires: fromDate(options.session.maxAge),
           })
 
-      return { session, user, isNewUser: isNewUser }
+      return { session, user, isNewUser }
     }
   }
 

--- a/packages/core/src/lib/callback-handler.ts
+++ b/packages/core/src/lib/callback-handler.ts
@@ -185,6 +185,7 @@ export async function handleLogin(
           // If you trust the oauth provider to correctly verify email addresses, you can opt-in to
           // account linking even when the user is not signed-in.
           user = userByEmail
+          isNewUser = false
         } else {
           // We end up here when we don't have an account with the same [provider].id *BUT*
           // we do already have an account with the same email address as the one in the
@@ -207,6 +208,7 @@ export async function handleLogin(
         // create a new session for them so they are signed in with it.
         const { id: _, ...newUser } = { ...profile, emailVerified: null }
         user = await createUser(newUser)
+        isNewUser = true
       }
       await events.createUser?.({ user })
 
@@ -221,7 +223,7 @@ export async function handleLogin(
             expires: fromDate(options.session.maxAge),
           })
 
-      return { session, user, isNewUser: true }
+      return { session, user, isNewUser: isNewUser }
     }
   }
 


### PR DESCRIPTION
…nabled for and already existing user

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

This pull request is to make sure that isNewUser is set to false when a user has already been created (i.e. via email) and the user logs in again via oauth. Right now even though the user has already been created beforehand, the isNewUser flag is always set to true at the end of the file. This pull request addresses this.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
