### PR TITLE
Fix `signIn()` not respecting `{ redirect: true }`

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -63,7 +63,7 @@ export async function signIn<
   const data = await res.clone().json()
   const error = new URL(data.url).searchParams.get("error")
 
-  if ((redirect && !error) || (!isSupportingReturn && !error)) {
+  if (redirect || !isSupportingReturn) {
     // TODO: Do not redirect for Credentials and Email providers by default in next major
     window.location.href = data.url ?? callbackUrl
     // If url contains a hash, the browser does not reload the page. We reload manually

--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -63,7 +63,7 @@ export async function signIn<
   const data = await res.clone().json()
   const error = new URL(data.url).searchParams.get("error")
 
-  if (redirect || !isSupportingReturn || !error) {
+  if ((redirect && !error) || (!isSupportingReturn && !error)) {
     // TODO: Do not redirect for Credentials and Email providers by default in next major
     window.location.href = data.url ?? callbackUrl
     // If url contains a hash, the browser does not reload the page. We reload manually


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
SvelteKit: When specifying `{ redirect: false }` during `signIn()`, the site still redirects.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: [#7670](https://github.com/nextauthjs/next-auth/issues/7670)

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
