### PR TITLE
fix: consume nonce exactly once

### DIFF
--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -97,8 +97,6 @@ export async function handleOAuth(
 
   const codeVerifier = await checks.pkce.use(cookies, resCookies, options)
 
-  await checks.nonce.use(cookies, resCookies, options)
-
   let redirect_uri = provider.callbackUrl
   if (!options.isOnRedirectProxy && provider.redirectProxyUrl) {
     redirect_uri = provider.redirectProxyUrl

--- a/packages/core/src/lib/oauth/handle-state.ts
+++ b/packages/core/src/lib/oauth/handle-state.ts
@@ -8,7 +8,7 @@ import type { InternalOptions, RequestInternal } from "../../types.js"
  * When the authorization flow contains a state, we check if it's a redirect proxy
  * and if so, we return the random state and the original redirect URL.
  */
-export function handleProxyRedirect(
+export function handleState(
   query: RequestInternal["query"],
   provider: OAuthConfigInternal<any>,
   isOnRedirectProxy: InternalOptions["isOnRedirectProxy"]
@@ -16,18 +16,19 @@ export function handleProxyRedirect(
   let randomState: string | undefined
   let proxyRedirect: string | undefined
 
-  if (provider.redirectProxyUrl) {
-    if (!query?.state)
-      throw new InvalidCheck(
-        "Missing state in query, but required for redirect proxy"
-      )
-    const state = decodeState(query.state)
-    randomState = state?.random
-
-    if (isOnRedirectProxy) {
-      if (!state?.origin) return { randomState }
-      proxyRedirect = `${state.origin}?${new URLSearchParams(query)}`
-    }
+  if (provider.redirectProxyUrl && !query?.state) {
+    throw new InvalidCheck(
+      "Missing state in query, but required for redirect proxy"
+    )
   }
+
+  const state = decodeState(query?.state)
+  randomState = state?.random
+
+  if (isOnRedirectProxy) {
+    if (!state?.origin) return { randomState }
+    proxyRedirect = `${state.origin}?${new URLSearchParams(query)}`
+  }
+
   return { randomState, proxyRedirect }
 }

--- a/packages/core/src/lib/routes/callback.ts
+++ b/packages/core/src/lib/routes/callback.ts
@@ -1,7 +1,7 @@
 import { CallbackRouteError, Verification } from "../../errors.js"
 import { handleLogin } from "../callback-handler.js"
 import { handleOAuth } from "../oauth/callback.js"
-import { handleProxyRedirect } from "../oauth/proxy-redirect.js"
+import { handleState } from "../oauth/handle-state.js"
 import { createHash } from "../web.js"
 import { handleAuthorized } from "./shared.js"
 
@@ -44,7 +44,7 @@ export async function callback(params: {
 
   try {
     if (provider.type === "oauth" || provider.type === "oidc") {
-      const { proxyRedirect, randomState } = handleProxyRedirect(
+      const { proxyRedirect, randomState } = handleState(
         query,
         provider,
         options.isOnRedirectProxy


### PR DESCRIPTION
We should only get the nonce value from the cookies once, when the provider type is OIDC.

Related #7313