### PR TITLE
Fix adapter card text color on hover when on dark mode

### DIFF
--- a/docs/src/css/adapters.css
+++ b/docs/src/css/adapters.css
@@ -29,6 +29,7 @@ html[data-theme="dark"] .adapter-card {
   color: #f5f5f5;
 }
 
+html[data-theme="dark"] .adapter-card:hover,
 .adapter-card:hover {
   text-decoration: none;
   color: black;


### PR DESCRIPTION
## ☕️ Reasoning
on [Database Adapters](https://authjs.dev/reference/adapters) page, if a user is using dark mode and hovers over the cards, they cannot see the card title because of unhandled card color on hover.

![image](https://github.com/nextauthjs/next-auth/assets/13068999/4016fc96-536a-4154-beda-054fa6bdee3e)


## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues
N/A
