### PR TITLE
Doc: Sending a Magic Link to Only Existing Users

### DIFF
--- a/docs/docs/configuration/callbacks.md
+++ b/docs/docs/configuration/callbacks.md
@@ -62,6 +62,27 @@ callbacks: {
 
   You can check for the `verificationRequest` property to avoid sending emails to addresses or domains on a blocklist (or to only explicitly generate them for email address in an allow list).
 
+  You can ensure that only existing users are sent a magic login link. You will need to grab the email the user entered and check your database to see if the email already exists in the User collection in your database. If it exists, send the user a magic link but otherwise, you can send the user to another page, such as "/register". 
+
+  ```js title="pages/api/auth/[...nextauth].js"
+  import User from "../../../models/User"; 
+  import db from "../../../utils/db"; 
+  ...
+  callbacks: {
+    async signIn({ user, account, email }) { 
+      await db.connect(); 
+      const userExists = await User.findOne({ 
+        email: user.email,  //the user object has an email property, which contains the email the user entered.
+      });
+      if (userExists) {
+        return true;   //if the email exists in the User collection, email them a magic login link
+      } else {
+        return "/register"; 
+      }
+    },
+   ...
+  ``` 
+  
 * When using the **Credentials Provider** the `user` object is the response returned from the `authorize` callback and the `profile` object is the raw body of the `HTTP POST` submission.
 
 :::note


### PR DESCRIPTION
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

Request to add to the documentation for the Sign In Callback to show how to send magic links to only existing users in a database.

Although this answer helped me figure out how to do this, I would rather add it to the documentation so its clear how to accomplish this for future next-auth users. https://github.com/nextauthjs/next-auth/issues/1229

Why its important: If new users can sign in with the magic link, this can lead to deformed user objects in the database. Instead, this code makes it possible to check your database and force new users to go to the registration page if they do not exist in the database.

It would edit this doc:
https://github.com/nextauthjs/next-auth/edit/v4/docs/docs/configuration/callbacks.md

![image](https://user-images.githubusercontent.com/101692334/236669484-704408cf-e618-4a3f-9f16-1486617378fb.png)



## 🧢 Checklist

- [X ] Documentation
- [ ] Tests (N/A)
- [X ] Ready to be merged

## 🎫 Affected issues

This was an issue about the same topic: https://github.com/nextauthjs/next-auth/issues/1229 Although it was closed, I'd rather add to the documentation to make it clear to new nextauth users how to accomplish this.

Fixes: It will close this issue I opened: https://github.com/nextauthjs/next-auth/issues/7401

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
