### PR TITLE
Added `signinInfo` when signing in

### DIFF
--- a/apps/playgrounds/nuxt/lib/auth/client.ts
+++ b/apps/playgrounds/nuxt/lib/auth/client.ts
@@ -27,7 +27,7 @@ export async function signIn<
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ) {
-  const { callbackUrl = window.location.href, redirect = true } = options ?? {}
+  const { callbackUrl = window.location.href, redirect = true, signinInfo } = options ?? {}
 
   // TODO: Support custom providers
   const isCredentials = providerId === "credentials"
@@ -58,6 +58,7 @@ export async function signIn<
       ...options,
       csrfToken,
       callbackUrl,
+      signinInfo: signinInfo === undefined ? undefined : encodeURIComponent(signinInfo)
     }),
   })
 

--- a/apps/playgrounds/nuxt/lib/auth/types.ts
+++ b/apps/playgrounds/nuxt/lib/auth/types.ts
@@ -23,6 +23,10 @@ export interface SignInOptions extends Record<string, unknown> {
   callbackUrl?: string
   /** [Documentation](https://next-auth.js.org/getting-started/client#using-the-redirect-false-option) */
   redirect?: boolean
+  /**
+   * Information that will be passed to the `signIn` callback, the `createUser` adapter function, and the `createUser` event.
+   */
+  signinInfo?: string
 }
 export interface SignInResponse {
   error: string | undefined

--- a/docs/docs/getting-started/upgrade-to-v4.md
+++ b/docs/docs/getting-started/upgrade-to-v4.md
@@ -140,7 +140,7 @@ The signatures for the callback methods now look like this:
 
 ```diff
 - signIn(user, account, profileOrEmailOrCredentials)
-+ signIn({ user, account, profile, email, credentials })
++ signIn({ user, account, profile, email, credentials, signinInfo })
 ```
 
 ```diff

--- a/docs/docs/guides/basics/callbacks.md
+++ b/docs/docs/guides/basics/callbacks.md
@@ -12,9 +12,9 @@ If you want to pass data such as an Access Token or User ID to the browser when 
 
 You can specify a handler for any of the callbacks below.
 
-```js title="pages/api/auth/[...nextauth].js"s
+```js title="pages/api/auth/[...nextauth].js"
   callbacks: {
-    async signIn({ user, account, profile, email, credentials }) {
+    async signIn({ user, account, profile, email, credentials, signinInfo }) {
       return true
     },
     async redirect({ url, baseUrl }) {
@@ -37,7 +37,7 @@ Use the `signIn()` callback to control if a user is allowed to sign in.
 
 ```js title="pages/api/auth/[...nextauth].js"
 callbacks: {
-  async signIn({ user, account, profile, email, credentials }) {
+  async signIn({ user, account, profile, email, credentials, signinInfo }) {
     const isAllowedToSignIn = true
     if (isAllowedToSignIn) {
       return true

--- a/docs/docs/guides/basics/events.md
+++ b/docs/docs/guides/basics/events.md
@@ -36,7 +36,7 @@ The message object will contain one of these depending on if you use JWT or data
 
 Sent when the adapter is told to create a new user.
 
-The message object will contain the user.
+The message object will contain the user and `signinInfo`.
 
 ### updateUser
 

--- a/docs/docs/reference/nextjs/client.md
+++ b/docs/docs/reference/nextjs/client.md
@@ -5,3 +5,14 @@ title: Client
 :::warning WIP
 `@auth/nextjs/client` is work in progress. For now, please use [NextAuth.js Client API](https://next-auth.js.org/getting-started/client).
 :::
+
+### Using the `signinInfo` option
+
+A string may be passed to the `signinInfo` parameter of the client's `signIn()` method. That string will be available in the `signIn` callback, the `createUser` adapter function, and the `createUser` event. This may be helpful in determining if a user can login (e.g. users must enter an invitation code or beta key) or in creating a user (e.g. the primary key is a user-supplied "DisplayName" - you'll likely need to write your own adapter).
+
+`signinInfo` must be a string. You are in charge of de/serialization.
+
+Example usage:
+
+- `signIn("google", { signinInfo: "Bill Johnson" })`
+

--- a/docs/docs/reference/solidstart/client.md
+++ b/docs/docs/reference/solidstart/client.md
@@ -10,6 +10,16 @@ signIn()
 signIn("provider") // example: signIn("github")
 ```
 
+### Using the `signinInfo` option
+
+A string may be passed to the `signinInfo` parameter of the client's `signIn()` method. That string will be available in the `signIn` callback, the `createUser` adapter function, and the `createUser` event. This may be helpful in determining if a user can login (e.g. users must enter an invitation code or beta key) or in creating a user (e.g. the primary key is a user-supplied "DisplayName" - you'll likely need to write your own adapter).
+
+`signinInfo` must be a string. You are in charge of de/serialization.
+
+Example usage:
+
+- `signIn("google", { signinInfo: "Bill Johnson" })`
+
 ## Signing out
 
 ```ts

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -116,7 +116,7 @@
  */
 
 import { ProviderType } from "./providers/index.js"
-import type { Account, Awaitable, User } from "./types.js"
+import type { Account, Awaitable, SigninInfo, User } from "./types.js"
 // TODO: Discuss if we should expose methods to serialize and deserialize
 // the data? Many adapters share this logic, so it could be useful to
 // have a common implementation.
@@ -216,7 +216,7 @@ export interface VerificationToken {
  * :::
  */
 export interface Adapter {
-  createUser?(user: Omit<AdapterUser, "id">): Awaitable<AdapterUser>
+  createUser?(user: Omit<AdapterUser, "id">, info?: { signinInfo?: SigninInfo }): Awaitable<AdapterUser>
   getUser?(id: string): Awaitable<AdapterUser | null>
   getUserByEmail?(email: string): Awaitable<AdapterUser | null>
   /** Using the provider id and the id of the user for a specific account, get the user. */

--- a/packages/core/src/lib/cookie.ts
+++ b/packages/core/src/lib/cookie.ts
@@ -103,6 +103,15 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
         maxAge: 60 * 15, // 15 minutes in seconds
       },
     },
+    signinInfo: {
+      name: `${cookiePrefix}next-auth.signin-info`,
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: useSecureCookies,
+      },
+    },
     nonce: {
       name: `${cookiePrefix}next-auth.nonce`,
       options: {

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -11,6 +11,8 @@ import type {
   ResponseInternal,
 } from "../types.js"
 
+const SIGNIN_INFO_MAX_AGE = 60 * 15 // 15 minutes in seconds
+
 /** @internal */
 export async function AuthInternal<
   Body extends string | Record<string, any> | any[]
@@ -139,6 +141,18 @@ export async function AuthInternal<
   } else {
     switch (action) {
       case "signin":
+        if (request.body?.signinInfo !== undefined) {
+          const expires = new Date()
+          expires.setTime(expires.getTime() + SIGNIN_INFO_MAX_AGE * 1000)
+          cookies.push({
+            name: options.cookies.signinInfo.name,
+            value: request.body.signinInfo,
+            options: {
+              ...options.cookies.signinInfo.options,
+              expires,
+            },
+          })
+        }
         if ((csrfDisabled || options.csrfTokenVerified) && options.provider) {
           const signin = await routes.signin(
             request.query,

--- a/packages/core/src/lib/routes/shared.ts
+++ b/packages/core/src/lib/routes/shared.ts
@@ -2,7 +2,7 @@ import { AuthorizedCallbackError } from "../../errors.js"
 import { InternalOptions } from "../../types.js"
 
 export async function handleAuthorized(
-  params: any,
+  params: Parameters<InternalOptions["callbacks"]["signIn"]>[0],
   { url, logger, callbacks: { signIn } }: InternalOptions
 ) {
   try {

--- a/packages/core/src/lib/routes/signin.ts
+++ b/packages/core/src/lib/routes/signin.ts
@@ -41,8 +41,9 @@ export async function signin(
         provider: provider.id,
       }
 
+      const signinInfo = body?.signinInfo === undefined ? undefined : decodeURIComponent(body.signinInfo)
       const unauthorizedOrError = await handleAuthorized(
-        { user, account, email: { verificationRequest: true } },
+        { user, account, email: { verificationRequest: true }, signinInfo },
         options
       )
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -163,6 +163,8 @@ export interface CallbacksOptions<P = Profile, A = Account> {
     }
     /** If Credentials provider is used, it contains the user credentials */
     credentials?: Record<string, CredentialInput>
+    /** Info from the client's `signIn()` function. */
+    signinInfo?: SigninInfo
   }) => Awaitable<boolean>
   /**
    * This callback is called anytime the user is redirected to a callback URL (e.g. on signin or signout).
@@ -237,8 +239,11 @@ export interface CookiesOptions {
   csrfToken: CookieOption
   pkceCodeVerifier: CookieOption
   state: CookieOption
+  signinInfo: CookieOption
   nonce: CookieOption
 }
+
+export type SigninInfo = string
 
 /**
  *  The various event callbacks you can register for from next-auth
@@ -269,7 +274,7 @@ export interface EventCallbacks {
       | { session: Awaited<ReturnType<Required<Adapter>["deleteSession"]>> }
       | { token: Awaited<ReturnType<JWTOptions["decode"]>> }
   ) => Awaitable<void>
-  createUser: (message: { user: User }) => Awaitable<void>
+  createUser: (message: { user: User, signinInfo?: SigninInfo }) => Awaitable<void>
   updateUser: (message: { user: User }) => Awaitable<void>
   linkAccount: (message: {
     user: User | AdapterUser

--- a/packages/frameworks-solid-start/src/client.ts
+++ b/packages/frameworks-solid-start/src/client.ts
@@ -27,7 +27,7 @@ export async function signIn<
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ) {
-  const { callbackUrl = window.location.href, redirect = true } = options ?? {}
+  const { callbackUrl = window.location.href, redirect = true, signinInfo } = options ?? {}
 
   // TODO: Support custom providers
   const isCredentials = providerId === "credentials"
@@ -56,6 +56,7 @@ export async function signIn<
       ...options,
       csrfToken,
       callbackUrl,
+      signinInfo: signinInfo === undefined ? undefined : encodeURIComponent(signinInfo)
     }),
   })
 

--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -27,7 +27,7 @@ export async function signIn<
   options?: SignInOptions,
   authorizationParams?: SignInAuthorizationParams
 ) {
-  const { callbackUrl = window.location.href, redirect = true } = options ?? {}
+  const { callbackUrl = window.location.href, redirect = true, signinInfo } = options ?? {}
 
   // TODO: Support custom providers
   const isCredentials = providerId === "credentials"
@@ -57,6 +57,7 @@ export async function signIn<
       ...options,
       csrfToken,
       callbackUrl,
+      signinInfo: signinInfo === undefined ? undefined : encodeURIComponent(signinInfo)
     }),
   })
 

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -210,7 +210,7 @@ export async function signIn<
 ): Promise<
   P extends RedirectableProviderType ? SignInResponse | undefined : undefined
 > {
-  const { callbackUrl = window.location.href, redirect = true } = options ?? {}
+  const { callbackUrl = window.location.href, redirect = true, signinInfo } = options ?? {}
 
   const baseUrl = apiBaseUrl(__NEXTAUTH)
   const providers = await getProviders()
@@ -248,6 +248,7 @@ export async function signIn<
       ...options,
       csrfToken: await getCsrfToken(),
       callbackUrl,
+      signinInfo: signinInfo === undefined ? undefined : encodeURIComponent(signinInfo)
     }),
   })
 

--- a/packages/next-auth/src/react/types.ts
+++ b/packages/next-auth/src/react/types.ts
@@ -32,6 +32,10 @@ export interface SignInOptions extends Record<string, unknown> {
   callbackUrl?: string
   /** [Documentation](https://next-auth.js.org/getting-started/client#using-the-redirect-false-option) */
   redirect?: boolean
+  /**
+   * Information that will be passed to the `signIn` callback, the `createUser` adapter function, and the `createUser` event.
+   */
+  signinInfo?: string
 }
 
 export interface SignInResponse {


### PR DESCRIPTION
## ☕️ Reasoning

Since [this PR](https://github.com/nextauthjs/next-auth/pull/4747) seems abandoned, I took the initiative of moving it to `packages/core` as suggested by Thang.

I made some changes to the naming and semantics. Instead of being specific to new users, the name `signinInfo` refers to info passed in during the signin process. After all, without an adapter, isn't _every_ user "new"?

## 🧢 Checklist

- [x] Documentation
- [ ] Tests (Not sure how to test, tbh...)
- [x] Ready to be merged

## 🎫 Affected issues

Supersedes https://github.com/nextauthjs/next-auth/pull/4747
Fixes https://github.com/nextauthjs/next-auth/issues/1069