### PR TITLE
docs: fix default maxAge formula

### DIFF
--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -190,7 +190,7 @@ export interface JWTEncodeParams<Payload = JWT> {
   /**
    * The maximum age of the Auth.js issued JWT in seconds.
    *
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge?: number
 }
@@ -213,7 +213,7 @@ export interface JWTOptions {
   /**
    * The maximum age of the Auth.js issued JWT in seconds.
    *
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge: number
   /** Override this method to control the Auth.js issued JWT encoding. */

--- a/packages/next-auth/src/jwt/types.ts
+++ b/packages/next-auth/src/jwt/types.ts
@@ -21,7 +21,7 @@ export interface JWTEncodeParams {
   secret: string | Buffer
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge?: number
 }
@@ -42,7 +42,7 @@ export interface JWTOptions {
   secret: string
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge: number
   /** Override this method to control the NextAuth.js issued JWT encoding. */


### PR DESCRIPTION
## ☕️ Reasoning

The formula provided in the documentation for `maxAge` is incorrect.

## 🧢 Checklist

- [x] Documentation
- [x] Ready to be merged
