### PR TITLE
docs: Authentik trailing slash information.

### DIFF
--- a/docs/docs/providers/authentik.md
+++ b/docs/docs/providers/authentik.md
@@ -31,5 +31,5 @@ providers: [
 ```
 
 :::note
-`issuer` has been known to sometimes require a trailing slash (e.g., `https://my-authentik-domain.com/application/o/my_slug/`) and others time require no trailing slash (e.g. `https://my-authentik-domain.com/application/o/my_slug`).
+`issuer` requires a trailing slash (e.g. `https://my-authentik-domain.com/application/o/my_slug/`).
 :::

--- a/docs/docs/providers/authentik.md
+++ b/docs/docs/providers/authentik.md
@@ -31,5 +31,5 @@ providers: [
 ```
 
 :::note
-`issuer` should include the slug without a trailing slash – e.g., `https://my-authentik-domain.com/application/o/My_Slug`
+`issuer` has been known to sometimes require a trailing slash (e.g., `https://my-authentik-domain.com/application/o/my_slug/`) and others time require no trailing slash (e.g. `https://my-authentik-domain.com/application/o/my_slug`).
 :::


### PR DESCRIPTION
Mention that trailing slashes in `issuer` may or may not be required.


## ☕️ Reasoning

From https://github.com/nextauthjs/next-auth/pull/4646, we saw that the author mentions that the Authentik Provider appends a trailing slash to `issuer`. While no proof of this has been found at this time (An up-to-date installation of authentik tested with a solid-start application requires a trailing slash), the author's findings may still have some merit. To this end, the documentation now states that the trailing slash may or may not be required.

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged


