### PR TITLE
Update email.md

### DIFF
--- a/docs/docs/providers/email.md
+++ b/docs/docs/providers/email.md
@@ -252,3 +252,27 @@ By default, NextAuth.js will normalize the email address. It treats values as ca
 :::warning
 Always make sure this returns a single e-mail address, even if multiple ones were passed in.
 :::
+
+
+## Sending Magic Links To Existing Users
+
+You can ensure that only existing users are sent a magic login link. You will need to grab the email the user entered and check your database to see if the email already exists in the "User" collection in your database. If it exists, it will send the user a magic link but otherwise, you can send the user to another page, such as "/register". 
+
+  ```js title="pages/api/auth/[...nextauth].js"
+  import User from "../../../models/User"; 
+  import db from "../../../utils/db"; 
+  ...
+  callbacks: {
+    async signIn({ user, account, email }) { 
+      await db.connect(); 
+      const userExists = await User.findOne({ 
+        email: user.email,  //the user object has an email property, which contains the email the user entered.
+      });
+      if (userExists) {
+        return true;   //if the email exists in the User collection, email them a magic login link
+      } else {
+        return "/register"; 
+      }
+    },
+   ...
+  ``` 


### PR DESCRIPTION
Request to add to the email provider documentation to explain how to send magic links to existing users.

Although this answer helped me figure out how to do this, I would rather add it to the documentation so its clear how to accomplish this for future next-auth users. https://github.com/nextauthjs/next-auth/issues/1229

Why its important: If new users can sign in with the magic link, this can lead to deformed user objects in the database. Instead, this code makes it possible to check your database and force new users to go to the registration page if they do not exist in the database.

I originally submitted this commit to the callback doc, but I agree with ndom91's comment that it fits better in the email provider documentation instead. Link to the old pull request: https://github.com/nextauthjs/next-auth/pull/7470

It would edit this doc:
https://next-auth.js.org/providers/email

Visual of what the commit would look like:
![image](https://github.com/nextauthjs/next-auth/assets/101692334/9152aa7a-91f3-408e-a6d9-5e533f7ad704)

## 🧢 Checklist

- [X ] Documentation
- [ ] Tests
- [X ] Ready to be merged

## 🎫 Affected issues
This was an issue about the same topic: https://github.com/nextauthjs/next-auth/issues/1229 Although it was closed, I'd rather add to the documentation to make it clear to new nextauth users how to accomplish this.

Fixes: It will close this issue I opened: https://github.com/nextauthjs/next-auth/issues/7401

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
