### PR TITLE
Prevent Stalled Request Warning

### DIFF
--- a/docs/docs/tutorials/avoid-corporate-link-checking-email-provider.md
+++ b/docs/docs/tutorials/avoid-corporate-link-checking-email-provider.md
@@ -30,7 +30,7 @@ import NextAuth from "next-auth"
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
 
   if(req.method === "HEAD") {
-     return res.status(200)
+     return res.status(200).end()
   }
 
   ...


### PR DESCRIPTION
## ☕️ Reasoning

This [article ](https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider) talks about how to deal with **HEAD** requests that consume the `email provider` authentication link.
The demo code is missing a call to `end()` which results in a `stalled request` warning in the console.

<img width="667" alt="stalled" src="https://user-images.githubusercontent.com/26460692/225477214-14095560-2cf7-4952-ac1b-43b802284c46.png">

![image](https://user-images.githubusercontent.com/26460692/225477639-61d738db-7be5-4439-a64e-1987164b92f0.png)


## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
