### PR TITLE
fix(docs): remove extra install

### DIFF
--- a/packages/adapter-sequelize/src/index.ts
+++ b/packages/adapter-sequelize/src/index.ts
@@ -9,7 +9,7 @@
  * ## Installation
  *
  * ```bash npm2yarn2pnpm
- * npm install install next-auth @next-auth/sequelize-adapter sequelize
+ * npm install next-auth @next-auth/sequelize-adapter sequelize
  * ```
  *
  * @module @next-auth/sequelize-adapter


### PR DESCRIPTION
## ☕️ Reasoning

Remove extra `install` on npm instructions for the sequelize-adapter https://authjs.dev/reference/adapter/sequelize

## 🧢 Checklist

- [x] Documentation
- [x] Ready to be merged