### PR TITLE
fix: detect origin when `instanceof Request` check fails

### DIFF
--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -77,6 +77,11 @@ async function toInternalRequest(
       query,
     }
   }
+
+  const { headers } = req
+  const host = headers?.["x-forwarded-host"] ?? headers?.host
+  req.origin = detectOrigin(host, headers?.["x-forwarded-proto"])
+
   return req
 }
 


### PR DESCRIPTION
Fixes #7229

The `instanceof Request` should return true in Next.js, but it does not in some cases. This workaround is shipped for now to unblock the users. Ultimately this should be fixed upstream in Next.js