### PR TITLE
Fixed the broken link of the auth.js core documentation

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,4 +21,4 @@
 
 ---
 
-Check out the documentation at [authjs.dev](https://authjs.dev/reference/core/modules/main).
+Check out the documentation at [authjs.dev](https://authjs.dev/reference#core).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,4 +21,4 @@
 
 ---
 
-Check out the documentation at [authjs.dev](https://authjs.dev/reference#core).
+Check out the documentation at [authjs.dev](https://authjs.dev/reference/core).


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Issue found was the link on auth.js core readme to the documentation is broken. Fixed this issue by updating readme link to the "API Reference" page for the auth.js core and testing the link.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
