### PR TITLE
Update size of icons on load && on resize event

### DIFF
--- a/docs/src/components/ProviderMarquee.js
+++ b/docs/src/components/ProviderMarquee.js
@@ -1,3 +1,5 @@
+'use client'
+
 // eslint-disable-next-line no-use-before-define
 import * as React from "react"
 import Marquee, { Motion, randomIntFromInterval } from "react-marquee-slider"
@@ -19,23 +21,28 @@ const icons = [
   "/img/providers/twitter.svg",
 ]
 
-export default React.memo(function ProviderMarquee() {
-  let scale = 0.4
-
+function changeScale() {
   if (typeof window !== "undefined") {
     const width = window.outerWidth
-    if (width > 800) {
-      scale = 0.6
-    }
+    
+    if (width > 800)        return 0.6
+    else if (width > 1100)  return 0.7
+    else if (width > 1400)  return 0.8
+}
 
-    if (width > 1100) {
-      scale = 0.7
+export default React.memo(function ProviderMarquee() {
+  // Get initial scale on load
+  const [scale, setScale] = React.useState(changeScale)
+  
+  React.useEffect(() => {
+    // Account for window size change
+    function handleEvent() {
+      setScale(changeScale)
     }
-
-    if (width > 1400) {
-      scale = 0.8
-    }
-  }
+        
+    window.addEventListener('resize', handleEvent)
+    return () => window.removeEventListener('resize', handleEvent)
+  }, [])
 
   return (
     <div className={styles.fullWidth}>

--- a/docs/src/components/ProviderMarquee.js
+++ b/docs/src/components/ProviderMarquee.js
@@ -1,5 +1,3 @@
-'use client'
-
 // eslint-disable-next-line no-use-before-define
 import * as React from "react"
 import Marquee, { Motion, randomIntFromInterval } from "react-marquee-slider"


### PR DESCRIPTION
Added 'use client' since window object would only be defined on client side ( and using hooks ); Thought it'd be a cool feature to add :)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
The icons in the Marquee don't really change if window resizes; thought it'd be cool if it did
( This is my first PR: apologies if my explanation isn't as thorough )

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
