### PR TITLE
fix(ts): support moduleResolution node16 and nodenext (#7351)

### DIFF
--- a/packages/core/src/providers/credentials.ts
+++ b/packages/core/src/providers/credentials.ts
@@ -1,6 +1,6 @@
 import type { CommonProviderOptions } from "./index.js"
 import type { Awaitable, User } from "../types.js"
-import type { JSXInternal } from "preact/src/jsx.js"
+import type { JSX } from "preact"
 
 /**
  * Besides providing type safety inside {@link CredentialsConfig.authorize}
@@ -8,7 +8,7 @@ import type { JSXInternal } from "preact/src/jsx.js"
  * on the default sign in page.
  */
 export interface CredentialInput
-  extends Partial<JSXInternal.IntrinsicElements["input"]> {
+  extends Partial<JSX.IntrinsicElements["input"]> {
   label?: string
 }
 


### PR DESCRIPTION
## ☕️ Reasoning

Support `moduleResolution` `node16` and `nodenext`

## 🧢 Checklist

I'm unable to build this project locally on my windows machine (build depends on `rm -f`). Since this is a single type import change I'm trusting the CI to run the tests.

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/7351

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
