### PR TITLE
fix(adapter-mongodb): proper "or" in peerDependency

### DIFF
--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "mongodb": "^5 | ^4",
+    "mongodb": "^5 || ^4",
     "next-auth": "^4"
   },
   "devDependencies": {


### PR DESCRIPTION
I guess CI didn't complain when wrongly introducing this, due to the devDependency somehow "solving" it correctly. 

when installing the current version, npm complains:

```
npm WARN Could not resolve dependency:
npm WARN peer mongodb@"^5 | ^4" from @next-auth/mongodb-adapter@1.1.2
```

relates to: https://github.com/nextauthjs/next-auth/issues/7126