### PR TITLE
Simplify authorization example for sveltekit

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -165,8 +165,7 @@
  * 	}
  *
  * 	// If the request is still here, just proceed as normally
- * 	const response = await resolve(event);
- * 	return response;
+ * 	return resolve(event);
  * }
  *
  * // First handle authentication, then authorization

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -165,10 +165,8 @@
  * 	}
  *
  * 	// If the request is still here, just proceed as normally
- * 	const result = await resolve(event, {
- * 		transformPageChunk: ({ html }) => html
- * 	});
- * 	return result;
+ * 	const response = await resolve(event);
+ * 	return response;
  * }
  *
  * // First handle authentication, then authorization


### PR DESCRIPTION
## ☕️ Reasoning

I was reading through the svelte-kit docs and didn't understand why the `transformPaheChunk` option was provided to the `resolve` function, then I realized that it's most likely not needed (if it is please tell me what it does, cause I don't understand 😅), so I deleted it in the hope that the next person reading it won't start wondering why that's needed.

I also renamded `result` to `response` as that seems to be more in-line with sveltekit doc conventions (https://kit.svelte.dev/docs/hooks#server-hooks-handle)

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #6911 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
