### PR TITLE
docs: Fix TSX to address warnings

### DIFF
--- a/docs/docs/configuration/pages.md
+++ b/docs/docs/configuration/pages.md
@@ -88,7 +88,7 @@ export default function SignIn({ providers }: InferGetServerSidePropsType<typeof
     <>
       {Object.values(providers).map((provider) => (
         <div key={provider.name}>
-          <button onClick={() => signIn(provider.id)}>
+          <button onClick={() => void signIn(provider.id)}>
             Sign in with {provider.name}
           </button>
         </div>


### PR DESCRIPTION
Add `void` keyword to address ESLint warning:

```
Promise-returning function provided to attribute where a void return was expected.eslint@typescript-eslint/no-misused-promises
```

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

Users (like me) come to NextAuth from the T3 starter example. Copying and pasting their code leads to this link error.
## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: N/A

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
