### PR TITLE
fix Vk provider tokens causing issues with database providers

### DIFF
--- a/packages/core/src/providers/vk.ts
+++ b/packages/core/src/providers/vk.ts
@@ -294,7 +294,25 @@ export default function VK<P extends Record<string, any> = VkProfile>(
     client: {
       token_endpoint_auth_method: "client_secret_post",
     },
-    token: `https://oauth.vk.com/access_token?v=${apiVersion}`,
+    token: {
+      url: `https://oauth.vk.com/access_token?v=${apiVersion}`,
+
+      async request({ client, params, checks, provider }) {
+        const response = await client.oauthCallback(
+          provider.callbackUrl,
+          params,
+          checks,
+          { exchangeBody: { client_id: options.clientId } }
+        )
+
+        return {
+          tokens: {
+            access_token: response.access_token,
+            expires_at: response.expires_at
+          }
+        }
+      },
+    },
     userinfo: `https://api.vk.com/method/users.get?fields=photo_100&v=${apiVersion}`,
     profile(result: P) {
       const profile = result.response?.[0] ?? {}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning
Currently the Vk provider returns extra unnecessary data along with the tokens (more exactly vk's internal `user_id` and `email`) which renders it unusable in some cases because the data can't be stored in a database (due to the previously mentioned properties missing in the schema).
<!-- What changes are being made? What feature/bug is being fixed here? -->

This change makes sure only the required `access_token` and `expires_at` properties are returned.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: https://github.com/nextauthjs/next-auth/pull/3709

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
