### PR TITLE
Changes 42 School Provider image_url to image

### DIFF
--- a/packages/core/src/providers/42-school.ts
+++ b/packages/core/src/providers/42-school.ts
@@ -1,5 +1,15 @@
 import type { OAuthConfig, OAuthUserConfig } from "./index.js"
 
+export interface UserImage {
+  link: string | null
+  versions: {
+    large: string | null
+    medium: string | null
+    small: string | null
+    micro: string | null
+  }
+}
+
 export interface UserData {
   id: number
   email: string
@@ -11,7 +21,7 @@ export interface UserData {
   url: string
   phone: "hidden" | string | null
   displayname: string
-  image_url: string | null
+  image: UserImage
   "staff?": boolean
   correction_point: number
   pool_month: string | null
@@ -170,7 +180,7 @@ export default function FortyTwo<P extends FortyTwoProfile>(
         id: profile.id.toString(),
         name: profile.usual_full_name,
         email: profile.email,
-        image: profile.image_url,
+        image: profile.image?.link,
       }
     },
     options,

--- a/packages/next-auth/src/providers/42-school.ts
+++ b/packages/next-auth/src/providers/42-school.ts
@@ -1,5 +1,15 @@
 import type { OAuthConfig, OAuthUserConfig } from "."
 
+export interface UserImage {
+  link: string | null
+  versions: {
+    large: string | null
+    medium: string | null
+    small: string | null
+    micro: string | null
+  }
+}
+
 export interface UserData {
   id: number
   email: string
@@ -11,7 +21,7 @@ export interface UserData {
   url: string
   phone: "hidden" | string | null
   displayname: string
-  image_url: string | null
+  image: UserImage
   "staff?": boolean
   correction_point: number
   pool_month: string | null
@@ -170,7 +180,7 @@ export default function FortyTwo<P extends FortyTwoProfile>(
         id: profile.id.toString(),
         name: profile.usual_full_name,
         email: profile.email,
-        image: profile.image_url,
+        image: profile.image?.link,
       }
     },
     options,


### PR DESCRIPTION
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
The 42 School api has deprecated the `image_url` field in favor of the field `image`.

The `image` field is an object with an image link and size variants:

```typescript
export interface UserImage {
  link: string | null
  versions: {
    large: string | null
    medium: string | null
    small: string | null
    micro: string | null
  }
}
```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

None