### PR TITLE
chore: merge changes back to v4

### DIFF
--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.5",
-    "@types/react": "^18.0.15",
+    "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.6",
     "fake-smtp-server": "^0.8.0",
     "pg": "^8.7.3",

--- a/apps/example-nextjs/package.json
+++ b/apps/example-nextjs/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^17",
-    "@types/react": "^18.0.15",
+    "@types/react": "^18.0.37",
     "typescript": "^4"
   }
 }

--- a/packages/next-auth/README.md
+++ b/packages/next-auth/README.md
@@ -204,8 +204,8 @@ We're happy to announce we've recently created an [OpenCollective](https://openc
         <sub>🥉 Bronze Financial Sponsor</sub>
       </td>
       <td align="center" valign="top">
-        <a href="https://clerk.dev" target="_blank">
-          <img width="128px" src="https://avatars.githubusercontent.com/u/49538330?s=200&v=4" alt="Prisma Logo" />
+        <a href="https://clerk.com" target="_blank">
+          <img width="128px" src="https://avatars.githubusercontent.com/u/49538330?s=200&v=4" alt="Clerk Logo" />
         </a><br />
         <div>Clerk</div><br />
         <sub>🥉 Bronze Financial Sponsor</sub>

--- a/packages/next-auth/README.md
+++ b/packages/next-auth/README.md
@@ -41,7 +41,7 @@ This is a monorepo containing the following packages / projects:
 ## Getting Started
 
 ```
-npm install --save next-auth
+npm install next-auth
 ```
 
 The easiest way to continue getting started, is to follow the [getting started](https://next-auth.js.org/getting-started/example) section in our docs.

--- a/packages/next-auth/README.md
+++ b/packages/next-auth/README.md
@@ -247,7 +247,7 @@ We're happy to announce we've recently created an [OpenCollective](https://openc
 ## Contributing
 
 We're open to all community contributions! If you'd like to contribute in any way, please first read
-our [Contributing Guide](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md).
+our [Contributing Guide](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -107,7 +107,7 @@
     "@types/node": "^17.0.42",
     "@types/nodemailer": "^6.4.4",
     "@types/oauth": "^0.9.1",
-    "@types/react": "^18.0.15",
+    "@types/react": "18.0.37",
     "@types/react-dom": "^18.0.6",
     "autoprefixer": "^10.4.7",
     "babel-plugin-jsx-pragmatic": "^1.0.2",

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "description": "Authentication for Next.js",
   "homepage": "https://next-auth.js.org",
   "repository": "https://github.com/nextauthjs/next-auth.git",

--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -77,6 +77,11 @@ async function toInternalRequest(
       query,
     }
   }
+
+  const { headers } = req
+  const host = headers?.["x-forwarded-host"] ?? headers?.host
+  req.origin = detectOrigin(host, headers?.["x-forwarded-proto"])
+
   return req
 }
 

--- a/packages/next-auth/src/jwt/types.ts
+++ b/packages/next-auth/src/jwt/types.ts
@@ -21,7 +21,7 @@ export interface JWTEncodeParams {
   secret: string | Buffer
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge?: number
 }
@@ -42,7 +42,7 @@ export interface JWTOptions {
   secret: string
   /**
    * The maximum age of the NextAuth.js issued JWT in seconds.
-   * @default 30 * 24 * 30 * 60 // 30 days
+   * @default 30 * 24 * 60 * 60 // 30 days
    */
   maxAge: number
   /** Override this method to control the NextAuth.js issued JWT encoding. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
       '@prisma/client': ^3
       '@supabase/supabase-js': ^2.0.5
       '@types/jsonwebtoken': ^8.5.5
-      '@types/react': ^18.0.15
+      '@types/react': ^18.0.37
       '@types/react-dom': ^18.0.6
       fake-smtp-server: ^0.8.0
       faunadb: ^4
@@ -88,7 +88,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@types/jsonwebtoken': 8.5.8
-      '@types/react': 18.0.15
+      '@types/react': 18.2.0
       '@types/react-dom': 18.0.6
       fake-smtp-server: 0.8.0
       pg: 8.7.3
@@ -462,7 +462,7 @@ importers:
       '@types/node': ^17.0.42
       '@types/nodemailer': ^6.4.4
       '@types/oauth': ^0.9.1
-      '@types/react': ^18.0.15
+      '@types/react': 18.0.37
       '@types/react-dom': ^18.0.6
       autoprefixer: ^10.4.7
       babel-plugin-jsx-pragmatic: ^1.0.2
@@ -512,13 +512,13 @@ importers:
       '@testing-library/dom': 8.14.0
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 13.3.0_biqbaboplfbrettd7655fr4n2y
-      '@testing-library/react-hooks': 8.0.1_bb2bxwco6ptpubzwpazr52qf6i
+      '@testing-library/react-hooks': 8.0.1_jf7puk66b2eiqxne3oe3xlxkou
       '@testing-library/user-event': 14.2.1_ihvo3xlg2d6kwqju3os3zitn3y
       '@types/jest': 28.1.3
       '@types/node': 17.0.45
       '@types/nodemailer': 6.4.4
       '@types/oauth': 0.9.1
-      '@types/react': 18.0.15
+      '@types/react': 18.0.37
       '@types/react-dom': 18.0.6
       autoprefixer: 10.4.7_postcss@8.4.14
       babel-plugin-jsx-pragmatic: 1.0.2
@@ -5348,7 +5348,7 @@ packages:
       '@docusaurus/react-loadable': 5.5.2_react@18.2.0
       '@docusaurus/types': 2.1.0_biqbaboplfbrettd7655fr4n2y
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.2.0
       '@types/react-router-config': 5.0.6
       '@types/react-router-dom': 5.3.3
       react: 18.2.0
@@ -5647,7 +5647,7 @@ packages:
     peerDependencies:
       react: '*'
     dependencies:
-      '@types/react': 18.0.26
+      '@types/react': 18.2.0
       prop-types: 15.8.1
       react: 18.2.0
     dev: true
@@ -5716,7 +5716,7 @@ packages:
       '@docusaurus/plugin-content-pages': 2.1.0_biqbaboplfbrettd7655fr4n2y
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.2.0
       '@types/react-router-config': 5.0.6
       clsx: 1.2.1
       parse-numeric-range: 1.3.0
@@ -5801,7 +5801,7 @@ packages:
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.2.0
       commander: 5.1.0
       joi: 17.6.0
       react: 18.2.0
@@ -8237,7 +8237,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react-hooks/8.0.1_bb2bxwco6ptpubzwpazr52qf6i:
+  /@testing-library/react-hooks/8.0.1_jf7puk66b2eiqxne3oe3xlxkou:
     resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -8254,7 +8254,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.20.13
-      '@types/react': 18.0.15
+      '@types/react': 18.0.37
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-error-boundary: 3.1.4_react@18.2.0
@@ -8782,14 +8782,14 @@ packages:
   /@types/react-dom/18.0.6:
     resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
     dependencies:
-      '@types/react': 18.0.26
+      '@types/react': 18.2.0
     dev: true
 
   /@types/react-router-config/5.0.6:
     resolution: {integrity: sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.26
+      '@types/react': 18.2.0
       '@types/react-router': 5.1.18
     dev: true
 
@@ -8797,7 +8797,7 @@ packages:
     resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.26
+      '@types/react': 18.2.0
       '@types/react-router': 5.1.18
     dev: true
 
@@ -8805,19 +8805,19 @@ packages:
     resolution: {integrity: sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.26
+      '@types/react': 18.2.0
     dev: true
 
-  /@types/react/18.0.15:
-    resolution: {integrity: sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==}
+  /@types/react/18.0.37:
+    resolution: {integrity: sha512-4yaZZtkRN3ZIQD3KSEwkfcik8s0SWV+82dlJot1AbGYHCzJkWP3ENBY6wYeDRmKZ6HkrgoGAmR2HqdwYGp6OEw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.0
     dev: true
 
-  /@types/react/18.0.26:
-    resolution: {integrity: sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==}
+  /@types/react/18.2.0:
+    resolution: {integrity: sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -9508,8 +9508,10 @@ packages:
       indent-string: 4.0.0
     dev: true
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -13785,7 +13787,7 @@ packages:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.0.9
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       body-parser: 1.20.0
       content-type: 1.0.4
       deep-freeze: 0.0.1
@@ -22295,7 +22297,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: true
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/31528554/235834863-4148f4f4-9556-4b74-9524-a4640b319ea7.png)

Since we're keeping `next-auth` package name and bump to v5, we will re-use the v4 branch.
In this PR, I cherry picked the commit to `packages/next-auth` folder in `main` back to `v4`