### PR TITLE
fix(OAuth): fix callback url when redirect_uri is customized

### DIFF
--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -102,6 +102,8 @@ export default async function oAuthCallback(params: {
       ...provider.token?.params,
     }
 
+    const callbackUrl =
+      provider?.authorization?.params?.redirect_uri || provider.callbackUrl
     if (provider.token?.request) {
       const response = await provider.token.request({
         provider,
@@ -111,9 +113,9 @@ export default async function oAuthCallback(params: {
       })
       tokens = new TokenSet(response.tokens)
     } else if (provider.idToken) {
-      tokens = await client.callback(provider.callbackUrl, params, checks)
+      tokens = await client.callback(callbackUrl, params, checks)
     } else {
-      tokens = await client.oauthCallback(provider.callbackUrl, params, checks)
+      tokens = await client.oauthCallback(callbackUrl, params, checks)
     }
 
     // REVIEW: How can scope be returned as an array?


### PR DESCRIPTION
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

When customizing the redirect_uri in OAuth providers, next-auth will keep using the default `callbackUrl` for the OAuth callback. Due to this, a `redirect_uri_mismatch` will be thrown as the provider expects the redirect URI to be used.

This PR updates the callback function to use the custom provider `redirect_uri` if set and falls back to the regular `provider.callbackUrl` otherwise.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/5733

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
