### PR TITLE
fix: profile email to lower case only as a string

### DIFF
--- a/.github/version-pr/index.js
+++ b/.github/version-pr/index.js
@@ -10,9 +10,10 @@ try {
   const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, "utf8"))
 
   const sha8 = process.env.GITHUB_SHA.substring(0, 8)
-  const prNumber = process.env.PR_NUMBER || "manual"
-
-  const packageVersion = `0.0.0-pr.${prNumber}.${sha8}`
+  const prefix = "0.0.0-"
+  const pr = process.env.PR_NUMBER
+  const source = pr ? `pr.${pr}` : "manual"
+  const packageVersion = `${prefix}${source}.${sha8}`
   packageJSON.version = packageVersion
   core.setOutput("version", packageVersion)
   fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON))

--- a/.github/version-pr/index.js
+++ b/.github/version-pr/index.js
@@ -5,12 +5,12 @@ const core = require("@actions/core")
 try {
   const packageJSONPath = path.join(
     process.cwd(),
-    "packages/next-auth/package.json"
+    `packages/${process.env.PACKAGE_PATH || "next-auth"}/package.json`
   )
   const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, "utf8"))
 
   const sha8 = process.env.GITHUB_SHA.substring(0, 8)
-  const prNumber = process.env.PR_NUMBER
+  const prNumber = process.env.PR_NUMBER || "manual"
 
   const packageVersion = `0.0.0-pr.${prNumber}.${sha8}`
   packageJSON.version = packageVersion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,7 @@ jobs:
         run: |
           cd packages/$PACKAGE_PATH
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+          pnpm build
           pnpm publish --no-git-checks --access public --tag experimental
           echo "🎉 Experimental release published 📦️ on npm: https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }}"
           echo "Install via: pnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
     name: Publish PR
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' }}
     environment: Preview
     steps:
       - name: Init
@@ -121,25 +121,55 @@ jobs:
         uses: ./.github/version-pr
         id: determine-version
         env:
-          PACKAGE_PATH: ${{ github.event.inputs.path }}
           PR_NUMBER: ${{ github.event.number }}
       - name: Publish to npm
         run: |
-          cd $PACKAGE_PATH
+          cd packages/core
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
           pnpm publish --no-git-checks --access public --tag experimental
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          PACKAGE_PATH: ${{ github.event.inputs.path }}
       - name: Comment version on PR
-        if: ${{ github.event_name == 'pull_request'}}
         uses: NejcZdovc/comment-pr@v2
         with:
           message:
-            "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }})!\n \
-            ```sh\npnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}\n```\n \
-            ```sh\nyarn add ${{ github.event.inputs.name }}@${{ env.VERSION }}\n```\n \
-            ```sh\nnpm i ${{ github.event.inputs.name }}@${{ env.VERSION }}\n```"
+            "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/@auth/core/v/${{ env.VERSION }})!\n \
+            ```sh\npnpm add @auth/core@${{ env.VERSION }}\n```\n \
+            ```sh\nyarn add @auth/core@${{ env.VERSION }}\n```\n \
+            ```sh\nnpm i @auth/core@${{ env.VERSION }}\n```"
         env:
           VERSION: ${{ steps.determine-version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+  release-manual:
+    name: Publish manually
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Init
+        uses: actions/checkout@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.4
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: pnpm install
+      - name: Determine version
+        uses: ./.github/version-pr
+        id: determine-version
+        env:
+          PACKAGE_PATH: ${{ github.event.inputs.path }}
+      - name: Publish to npm
+        run: |
+          cd packages/$PACKAGE_PATH
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+          pnpm publish --no-git-checks --access public --tag experimental
+          echo "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }})!"
+          echo "pnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}"
+        
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_PATH: ${{ github.event.inputs.path }}
+          VERSION: ${{ steps.determine-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,9 @@ jobs:
           PACKAGE_PATH: ${{ github.event.inputs.path }}
       - name: Publish to npm
         run: |
+          pnpm build
           cd packages/$PACKAGE_PATH
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-          pnpm build
           pnpm publish --no-git-checks --access public --tag experimental
           echo "🎉 Experimental release published 📦️ on npm: https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }}"
           echo "Install via: pnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,6 @@ jobs:
   release-manual:
     name: Publish manually
     runs-on: ubuntu-latest
-    needs: test
     if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Init

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,24 @@ on:
       - next
       - 3.x
   pull_request:
+  # TODO: Support latest releases
+  workflow_dispatch:
+    inputs:
+      name: 
+        type: choice
+        description: Package name (npm)
+        options:
+        - "@auth/nextjs"
+        - "@auth/core"
+        - "next-auth"
+      # TODO: Infer from package name
+      path:
+        type: choice
+        description: Directory name (packages/*)
+        options:
+        - "frameworks-nextjs"
+        - "core"
+        - "next-auth"
 
 jobs:
   test:
@@ -86,7 +104,7 @@ jobs:
     name: Publish PR
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     environment: Preview
     steps:
       - name: Init
@@ -103,22 +121,25 @@ jobs:
         uses: ./.github/version-pr
         id: determine-version
         env:
+          PACKAGE_PATH: ${{ github.event.inputs.path }}
           PR_NUMBER: ${{ github.event.number }}
       - name: Publish to npm
         run: |
-          cd packages/core
+          cd $PACKAGE_PATH
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
           pnpm publish --no-git-checks --access public --tag experimental
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_PATH: ${{ github.event.inputs.path }}
       - name: Comment version on PR
+        if: ${{ github.event_name == 'pull_request'}}
         uses: NejcZdovc/comment-pr@v2
         with:
           message:
-            "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/@auth/core/v/${{ env.VERSION }})!\n \
-            ```sh\npnpm add @auth/core@${{ env.VERSION }}\n```\n \
-            ```sh\nyarn add @auth/core@${{ env.VERSION }}\n```\n \
-            ```sh\nnpm i @auth/core@${{ env.VERSION }}\n```"
+            "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }})!\n \
+            ```sh\npnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}\n```\n \
+            ```sh\nyarn add ${{ github.event.inputs.name }}@${{ env.VERSION }}\n```\n \
+            ```sh\nnpm i ${{ github.event.inputs.name }}@${{ env.VERSION }}\n```"
         env:
           VERSION: ${{ steps.determine-version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
           cd packages/$PACKAGE_PATH
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
           pnpm publish --no-git-checks --access public --tag experimental
-          echo "\n\n🎉 Experimental release published 📦️ on npm: https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }})!"
+          echo "🎉 Experimental release published 📦️ on npm: https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }}"
           echo "Install via: pnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,9 +165,8 @@ jobs:
           cd packages/$PACKAGE_PATH
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
           pnpm publish --no-git-checks --access public --tag experimental
-          echo "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }})!"
-          echo "pnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}"
-        
+          echo "\n\n🎉 Experimental release published 📦️ on npm: https://npmjs.com/package/${{ github.event.inputs.name }}/v/${{ env.VERSION }})!"
+          echo "Install via: pnpm add ${{ github.event.inputs.name }}@${{ env.VERSION }}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PACKAGE_PATH: ${{ github.event.inputs.path }}

--- a/apps/examples/nextjs/pages/admin.tsx
+++ b/apps/examples/nextjs/pages/admin.tsx
@@ -7,7 +7,7 @@ export default function Page() {
       <p>Only admin users can see this page.</p>
       <p>
         To learn more about the NextAuth middleware see&nbsp;
-        <a href="https://docs-git-misc-docs-nextauthjs.vercel.app/configuration/nextjs#middleware">
+        <a href="https://next-auth.js.org/configuration/nextjs#middleware">
           the docs
         </a>
         .

--- a/docs/docs/concepts/faq.md
+++ b/docs/docs/concepts/faq.md
@@ -269,7 +269,7 @@ Ultimately if your request is not accepted or is not actively in development, yo
 </summary>
 <p>
 
-Auth.js by default uses JSON Web Tokens for saving the user's session. However, if you use a [database adapter](/guides/adapters/using-a-database-adapter), the database will be used to persist the user's session. You can force the usage of JWT when using a database [through the configuration options](/reference/configuration/auth-config#session). Since v4 all our JWT tokens are now encrypted by default with A256GCM.
+Auth.js by default uses JSON Web Tokens for saving the user's session. However, if you use a [database adapter](/guides/adapters/using-a-database-adapter), the database will be used to persist the user's session. You can force the usage of JWT when using a database [through the configuration options](/reference/configuration/auth-config#session). Since v4 all our JWTs are now encrypted by default with A256GCM.
 
 </p>
 </details>

--- a/docs/docs/guides/basics/events.md
+++ b/docs/docs/guides/basics/events.md
@@ -29,7 +29,7 @@ Sent when the user signs out.
 
 The message object will contain one of these depending on if you use JWT or database persisted sessions:
 
-- `token`: The JWT token for this session.
+- `token`: The JWT for this session.
 - `session`: The session object from your adapter that is being ended
 
 ### createUser
@@ -60,5 +60,5 @@ Sent at the end of a request for the current session.
 
 The message object will contain one of these depending on if you use JWT or database persisted sessions:
 
-- `token`: The JWT token for this session.
+- `token`: The JWT for this session.
 - `session`: The session object from your adapter.

--- a/docs/docs/reference/adapters/index.md
+++ b/docs/docs/reference/adapters/index.md
@@ -96,8 +96,13 @@ erDiagram
       string type
       string provider
       string providerAccountId
+      string refresh_token
       string access_token
+      int expires_at
+      string token_type
+      string scope
       string id_token
+      string session_state
     }
     VerificationToken {
       string identifier
@@ -137,7 +142,7 @@ The Account model is for information about OAuth accounts associated with a User
 
 A single User can have multiple Accounts, but each Account can only have one User.
 
-Account creation in the database is automatic and happens when the user is logging in for the first time with a provider, or the [`Adapter.linkAccount`](/reference/core/adapters#linkaccount) method is invoked. The default data saved is `access_token`, `refresh_token`, `id_token` and `expires_at`. You can save other fields by returning them in the [OAuth provider](/guides/providers/custom-provider)'s [`account()`](/reference/core/providers#account) callback.
+Account creation in the database is automatic and happens when the user is logging in for the first time with a provider, or the [`Adapter.linkAccount`](/reference/core/adapters#linkaccount) method is invoked. The default data saved is `access_token`, `expires_at`, `refresh_token`, `id_token`, `token_type`, `scope` and `session_state`. You can save other fields or remove the ones you don't need by returning them in the [OAuth provider](/guides/providers/custom-provider)'s [`account()`](/reference/core/providers#account) callback.
 
 Linking Accounts to Users happen automatically, only when they have the same e-mail address, and the user is currently signed in. Check the [FAQ](/concepts/faq#security) for more information on why this is a requirement.
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const path = require("path")
 const coreSrc = "../packages/core/src"
 const providers = fs
   .readdirSync(path.join(__dirname, coreSrc, "/providers"))
-  .filter((file) => file.endsWith(".ts") && !file.startsWith("oauth"))
+  .filter((file) => file.endsWith(".ts"))
   .map((p) => `${coreSrc}/providers/${p}`)
 
 const typedocConfig = require("./typedoc.json")

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -42,8 +42,6 @@ import type { Adapter, AdapterAccount } from "next-auth/adapters"
  * })
  * ```
  *
- * ## Advanced usage
- *
  * ### Create the Prisma schema from scratch
  *
  * You need to use at least Prisma 2.26.0. Create a schema file in `prisma/schema.prisma` similar to this one:

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -228,6 +228,10 @@ export interface Adapter {
   deleteUser?(
     userId: string
   ): Promise<void> | Awaitable<AdapterUser | null | undefined>
+  /**
+   * This method is invoked internally (but optionally can be used for manual linking).
+   * It creates an [Account](https://authjs.dev/reference/adapters#models) in the database.
+   */
   linkAccount?(
     account: AdapterAccount
   ): Promise<void> | Awaitable<AdapterAccount | null | undefined>

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -125,7 +125,12 @@ export class MissingSecret extends AuthError {}
  */
 export class OAuthAccountNotLinked extends AuthError {}
 
-/** @todo */
+/**
+ * Thrown when an OAuth provider returns an error during the sign in process.
+ * This could happen for example if the user denied access to the application or there was a configuration error.
+ *
+ * For a full list of possible reasons, check out the specification [Authorization Code Grant: Error Response](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1)
+ */
 export class OAuthCallbackError extends AuthError {}
 
 /** @todo */

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -22,13 +22,6 @@ export class AuthError extends Error {
 
 /**
  * @todo
- * Thrown when an Email address is already associated with an account
- * but the user is trying an OAuth account that is not linked to it.
- */
-export class AccountNotLinked extends AuthError {}
-
-/**
- * @todo
  * One of the database `Adapter` methods failed.
  */
 export class AdapterError extends AuthError {}
@@ -37,8 +30,8 @@ export class AdapterError extends AuthError {}
 export class AuthorizedCallbackError extends AuthError {}
 
 /**
- * There was an error while trying to finish up authenticating the user.
- * Depending on the type of provider, this could be for multiple reasons.
+ * This error occurs when the user cannot finish the sign-in process.
+ * Depending on the provider type, this could have happened for multiple reasons.
  *
  * :::tip
  * Check out `[auth][details]` in the error message to know which provider failed.
@@ -48,7 +41,7 @@ export class AuthorizedCallbackError extends AuthError {}
  * ```
  * :::
  *
- * For an **OAuth provider**, possible causes are:
+ * For an [OAuth provider](https://authjs.dev/reference/core/providers_oauth), possible causes are:
  * - The user denied access to the application
  * - There was an error parsing the OAuth Profile:
  *   Check out the provider's `profile` or `userinfo.request` method to make sure
@@ -56,7 +49,7 @@ export class AuthorizedCallbackError extends AuthError {}
  * - The `signIn` or `jwt` callback methods threw an uncaught error:
  *   Check the callback method implementations.
  *
- * For an **Email provider**, possible causes are:
+ * For an [Email provider](https://authjs.dev/reference/core/providers_email), possible causes are:
  * - The provided email/token combination was invalid/missing:
  *   Check if the provider's `sendVerificationRequest` method correctly sends the email.
  * - The provided email/token combination has expired:
@@ -64,7 +57,7 @@ export class AuthorizedCallbackError extends AuthError {}
  * - There was an error with the database:
  *   Check the database logs.
  *
- * For a **Credentials provider**, possible causes are:
+ * For a [Credentials provider](https://authjs.dev/reference/core/providers_credentials), possible causes are:
  * - The `authorize` method threw an uncaught error:
  *   Check the provider's `authorize` method.
  * - The `signIn` or `jwt` callback methods threw an uncaught error:
@@ -107,11 +100,30 @@ export class MissingAPIRoute extends AuthError {}
 /** @todo */
 export class MissingAuthorize extends AuthError {}
 
-/** @todo */
+/**
+ * Auth.js requires a secret to be set, but none was not found. This is used to encrypt cookies, JWTs and other sensitive data.
+ *
+ * :::note
+ * If you are using a framework like Next.js, we try to automatically infer the secret from the `AUTH_SECRET` environment variable.
+ * Alternatively, you can also explicitly set the [`AuthConfig.secret`](https://authjs.dev/reference/core#secret).
+ * :::
+ *
+ *
+ * :::tip
+ * You can generate a good secret value:
+ *  - On Unix systems: type `openssl rand -hex 32` in the terminal
+ *  - Or generate one [online](https://generate-secret.vercel.app/32)
+ *
+ * :::
+ */
 export class MissingSecret extends AuthError {}
 
-/** @todo */
-export class OAuthSignInError extends AuthError {}
+/**
+ * @todo
+ * Thrown when an Email address is already associated with an account
+ * but the user is trying an OAuth account that is not linked to it.
+ */
+export class OAuthAccountNotLinked extends AuthError {}
 
 /** @todo */
 export class OAuthCallbackError extends AuthError {}
@@ -119,19 +131,51 @@ export class OAuthCallbackError extends AuthError {}
 /** @todo */
 export class OAuthCreateUserError extends AuthError {}
 
-/** @todo */
+/**
+ * This error occurs during an OAuth sign in attempt when the provdier's
+ * response could not be parsed. This could for example happen if the provider's API
+ * changed, or the [`OAuth2Config.profile`](https://authjs.dev/reference/core/providers_oauth#profile) method is not implemented correctly.
+ */
 export class OAuthProfileParseError extends AuthError {}
 
 /** @todo */
 export class SessionTokenError extends AuthError {}
 
-/** @todo */
+/**
+ * This error occurs when the user cannot initiate the sign-in process.
+ * Depending on the provider type, this could have happened for multiple reasons.
+ *
+ * :::tip
+ * Check out `[auth][details]` in the error message to know which provider failed.
+ * @example
+ * ```sh
+ * [auth][details]: { "provider": "github" }
+ * ```
+ * :::
+ *
+ * For an [OAuth provider](https://authjs.dev/reference/core/providers_oauth), possible causes are:
+ * - The Authorization Server is not compliant with the [OAuth 2.0 specifcation](https://www.ietf.org/rfc/rfc6749.html)
+ *   Check the details in the error message.
+ * - A runtime error occurred in Auth.js. This should be reported as a bug.
+ *
+ * For an [Email provider](https://authjs.dev/reference/core/providers_email), possible causes are:
+ * - The email sent from the client is invalid, could not be normalized by [`EmailConfig.normalizeIdentifier`](https://authjs.dev/reference/core/providers_email#normalizeidentifier)
+ * - The provided email/token combination has expired:
+ *   Ask the user to log in again.
+ * - There was an error with the database:
+ *   Check the database logs.
+ *
+ */
 export class SignInError extends AuthError {}
 
 /** @todo */
 export class SignOutError extends AuthError {}
 
-/** @todo */
+/**
+ * Auth.js was requested to handle an operation that it does not support.
+ *
+ * See [`AuthAction`](https://authjs.dev/reference/core/types#authaction) for the supported actions.
+ */
 export class UnknownAction extends AuthError {}
 
 /** @todo */

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -190,7 +190,7 @@ export interface JWTEncodeParams<Payload = JWT> {
   /**
    * The maximum age of the Auth.js issued JWT in seconds.
    *
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge?: number
 }
@@ -213,7 +213,7 @@ export interface JWTOptions {
   /**
    * The maximum age of the Auth.js issued JWT in seconds.
    *
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge: number
   /** Override this method to control the Auth.js issued JWT encoding. */

--- a/packages/core/src/lib/callback-handler.ts
+++ b/packages/core/src/lib/callback-handler.ts
@@ -1,4 +1,4 @@
-import { AccountNotLinked } from "../errors.js"
+import { OAuthAccountNotLinked } from "../errors.js"
 import { fromDate } from "./utils/date.js"
 
 import type {
@@ -122,118 +122,116 @@ export async function handleLogin(
         })
 
     return { session, user, isNewUser }
-  } else if (account.type === "oauth" || account.type === "oidc") {
-    // If signing in with OAuth account, check to see if the account exists already
-    const userByAccount = await getUserByAccount({
-      providerAccountId: account.providerAccountId,
-      provider: account.provider,
-    })
-    if (userByAccount) {
-      if (user) {
-        // If the user is already signed in with this account, we don't need to do anything
-        if (userByAccount.id === user.id) {
-          return { session, user, isNewUser }
-        }
-        // If the user is currently signed in, but the new account they are signing in
-        // with is already associated with another user, then we cannot link them
-        // and need to return an error.
-        throw new AccountNotLinked(
-          "The account is already associated with another user",
-          { provider: account.provider }
-        )
-      }
-      // If there is no active session, but the account being signed in with is already
-      // associated with a valid user then create session to sign the user in.
-      session = useJwtSession
-        ? {}
-        : await createSession({
-            sessionToken: generateSessionToken(),
-            userId: userByAccount.id,
-            expires: fromDate(options.session.maxAge),
-          })
+  }
 
-      return { session, user: userByAccount, isNewUser }
-    } else {
-      const { provider: p } = options as InternalOptions<"oauth" | "oidc">
-      const { type, provider, providerAccountId, userId, ...tokenSet } = account
-      const defaults = { providerAccountId, provider, type, userId }
-      account = Object.assign(p.account(tokenSet), defaults)
-
-      if (user) {
-        // If the user is already signed in and the OAuth account isn't already associated
-        // with another user account then we can go ahead and link the accounts safely.
-        await linkAccount({ ...account, userId: user.id })
-        await events.linkAccount?.({ user, account, profile })
-
-        // As they are already signed in, we don't need to do anything after linking them
+  // If signing in with OAuth account, check to see if the account exists already
+  const userByAccount = await getUserByAccount({
+    providerAccountId: account.providerAccountId,
+    provider: account.provider,
+  })
+  if (userByAccount) {
+    if (user) {
+      // If the user is already signed in with this account, we don't need to do anything
+      if (userByAccount.id === user.id) {
         return { session, user, isNewUser }
       }
+      // If the user is currently signed in, but the new account they are signing in
+      // with is already associated with another user, then we cannot link them
+      // and need to return an error.
+      throw new OAuthAccountNotLinked(
+        "The account is already associated with another user",
+        { provider: account.provider }
+      )
+    }
+    // If there is no active session, but the account being signed in with is already
+    // associated with a valid user then create session to sign the user in.
+    session = useJwtSession
+      ? {}
+      : await createSession({
+          sessionToken: generateSessionToken(),
+          userId: userByAccount.id,
+          expires: fromDate(options.session.maxAge),
+        })
 
-      // If the user is not signed in and it looks like a new OAuth account then we
-      // check there also isn't an user account already associated with the same
-      // email address as the one in the OAuth profile.
-      //
-      // This step is often overlooked in OAuth implementations, but covers the following cases:
-      //
-      // 1. It makes it harder for someone to accidentally create two accounts.
-      //    e.g. by signin in with email, then again with an oauth account connected to the same email.
-      // 2. It makes it harder to hijack a user account using a 3rd party OAuth account.
-      //    e.g. by creating an oauth account then changing the email address associated with it.
-      //
-      // It's quite common for services to automatically link accounts in this case, but it's
-      // better practice to require the user to sign in *then* link accounts to be sure
-      // someone is not exploiting a problem with a third party OAuth service.
-      //
-      // OAuth providers should require email address verification to prevent this, but in
-      // practice that is not always the case; this helps protect against that.
-      const userByEmail = profile.email
-        ? await getUserByEmail(profile.email)
-        : null
-      if (userByEmail) {
-        const provider = options.provider as OAuthConfig<any>
-        if (provider?.allowDangerousEmailAccountLinking) {
-          // If you trust the oauth provider to correctly verify email addresses, you can opt-in to
-          // account linking even when the user is not signed-in.
-          user = userByEmail
-        } else {
-          // We end up here when we don't have an account with the same [provider].id *BUT*
-          // we do already have an account with the same email address as the one in the
-          // OAuth profile the user has just tried to sign in with.
-          //
-          // We don't want to have two accounts with the same email address, and we don't
-          // want to link them in case it's not safe to do so, so instead we prompt the user
-          // to sign in via email to verify their identity and then link the accounts.
-          throw new AccountNotLinked(
-            "Another account already exists with the same e-mail address",
-            { provider: account.provider }
-          )
-        }
-      } else {
-        // If the current user is not logged in and the profile isn't linked to any user
-        // accounts (by email or provider account id)...
-        //
-        // If no account matching the same [provider].id or .email exists, we can
-        // create a new account for the user, link it to the OAuth account and
-        // create a new session for them so they are signed in with it.
-        const { id: _, ...newUser } = { ...profile, emailVerified: null }
-        user = await createUser(newUser)
-      }
-      await events.createUser?.({ user })
+    return { session, user: userByAccount, isNewUser }
+  } else {
+    const { provider: p } = options as InternalOptions<"oauth" | "oidc">
+    const { type, provider, providerAccountId, userId, ...tokenSet } = account
+    const defaults = { providerAccountId, provider, type, userId }
+    account = Object.assign(p.account(tokenSet), defaults)
 
+    if (user) {
+      // If the user is already signed in and the OAuth account isn't already associated
+      // with another user account then we can go ahead and link the accounts safely.
       await linkAccount({ ...account, userId: user.id })
       await events.linkAccount?.({ user, account, profile })
 
-      session = useJwtSession
-        ? {}
-        : await createSession({
-            sessionToken: generateSessionToken(),
-            userId: user.id,
-            expires: fromDate(options.session.maxAge),
-          })
-
-      return { session, user, isNewUser: true }
+      // As they are already signed in, we don't need to do anything after linking them
+      return { session, user, isNewUser }
     }
-  }
 
-  throw new Error("Unsupported account type")
+    // If the user is not signed in and it looks like a new OAuth account then we
+    // check there also isn't an user account already associated with the same
+    // email address as the one in the OAuth profile.
+    //
+    // This step is often overlooked in OAuth implementations, but covers the following cases:
+    //
+    // 1. It makes it harder for someone to accidentally create two accounts.
+    //    e.g. by signin in with email, then again with an oauth account connected to the same email.
+    // 2. It makes it harder to hijack a user account using a 3rd party OAuth account.
+    //    e.g. by creating an oauth account then changing the email address associated with it.
+    //
+    // It's quite common for services to automatically link accounts in this case, but it's
+    // better practice to require the user to sign in *then* link accounts to be sure
+    // someone is not exploiting a problem with a third party OAuth service.
+    //
+    // OAuth providers should require email address verification to prevent this, but in
+    // practice that is not always the case; this helps protect against that.
+    const userByEmail = profile.email
+      ? await getUserByEmail(profile.email)
+      : null
+    if (userByEmail) {
+      const provider = options.provider as OAuthConfig<any>
+      if (provider?.allowDangerousEmailAccountLinking) {
+        // If you trust the oauth provider to correctly verify email addresses, you can opt-in to
+        // account linking even when the user is not signed-in.
+        user = userByEmail
+      } else {
+        // We end up here when we don't have an account with the same [provider].id *BUT*
+        // we do already have an account with the same email address as the one in the
+        // OAuth profile the user has just tried to sign in with.
+        //
+        // We don't want to have two accounts with the same email address, and we don't
+        // want to link them in case it's not safe to do so, so instead we prompt the user
+        // to sign in via email to verify their identity and then link the accounts.
+        throw new OAuthAccountNotLinked(
+          "Another account already exists with the same e-mail address",
+          { provider: account.provider }
+        )
+      }
+    } else {
+      // If the current user is not logged in and the profile isn't linked to any user
+      // accounts (by email or provider account id)...
+      //
+      // If no account matching the same [provider].id or .email exists, we can
+      // create a new account for the user, link it to the OAuth account and
+      // create a new session for them so they are signed in with it.
+      const { id: _, ...newUser } = { ...profile, emailVerified: null }
+      user = await createUser(newUser)
+    }
+    await events.createUser?.({ user })
+
+    await linkAccount({ ...account, userId: user.id })
+    await events.linkAccount?.({ user, account, profile })
+
+    session = useJwtSession
+      ? {}
+      : await createSession({
+          sessionToken: generateSessionToken(),
+          userId: user.id,
+          expires: fromDate(options.session.maxAge),
+        })
+
+    return { session, user, isNewUser: true }
+  }
 }

--- a/packages/core/src/lib/callback-handler.ts
+++ b/packages/core/src/lib/callback-handler.ts
@@ -49,7 +49,7 @@ export async function handleLogin(
   }
 
   const profile = _profile as AdapterUser
-  const account = _account as AdapterAccount
+  let account = _account as AdapterAccount
 
   const {
     createUser,
@@ -154,6 +154,11 @@ export async function handleLogin(
 
       return { session, user: userByAccount, isNewUser }
     } else {
+      const { provider: p } = options as InternalOptions<"oauth" | "oidc">
+      const { type, provider, providerAccountId, userId, ...tokenSet } = account
+      const defaults = { providerAccountId, provider, type, userId }
+      account = Object.assign(p.account(tokenSet), defaults)
+
       if (user) {
         // If the user is already signed in and the OAuth account isn't already associated
         // with another user account then we can go ahead and link the accounts safely.

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -110,7 +110,6 @@ export async function AuthInternal<
         if (
           [
             "Signin",
-            "OAuthCallback",
             "OAuthCreateAccount",
             "EmailCreateAccount",
             "Callback",

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -110,14 +110,11 @@ export async function AuthInternal<
         if (
           [
             "Signin",
-            "OAuthSignin",
             "OAuthCallback",
             "OAuthCreateAccount",
             "EmailCreateAccount",
             "Callback",
             "OAuthAccountNotLinked",
-            "EmailSignin",
-            "CredentialsSignin",
             "SessionRequired",
           ].includes(error as string)
         ) {

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -47,7 +47,7 @@ export async function AuthInternal<
       case "providers":
         return (await routes.providers(options.providers)) as any
       case "session": {
-        const session = await routes.session(sessionStore, options)
+        const session = await routes.session({ sessionStore, options })
         if (session.cookies) cookies.push(...session.cookies)
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         return { ...session, cookies } as any
@@ -177,6 +177,22 @@ export async function AuthInternal<
           return { ...callback, cookies }
         }
         break
+      case "session": {
+        if (options.csrfTokenVerified) {
+          const session = await routes.session({
+            options,
+            sessionStore,
+            newSession: request.body?.data,
+            isUpdate: true,
+          })
+          if (session.cookies) cookies.push(...session.cookies)
+          return { ...session, cookies } as any
+        }
+
+        // If CSRF token is invalid, return a 400 status code
+        // we should not redirect to a page as this is an API route
+        return { status: 400, cookies }
+      }
       default:
     }
   }

--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -171,18 +171,18 @@ export async function handleOAuth(
       Math.floor(Date.now() / 1000) + Number(tokens.expires_in)
   }
 
-  const profileResult = await getUserAndProfile(
+  const profileResult = await getUserAndAccount(
     profile,
     provider,
     tokens,
     logger
   )
 
-  return { ...profileResult, cookies: resCookies }
+  return { ...profileResult, profile, cookies: resCookies }
 }
 
-/** Returns profile, raw profile and auth provider details */
-async function getUserAndProfile(
+/** Returns the user and account that is going to be created in the database. */
+async function getUserAndAccount(
   OAuthProfile: Profile,
   provider: OAuthConfigInternal<any>,
   tokens: TokenSet,
@@ -206,7 +206,6 @@ async function getUserAndProfile(
         providerAccountId: user.id.toString(),
         ...tokens,
       },
-      OAuthProfile,
     }
   } catch (e) {
     // If we didn't get a response either there was a problem with the provider

--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -219,6 +219,8 @@ async function getUserAndProfile(
     // redirected back to the sign up page. We log the error to help developers
     // who might be trying to debug this when configuring a new provider.
     logger.debug("getProfile error details", OAuthProfile)
-    logger.error(new OAuthProfileParseError(e as Error))
+    logger.error(
+      new OAuthProfileParseError(e as Error, { provider: provider.id })
+    )
   }
 }

--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -89,11 +89,9 @@ export async function handleOAuth(
 
   /** https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1 */
   if (o.isOAuth2Error(codeGrantParams)) {
-    logger.debug("OAuthCallbackError", {
-      providerId: provider.id,
-      ...codeGrantParams,
-    })
-    throw new OAuthCallbackError(codeGrantParams.error)
+    const cause = { providerId: provider.id, ...codeGrantParams }
+    logger.debug("OAuthCallbackError", cause)
+    throw new OAuthCallbackError("OAuth Provider returned an error", cause)
   }
 
   const codeVerifier = await checks.pkce.use(cookies, resCookies, options)

--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -190,7 +190,10 @@ async function getUserAndAccount(
 ) {
   try {
     const user = await provider.profile(OAuthProfile, tokens)
-    user.email = user.email?.toLowerCase()
+
+    if (typeof user.email === "string") {
+      user.email = user.email.toLowerCase()
+    }
 
     if (!user.id) {
       throw new TypeError(

--- a/packages/core/src/lib/pages/signin.tsx
+++ b/packages/core/src/lib/pages/signin.tsx
@@ -11,7 +11,7 @@ const signinErrors: Record<
   default: "Unable to sign in.",
   signin: "Try signing in with a different account.",
   oauthsignin: "Try signing in with a different account.",
-  oauthcallback: "Try signing in with a different account.",
+  oauthcallbackerror: "Try signing in with a different account.",
   oauthcreateaccount: "Try signing in with a different account.",
   emailcreateaccount: "Try signing in with a different account.",
   callback: "Try signing in with a different account.",

--- a/packages/core/src/lib/providers.ts
+++ b/packages/core/src/lib/providers.ts
@@ -1,3 +1,4 @@
+import { OAuthProfileParseError } from "../errors.js"
 import { merge } from "./utils/merge.js"
 
 import type {
@@ -90,8 +91,10 @@ function normalizeOAuth(
  * @see https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
  */
 const defaultProfile: ProfileCallback<Profile> = (profile) => {
+  const id = profile.sub ?? profile.id
+  if (!id) throw new OAuthProfileParseError("Missing user id")
   return stripUndefined({
-    id: profile.sub ?? profile.id,
+    id: id.toString(),
     name: profile.name ?? profile.nickname ?? profile.preferred_username,
     email: profile.email,
     image: profile.picture,

--- a/packages/core/src/lib/providers.ts
+++ b/packages/core/src/lib/providers.ts
@@ -106,14 +106,16 @@ const defaultProfile: ProfileCallback<Profile> = (profile) => {
  * @see https://www.ietf.org/rfc/rfc6749.html#section-5.1
  * @see https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse
  * @see https://authjs.dev/reference/adapters#account
- *
- * @todo Return `refresh_token` and `expires_at` as well when built-in
- * refresh token support is added. (Can make it opt-in first with a flag).
  */
 const defaultAccount: AccountCallback = (account) => {
   return stripUndefined({
     access_token: account.access_token,
     id_token: account.id_token,
+    refresh_token: account.refresh_token,
+    expires_at: account.expires_at,
+    scope: account.scope,
+    token_type: account.token_type,
+    session_state: account.session_state,
   })
 }
 

--- a/packages/core/src/lib/routes/callback.ts
+++ b/packages/core/src/lib/routes/callback.ts
@@ -75,7 +75,7 @@ export async function callback(params: {
       const {
         user: userFromProvider,
         account,
-        OAuthProfile,
+        profile: OAuthProfile,
       } = authorizationResult
 
       // If we don't have a profile object then either something went wrong

--- a/packages/core/src/lib/routes/callback.ts
+++ b/packages/core/src/lib/routes/callback.ts
@@ -134,6 +134,7 @@ export async function callback(params: {
           account,
           profile: OAuthProfile,
           isNewUser,
+          trigger: isNewUser ? "signUp" : "signIn",
         })
 
         // Clear cookies if token is null
@@ -244,6 +245,7 @@ export async function callback(params: {
           user: loggedInUser,
           account,
           isNewUser,
+          trigger: isNewUser ? "signUp" : "signIn",
         })
 
         // Clear cookies if token is null
@@ -340,6 +342,7 @@ export async function callback(params: {
         // @ts-expect-error
         account,
         isNewUser: false,
+        trigger: "signIn",
       })
 
       // Clear cookies if token is null

--- a/packages/core/src/lib/routes/callback.ts
+++ b/packages/core/src/lib/routes/callback.ts
@@ -1,4 +1,8 @@
-import { CallbackRouteError, Verification } from "../../errors.js"
+import {
+  CallbackRouteError,
+  OAuthCallbackError,
+  Verification,
+} from "../../errors.js"
 import { handleLogin } from "../callback-handler.js"
 import { handleOAuth } from "../oauth/callback.js"
 import { handleState } from "../oauth/handle-state.js"
@@ -368,6 +372,15 @@ export async function callback(params: {
       cookies,
     }
   } catch (e) {
+    if (e instanceof OAuthCallbackError) {
+      logger.error(e)
+      // REVIEW: Should we expose original error= and error_description=
+      // Should we use a different name for error= then, since we already use it for all kind of errors?
+      url.searchParams.set("error", OAuthCallbackError.name)
+      url.pathname += "/signin"
+      return { redirect: url.toString(), cookies }
+    }
+
     const error = new CallbackRouteError(e as Error, { provider: provider.id })
 
     logger.debug("callback route error details", { method, query, body })

--- a/packages/core/src/lib/routes/callback.ts
+++ b/packages/core/src/lib/routes/callback.ts
@@ -370,6 +370,7 @@ export async function callback(params: {
   } catch (e) {
     const error = new CallbackRouteError(e as Error, { provider: provider.id })
 
+    logger.debug("callback route error details", { method, query, body })
     logger.error(error)
     url.searchParams.set("error", CallbackRouteError.name)
     url.pathname += "/error"

--- a/packages/core/src/lib/routes/session.ts
+++ b/packages/core/src/lib/routes/session.ts
@@ -36,8 +36,10 @@ export async function session(params: {
     try {
       const decodedToken = await jwt.decode({ ...jwt, token: sessionToken })
 
+      if (!decodedToken) throw new Error("Invalid JWT")
+
+      // @ts-expect-error
       const token = await callbacks.jwt({
-        // @ts-expect-error
         token: decodedToken,
         ...(isUpdate && { trigger: "update" }),
         session: newSession,
@@ -45,18 +47,13 @@ export async function session(params: {
 
       const newExpires = fromDate(sessionMaxAge)
 
-      // By default, only exposes a limited subset of information to the client
-      // as needed for presentation purposes (e.g. "you are logged in as...").
-      const session = {
-        user: {
-          name: token?.name,
-          email: token?.email,
-          image: token?.picture,
-        },
-        expires: newExpires.toISOString(),
-      }
-
       if (token !== null) {
+        // By default, only exposes a limited subset of information to the client
+        // as needed for presentation purposes (e.g. "you are logged in as...").
+        const session = {
+          user: { name: token.name, email: token.email, image: token.picture },
+          expires: newExpires.toISOString(),
+        }
         // @ts-expect-error
         const newSession = await callbacks.session({ session, token })
 
@@ -132,11 +129,7 @@ export async function session(params: {
         // By default, only exposes a limited subset of information to the client
         // as needed for presentation purposes (e.g. "you are logged in as...").
         session: {
-          user: {
-            name: user.name,
-            email: user.email,
-            picture: user.image,
-          },
+          user: { name: user.name, email: user.email, image: user.image },
           expires: session.expires.toISOString(),
         },
         user,

--- a/packages/core/src/lib/routes/session.ts
+++ b/packages/core/src/lib/routes/session.ts
@@ -6,10 +6,13 @@ import type { InternalOptions, ResponseInternal, Session } from "../../types.js"
 import type { SessionStore } from "../cookie.js"
 
 /** Return a session object filtered via `callbacks.session` */
-export async function session(
-  sessionStore: SessionStore,
+export async function session(params: {
   options: InternalOptions
-): Promise<ResponseInternal<Session | null>> {
+  sessionStore: SessionStore
+  isUpdate?: boolean
+  newSession?: any
+}): Promise<ResponseInternal<Session | null>> {
+  const { options, sessionStore, newSession, isUpdate } = params
   const {
     adapter,
     jwt,
@@ -33,21 +36,25 @@ export async function session(
     try {
       const decodedToken = await jwt.decode({ ...jwt, token: sessionToken })
 
+      const token = await callbacks.jwt({
+        // @ts-expect-error
+        token: decodedToken,
+        ...(isUpdate && { trigger: "update" }),
+        session: newSession,
+      })
+
       const newExpires = fromDate(sessionMaxAge)
 
       // By default, only exposes a limited subset of information to the client
       // as needed for presentation purposes (e.g. "you are logged in as...").
       const session = {
         user: {
-          name: decodedToken?.name,
-          email: decodedToken?.email,
-          image: decodedToken?.picture,
+          name: token?.name,
+          email: token?.email,
+          image: token?.picture,
         },
         expires: newExpires.toISOString(),
       }
-
-      // @ts-expect-error
-      const token = await callbacks.jwt({ token: decodedToken })
 
       if (token !== null) {
         // @ts-expect-error
@@ -128,11 +135,13 @@ export async function session(
           user: {
             name: user.name,
             email: user.email,
-            image: user.image,
+            picture: user.image,
           },
           expires: session.expires.toISOString(),
         },
         user,
+        newSession,
+        ...(isUpdate ? { trigger: "update" } : {}),
       })
 
       // Return session payload as response

--- a/packages/core/src/lib/routes/signin.ts
+++ b/packages/core/src/lib/routes/signin.ts
@@ -55,8 +55,9 @@ export async function signin(
   } catch (e) {
     const error = new SignInError(e as Error, { provider: provider.id })
     logger.error(error)
-    url.searchParams.set("error", error.name)
-    url.pathname += "/error"
+    const code = provider.type === "email" ? "EmailSignin" : "OAuthSignin"
+    url.searchParams.set("error", code)
+    url.pathname += "/signin"
     return { redirect: url.toString() }
   }
 }

--- a/packages/core/src/lib/web.ts
+++ b/packages/core/src/lib/web.ts
@@ -33,6 +33,8 @@ export async function toInternalRequest(
     // TODO: url.toString() should not include action and providerId
     // see init.ts
     const url = new URL(req.url.replace(/\/$/, ""))
+    // FIXME: Upstream issue in Next.js, pathname segments get included as part of the query string
+    url.searchParams.delete("nextauth")
     const { pathname } = url
 
     const action = actions.find((a) => pathname.includes(a))

--- a/packages/core/src/providers/credentials.ts
+++ b/packages/core/src/providers/credentials.ts
@@ -32,12 +32,14 @@ export interface CredentialsConfig<
    * @example
    * ```ts
    * //...
-   * async authorize(, request) {
+   * async authorize(credentials, request) {
+   *   if(!isValidCredentials(credentials)) return null
    *   const response = await fetch(request)
    *   if(!response.ok) return null
    *   return await response.json() ?? null
    * }
    * //...
+   * ```
    */
   authorize: (
     /**

--- a/packages/core/src/providers/email.ts
+++ b/packages/core/src/providers/email.ts
@@ -29,7 +29,7 @@ export interface SendVerificationRequestParams {
 export interface EmailConfig extends CommonProviderOptions {
   type: "email"
   // TODO: Make use of https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
-  server: string | SMTPTransportOptions
+  server?: string | SMTPTransportOptions
   /** @default `"Auth.js <no-reply@authjs.dev>"` */
   from?: string
   /**
@@ -72,7 +72,7 @@ export interface EmailConfig extends CommonProviderOptions {
    * By default, we treat email addresses as all lower case,
    * but you can override this function to change this behavior.
    *
-   * [Documentation](https://authjs.dev/guides/providers/email#normalizing-the-e-mail-address) | [RFC 2821](https://tools.ietf.org/html/rfc2821) | [Email syntax](https://en.wikipedia.org/wiki/Email_address#Syntax)
+   * [Normalizing the email address](https://authjs.dev/reference/core/providers_email#normalizing-the-email-address) | [RFC 2821](https://tools.ietf.org/html/rfc2821) | [Email syntax](https://en.wikipedia.org/wiki/Email_address#Syntax)
    */
   normalizeIdentifier?: (identifier: string) => string
 }
@@ -287,7 +287,7 @@ export type EmailProviderType = "email"
  * 
  * ## Normalizing the email address
  * 
- * By default, NextAuth.js will normalize the email address. It treats values as case-insensitive (which is technically not compliant to the [RFC 2821 spec](https://datatracker.ietf.org/doc/html/rfc2821), but in practice this causes more problems than it solves, eg. when looking up users by e-mail from databases.) and also removes any secondary email address that was passed in as a comma-separated list. You can apply your own normalization via the `normalizeIdentifier` method on the `EmailProvider`. The following example shows the default behavior:
+ * By default, Auth.js will normalize the email address. It treats values as case-insensitive (which is technically not compliant to the [RFC 2821 spec](https://datatracker.ietf.org/doc/html/rfc2821), but in practice this causes more problems than it solves, eg. when looking up users by e-mail from databases.) and also removes any secondary email address that was passed in as a comma-separated list. You can apply your own normalization via the `normalizeIdentifier` method on the `EmailProvider`. The following example shows the default behavior:
  * ```ts
  *   EmailProvider({
  *     // ...
@@ -301,7 +301,7 @@ export type EmailProviderType = "email"
  *       return `${local}@${domain}`
  * 
  *       // You can also throw an error, which will redirect the user
- *       // to the error page with error=EmailSignin in the URL
+ *       // to the sign-in page with error=EmailSignin in the URL
  *       // if (identifier.split("@").length > 2) {
  *       //   throw new Error("Only one email allowed")
  *       // }

--- a/packages/core/src/providers/eveonline.ts
+++ b/packages/core/src/providers/eveonline.ts
@@ -52,7 +52,7 @@ export interface EVEOnlineProfile extends Record<string, any> {
  * :::
  *
  * :::tip
- * If using JWT for the session, you can add the `CharacterID` to the JWT token and session. Example:
+ * If using JWT for the session, you can add the `CharacterID` to the JWT and session. Example:
  * ```js
  * options: {
  *   jwt: {

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -65,6 +65,7 @@ export interface GitHubProfile {
     space: number
     private_repos: number
   }
+  [claim: string]: unknown
 }
 
 /**

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -95,7 +95,7 @@ export type ProfileCallback<Profile> = (
   tokens: TokenSet
 ) => Awaitable<User>
 
-export type AccountCallback = (account: TokenSet) => TokenSet
+export type AccountCallback = (tokens: TokenSet) => TokenSet
 
 export interface OAuthProviderButtonStyles {
   logo: string
@@ -155,7 +155,31 @@ export interface OAuth2Config<Profile>
    * Receives the full {@link TokenSet} returned by the OAuth provider, and returns a subset.
    * It is used to create the account associated with a user in the database.
    *
-   * Defaults to: `access_token` and `id_token`
+   * :::note
+   * You need to adjust your database's [Account model](https://authjs.dev/reference/adapters#account) to match the returned properties.
+   * Check out the documentation of your [database adapter](https://authjs.dev/reference/adapters) for more information.
+   * :::
+   *
+   * Defaults to: `access_token`, `id_token`, `refresh_token`, `expires_at`, `scope`, `token_type`, `session_state`
+   *
+   * @example
+   * ```ts
+   * import GitHub from "@auth/core/providers/github"
+   * // ...
+   * GitHub({
+   *   account(account) {
+   *     // https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens#refreshing-a-user-access-token-with-a-refresh-token
+   *     const refresh_token_expires_at =
+   *       Math.floor(Date.now() / 1000) + Number(account.refresh_token_expires_in)
+   *     return {
+   *       access_token: account.access_token,
+   *       expires_at: account.expires_at,
+   *       refresh_token: account.refresh_token,
+   *       refresh_token_expires_at
+   *     }
+   *   }
+   * })
+   * ```
    *
    * @see [Database Adapter: Account model](https://authjs.dev/reference/adapters#account)
    * @see https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -263,11 +263,9 @@ export type OIDCConfigInternal<Profile> = OAuthConfigInternal<Profile> & {
 export type OAuthUserConfig<Profile> = Omit<
   Partial<OAuthConfig<Profile>>,
   "options" | "type"
-> &
-  Required<Pick<OAuthConfig<Profile>, "clientId" | "clientSecret">>
+>
 
 export type OIDCUserConfig<Profile> = Omit<
   Partial<OIDCConfig<Profile>>,
   "options" | "type"
-> &
-  Required<Pick<OIDCConfig<Profile>, "clientId" | "clientSecret">>
+>

--- a/packages/core/src/providers/twitter.ts
+++ b/packages/core/src/providers/twitter.ts
@@ -99,6 +99,7 @@ export interface TwitterProfile {
       text: string
     }>
   }
+  [claims: string]: unknown
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -141,32 +141,32 @@ export interface Account extends Partial<OpenIDTokenEndpointResponse> {
  * @see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
  */
 export interface Profile {
-  sub: string
-  name?: string
-  given_name?: string
-  family_name?: string
-  middle_name?: string
-  nickname?: string
-  preferred_username?: string
-  profile?: string
-  picture?: string
-  website?: string
-  email?: string
-  email_verified?: boolean
-  gender?: string
-  birthdate?: string
-  zoneinfo?: string
-  locale?: string
-  phone_number?: string
-  updated_at?: number
+  sub?: string | null
+  name?: string | null
+  given_name?: string | null
+  family_name?: string | null
+  middle_name?: string | null
+  nickname?: string | null
+  preferred_username?: string | null
+  profile?: string | null
+  picture?: string | null
+  website?: string | null
+  email?: string | null
+  email_verified?: boolean | null
+  gender?: string | null
+  birthdate?: string | null
+  zoneinfo?: string | null
+  locale?: string | null
+  phone_number?: string | null
+  updated_at?: Date | string | number | null
   address?: {
-    formatted?: string
-    street_address?: string
-    locality?: string
-    region?: string
-    postal_code?: string
-    country?: string
-  }
+    formatted?: string | null
+    street_address?: string | null
+    locality?: string | null
+    region?: string | null
+    postal_code?: string | null
+    country?: string | null
+  } | null
   [claim: string]: unknown
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -304,7 +304,7 @@ export interface EventCallbacks {
   /**
    * The message object will contain one of these depending on
    * if you use JWT or database persisted sessions:
-   * - `token`: The JWT token for this session.
+   * - `token`: The JWT for this session.
    * - `session`: The session object from your adapter that is being ended.
    */
   signOut: (
@@ -322,7 +322,7 @@ export interface EventCallbacks {
   /**
    * The message object will contain one of these depending on
    * if you use JWT or database persisted sessions:
-   * - `token`: The JWT token for this session.
+   * - `token`: The JWT for this session.
    * - `session`: The session object from your adapter.
    */
   session: (message: { session: Session; token: JWT }) => Awaitable<void>
@@ -427,15 +427,40 @@ export type InternalProvider<T = ProviderType> = (T extends "oauth"
   callbackUrl: string
 }
 
+/**
+ * Supported actions by Auth.js. Each action map to a REST API endpoint.
+ * Some actions have a `GET` and `POST` variant, depending on if the action
+ * changes the state of the server.
+ *
+ * - **`"callback"`**:
+ *   - **`GET`**: Handles the callback from an [OAuth provider](https://authjs.dev/reference/core/providers_oauth).
+ *   - **`POST`**: Handles the callback from a [Credentials provider](https://authjs.dev/reference/core/providers_credentials).
+ * - **`"csrf"`**: Returns the raw CSRF token, which is saved in a cookie (encrypted).
+ * It is used for CSRF protection, implementing the [double submit cookie](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie) technique.
+ * :::note
+ * Some frameworks have built-in CSRF protection and can therefore disable this action. In this case, the corresponding endpoint will return a 404 response. Read more at [`skipCSRFCheck`](https://authjs.dev/reference/core#skipcsrfcheck).
+ * _⚠ We don't recommend manually disabling CSRF protection, unless you know what you're doing._
+ * :::
+ * - **`"error"`**: Renders the built-in error page.
+ * - **`"providers"`**: Returns a client-safe list of all configured providers.
+ * - **`"session"`**: Returns the user's session if it exists, otherwise `null`.
+ * - **`"signin"`**:
+ *   - **`GET`**: Renders the built-in sign-in page.
+ *   - **`POST`**: Initiates the sign-in flow.
+ * - **`"signout"`**:
+ *   - **`GET`**: Renders the built-in sign-out page.
+ *   - **`POST`**: Initiates the sign-out flow. This will invalidate the user's session (deleting the cookie, and if there is a session in the database, it will be deleted as well).
+ * - **`"verify-request"`**: Renders the built-in verification request page.
+ */
 export type AuthAction =
+  | "callback"
+  | "csrf"
+  | "error"
   | "providers"
   | "session"
-  | "csrf"
   | "signin"
   | "signout"
-  | "callback"
   | "verify-request"
-  | "error"
 
 /** @internal */
 export interface RequestInternal {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -149,7 +149,7 @@ export interface Profile {
   nickname?: string | null
   preferred_username?: string | null
   profile?: string | null
-  picture?: string | null
+  picture?: string | null | any
   website?: string | null
   email?: string | null
   email_verified?: boolean | null

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -337,7 +337,7 @@ export type ErrorPageParam = "Configuration" | "AccessDenied" | "Verification"
 export type SignInPageErrorParam =
   | "Signin"
   | "OAuthSignin"
-  | "OAuthCallback"
+  | "OAuthCallbackError"
   | "OAuthCreateAccount"
   | "EmailCreateAccount"
   | "Callback"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,16 +116,58 @@ export interface Account extends Partial<OpenIDTokenEndpointResponse> {
   providerAccountId: string
   /** Provider's type for this account */
   type: ProviderType
-  /** id of the user this account belongs to */
+  /**
+   * id of the user this account belongs to
+   *
+   * @see https://authjs.dev/reference/adapters#user
+   */
   userId?: string
+  /**
+   * Calculated value based on {@link OAuth2TokenEndpointResponse.expires_in}.
+   *
+   * It is the absolute timestamp (in seconds) when the {@link OAuth2TokenEndpointResponse.access_token} expires.
+   *
+   * This value can be used for implementing token rotation together with {@link OAuth2TokenEndpointResponse.refresh_token}.
+   *
+   * @see https://authjs.dev/guides/basics/refresh-token-rotation#database-strategy
+   * @see https://www.rfc-editor.org/rfc/rfc6749#section-5.1
+   */
+  expires_at?: number
 }
 
-/** The OAuth profile returned from your provider */
+/**
+ * The user info returned from your OAuth provider.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+ */
 export interface Profile {
-  sub?: string | null
-  name?: string | null
-  email?: string | null
-  image?: string | null
+  sub: string
+  name?: string
+  given_name?: string
+  family_name?: string
+  middle_name?: string
+  nickname?: string
+  preferred_username?: string
+  profile?: string
+  picture?: string
+  website?: string
+  email?: string
+  email_verified?: boolean
+  gender?: string
+  birthdate?: string
+  zoneinfo?: string
+  locale?: string
+  phone_number?: string
+  updated_at?: number
+  address?: {
+    formatted?: string
+    street_address?: string
+    locality?: string
+    region?: string
+    postal_code?: string
+    country?: string
+  }
+  [claim: string]: unknown
 }
 
 /** [Documentation](https://authjs.dev/guides/basics/callbacks) */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -98,7 +98,15 @@ export interface Theme {
  */
 export type TokenSet = Partial<
   OAuth2TokenEndpointResponse | OpenIDTokenEndpointResponse
->
+> & {
+  /**
+   * Date of when the `access_token` expires in seconds.
+   * This value is calculated from the `expires_in` value.
+   *
+   * @see https://www.ietf.org/rfc/rfc6749.html#section-4.2.2
+   */
+  expires_at?: number
+}
 
 /**
  * Usually contains information about the provider being used

--- a/packages/frameworks-solid-start/src/client.ts
+++ b/packages/frameworks-solid-start/src/client.ts
@@ -51,7 +51,7 @@ export async function signIn<
       "Content-Type": "application/x-www-form-urlencoded",
       "X-Auth-Return-Redirect": "1",
     },
-    // @ts-expect-error -- ignore
+    // @ts-ignore
     body: new URLSearchParams({
       ...options,
       csrfToken,

--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -52,7 +52,7 @@ export async function signIn<
       "Content-Type": "application/x-www-form-urlencoded",
       "X-Auth-Return-Redirect": "1",
     },
-    // @ts-expect-error -- ignore
+    // @ts-ignore
     body: new URLSearchParams({
       ...options,
       csrfToken,

--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -150,7 +150,11 @@ async function getProfile({
   try {
     logger.debug("PROFILE_DATA", { OAuthProfile })
     const profile = await provider.profile(OAuthProfile, tokens)
-    profile.email = profile.email?.toLowerCase()
+    
+    if (typeof profile.email === 'string') {
+      profile.email = profile.email.toLowerCase()
+    }
+    
     if (!profile.id)
       throw new TypeError(
         `Profile id is missing in ${provider.name} OAuth profile response`

--- a/packages/next-auth/src/jwt/types.ts
+++ b/packages/next-auth/src/jwt/types.ts
@@ -21,7 +21,7 @@ export interface JWTEncodeParams {
   secret: string | Buffer
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge?: number
 }
@@ -42,7 +42,7 @@ export interface JWTOptions {
   secret: string
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge: number
   /** Override this method to control the NextAuth.js issued JWT encoding. */


### PR DESCRIPTION
## ☕️ Reasoning

Currently the OAuth callback attempts to convert the OAuth Profile email to lower case. However the optional chaining will convert any `null` values to `undefined`. This causes issues when trying to serialize the profile to JSON

> SerializableError: Error serializing `.session.user.email` returned from `getServerSideProps` in "/".
> Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.

I did find there was usage of nullish coalescing (`?? null`) at one point, but it was removed in a previous PR

https://github.com/nextauthjs/next-auth/pull/2411/files#diff-d97dc8c04f47dad7bd2300c6325704cd08796d179b105f9839324fee25a85db3R115

By checking the existence of an email string, it ensures other values aren't modified in any way

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
