### PR TITLE
docs: Remove --save from install command

### DIFF
--- a/packages/next-auth/README.md
+++ b/packages/next-auth/README.md
@@ -41,7 +41,7 @@ This is a monorepo containing the following packages / projects:
 ## Getting Started
 
 ```
-npm install --save next-auth
+npm install next-auth
 ```
 
 The easiest way to continue getting started, is to follow the [getting started](https://next-auth.js.org/getting-started/example) section in our docs.


### PR DESCRIPTION
`--save` is no longer needed on npm install.

`--save` hasn't been required since NPM v5, released in May 2017. Next.js 1.0 came out in October 2016. It would be reasonable to expect anyone implementing this package in 2023 is not on NPM v4 or earlier.
