### PR TITLE
chore(ci): disable node cache to speed up ci

### DIFF
--- a/.github/workflows/issue-validator.yml
+++ b/.github/workflows/issue-validator.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: "Run issue validator"
+      - name: Run issue validator
         run: node /home/runner/work/next-auth/next-auth/.github/actions/issue-validator/index.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Release
 on:
   push:
     branches:
-      - "main"
-      - "beta"
-      - "next"
-      - "3.x"
+      - main
+      - beta
+      - next
+      - 3.x
   pull_request:
 
 jobs:
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
       - name: Run tests
@@ -74,7 +73,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
       - name: Publish to npm and GitHub
@@ -99,7 +97,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
       - name: Determine version


### PR DESCRIPTION
## ☕️ Reasoning

in my experience restoring and storing cache costs so much time, that the (tiny if even) gain during install is gone. this tries to prove that for next-auth.

[before](https://github.com/nextauthjs/next-auth/actions/runs/4409775149/jobs/7726475689): 

install: 1m 16s
post-setup: 1m 44s

[after](https://github.com/nextauthjs/next-auth/actions/runs/4409880568/jobs/7726722542):

install: 1m 11s
post-setup: 0s

... also yamllint complaint about redundant string indicators.

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
