### PR TITLE
Update securing-pages-and-api-routes.md

### DIFF
--- a/docs/docs/tutorials/securing-pages-and-api-routes.md
+++ b/docs/docs/tutorials/securing-pages-and-api-routes.md
@@ -73,14 +73,34 @@ You can protect server side rendered pages using the `getServerSession` method. 
 You need to add this to every server rendered page you want to protect. Be aware, `getServerSession` takes slightly different arguments than the method it is replacing, `getSession`.
 
 ```js title="pages/server-side-example.js"
-import { getServerSession } from "next-auth/next"
-import { authOptions } from "./api/auth/[...nextauth]"
-import { useSession } from "next-auth/react"
 
-export default function Page() {
-  const { data: session } = useSession()
+import { useSession } from 'next-auth/react'
+import { GetServerSideProps } from 'next'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../api/auth/[...nextauth]'
+import { useEffect, useState } from 'react'
 
-  if (typeof window === "undefined") return null
+export const getServerSideProps: GetServerSideProps = async function (context) {
+    return {
+      props: {
+        session: await getServerSession(
+          context.req,
+          context.res,
+          authOptions
+        )
+      }
+    }
+}
+
+export default function Abc() {
+  const [hasMounted, setHasMounted] = useState(false)
+  const {data: session} = useSession()
+
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
+  if(!hasMounted) return null
 
   if (session) {
     return (
@@ -93,17 +113,6 @@ export default function Page() {
   return <p>Access Denied</p>
 }
 
-export async function getServerSideProps(context) {
-  return {
-    props: {
-      session: await getServerSession(
-        context.req,
-        context.res,
-        authOptions
-      ),
-    },
-  }
-}
 ```
 
 :::tip


### PR DESCRIPTION
### The problem

The example for protecting page on server-side causes hydration error.

The use of the line: if (typeof window === "undefined") return null will cause hydration error because the generate page from the server will not match the ones generate in the client. That is, the one's generated in the server will be null, while in the client it will be the "<p> access denied </p>. Since the scripts sent in the client is to perform hydration (which expects that the page structure is the same) instead of render, it will raise error.

This may cause unexpected behavior.

### Solution
Use a state so that the page structure from the server will be the same in the client, instead of relying on the window object's existence.

Reference:
https://www.joshwcomeau.com/react/the-perils-of-rehydration/

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
