### PR TITLE
docs(providers): update default vk provider version and options link

### DIFF
--- a/docs/docs/providers/vk.md
+++ b/docs/docs/providers/vk.md
@@ -15,7 +15,7 @@ https://vk.com/apps?act=manage
 
 The **VK Provider** comes with a set of default options:
 
-- [VK Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/vk.js)
+- [VK Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/vk.ts)
 
 You can override any of the options to suit your own use case.
 
@@ -34,7 +34,7 @@ providers: [
 ```
 
 :::note
-By default the provider uses `5.126` version of the API. See https://vk.com/dev/versions for more info.
+By default the provider uses `5.131` version of the API. See https://vk.com/dev/versions for more info.
 :::
 
 If you want to use a different version, you can pass it to provider's options object:
@@ -42,7 +42,7 @@ If you want to use a different version, you can pass it to provider's options ob
 ```js
 // pages/api/auth/[...nextauth].js
 
-const apiVersion = "5.126"
+const apiVersion = "5.131"
 ...
 providers: [
   VkProvider({


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

By default VK provider uses `5.131` version now:
https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/vk.ts

Provider options link is not working. It changed to .ts extension.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
