### PR TITLE
feat(ci): enable `pnpm` caching in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
       - name: Install dependencies
         run: pnpm install
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           node-version: 18
           cache: "pnpm"
-          cache-dependency-path: "pnpm-lock.yaml"
       - name: Install dependencies
         run: pnpm install
       - name: Run tests


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Set the `cache` and `cache-dependency-path` argument to enable caching to speed up CI times.