### PR TITLE
docs: show close button

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -101,6 +101,11 @@ html[data-theme="dark"] hr {
   border-color: #242526;
 }
 
+/* Docusaurus announcementBar close button */
+.close {
+  color: inherit;
+}
+
 .home-main .code {
   padding: 0;
   height: 100%;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Docusaurus lacking a feature to set announcementBar close button color in their config file. For now color of close button comes directly from `infima` which Docusaurus relies on. At least changing it to inherit text color of announcementBar would be a good idea. Ideally, should be possible with config, but they don't have this feature yet. 

I changed the global styles file so that it inherits text color of annoucementBar which is set here 
https://github.com/nextauthjs/next-auth/blob/80c1f375b86d40d3650e4d3120a9aaddd869f230/docs/docusaurus.config.js#L129 
this should do the job for most of the time. Also I am going to go open an issue and a PR in Docusaurus to add option to set color of close button directly from config file.
## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues 
#6935 

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #6935 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
