### PR TITLE
fix(server actions): origin is under headers object

### DIFF
--- a/packages/next-auth/src/core/index.ts
+++ b/packages/next-auth/src/core/index.ts
@@ -140,7 +140,7 @@ export async function AuthHandler<
     authOptions,
     action,
     providerId,
-    origin: req.origin,
+    origin: req.headers.origin,
     callbackUrl: req.body?.callbackUrl ?? req.query?.callbackUrl,
     csrfToken: req.body?.csrfToken,
     cookies: req.cookies,

--- a/packages/next-auth/src/core/lib/assert.ts
+++ b/packages/next-auth/src/core/lib/assert.ts
@@ -48,7 +48,7 @@ export function assertConfig(params: {
   const warnings: WarningCode[] = []
 
   if (!warned) {
-    if (!req.origin) warnings.push("NEXTAUTH_URL")
+    if (!req.headers.origin) warnings.push("NEXTAUTH_URL")
 
     // TODO: Make this throw an error in next major. This will also get rid of `NODE_ENV`
     if (!options.secret && process.env.NODE_ENV !== "production")
@@ -70,7 +70,7 @@ export function assertConfig(params: {
 
   const callbackUrlParam = req.query?.callbackUrl as string | undefined
 
-  const url = parseUrl(req.origin)
+  const url = parseUrl(req.headers.origin)
 
   if (callbackUrlParam && !isValidHttpUrl(callbackUrlParam, url.base)) {
     return new InvalidCallbackUrl(


### PR DESCRIPTION
## ☕️ Reasoning

Testing out server actions in Next 13.4 I've noticed that the `experimental` version of next auth complains about `NEXTAUTH_URL` not being set. The result is that upon sign in I'm always redirected to localhost:3000.

This PR pulls the origin from the headers rather than the req object as it is not defined there.