### PR TITLE
feat: introduce `@auth/xata-adapter`

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_bug_adapter.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_adapter.yml
@@ -34,7 +34,7 @@ body:
         - "@next-auth/supabase-adapter"
         - "@auth/typeorm-adapter"
         - "@auth/upstash-redis-adapter"
-        - "@next-auth/xata-adapter"
+        - "@auth/xata-adapter"
     validations:
       required: true
   - type: textarea

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -40,4 +40,4 @@ upstash-redis:
   - "@auth/upstash-redis-adapter"
 
 xata:
-  - "@next-auth/xata-adapter"
+  - "@auth/xata-adapter"

--- a/packages/adapter-xata/README.md
+++ b/packages/adapter-xata/README.md
@@ -8,14 +8,14 @@
   </a>
   <h3 align="center"><b>Xata Adapter</b> - NextAuth.js / Auth.js</a></h3>
   <p align="center" style="align: center;">
-    <a href="https://npm.im/@next-auth/xata-adapter">
+    <a href="https://npm.im/@auth/xata-adapter">
       <img src="https://img.shields.io/badge/TypeScript-blue?style=flat-square" alt="TypeScript" />
     </a>
-    <a href="https://npm.im/@next-auth/xata-adapter">
-      <img alt="npm" src="https://img.shields.io/npm/v/@next-auth/xata-adapter?color=green&label=@next-auth/xata-adapter&style=flat-square">
+    <a href="https://npm.im/@auth/xata-adapter">
+      <img alt="npm" src="https://img.shields.io/npm/v/@auth/xata-adapter?color=green&label=@auth/xata-adapter&style=flat-square">
     </a>
-    <a href="https://www.npmtrends.com/@next-auth/xata-adapter">
-      <img src="https://img.shields.io/npm/dm/@next-auth/xata-adapter?label=%20downloads&style=flat-square" alt="Downloads" />
+    <a href="https://www.npmtrends.com/@auth/xata-adapter">
+      <img src="https://img.shields.io/npm/dm/@auth/xata-adapter?label=%20downloads&style=flat-square" alt="Downloads" />
     </a>
     <a href="https://github.com/nextauthjs/next-auth/stargazers">
       <img src="https://img.shields.io/github/stars/nextauthjs/next-auth?style=flat-square" alt="Github Stars" />

--- a/packages/adapter-xata/package.json
+++ b/packages/adapter-xata/package.json
@@ -1,14 +1,26 @@
 {
-  "name": "@next-auth/xata-adapter",
-  "version": "0.2.2",
-  "description": "Xata adapter for next-auth.",
+  "name": "@auth/xata-adapter",
+  "version": "0.0.0",
+  "description": "Xata adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",
   "bugs": {
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },
   "author": "Tejas Kumar",
-  "main": "dist/index.js",
+  "type": "module",
+  "types": "./index.d.ts",
+  "files": [
+    "*.js",
+    "*.d.ts*",
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
+  },
   "license": "ISC",
   "keywords": [
     "next-auth",
@@ -24,19 +36,16 @@
     "build": "tsc",
     "test": "jest"
   },
-  "files": [
-    "README.md",
-    "dist"
-  ],
+  "dependencies": {
+    "@auth/core": "workspace:*"
+  },
   "peerDependencies": {
-    "@xata.io/client": ">=0.13.0",
-    "next-auth": "^4"
+    "@xata.io/client": ">=0.13.0"
   },
   "devDependencies": {
     "@next-auth/adapter-test": "workspace:^0.0.0",
     "@next-auth/tsconfig": "workspace:^0.0.0",
     "jest": "^27.4.3",
-    "next-auth": "workspace:*",
     "@xata.io/client": "^0.13.0",
     "typescript": "^4.7.4"
   },

--- a/packages/adapter-xata/src/index.ts
+++ b/packages/adapter-xata/src/index.ts
@@ -10,7 +10,7 @@
  *
  * ```bash npm2yarn2pnpm
  * # Install Auth.js and the Xata adapter
- * npm install next-auth @next-auth/xata-adapter
+ * npm install @auth/xata-adapter
  *
  * # Install the Xata CLI globally if you don't already have it
  * npm install --location=global @xata.io/cli
@@ -19,9 +19,9 @@
  * xata auth login
  * ```
  *
- * @module @next-auth/xata-adapter
+ * @module @auth/xata-adapter
  */
-import type { Adapter } from "next-auth/adapters"
+import type { Adapter } from "@auth/core/adapters"
 
 import type { XataClient } from "./xata"
 
@@ -220,7 +220,7 @@ import type { XataClient } from "./xata"
  * ```diff
  * import NextAuth from "next-auth"
  * import GoogleProvider from "next-auth/providers/google"
- * +import { XataAdapter } from "@next-auth/xata-adapter"
+ * +import { XataAdapter } from "@auth/xata-adapter"
  * +import { XataClient } from "../../../xata" // or wherever you've chosen to create the client
  *
  * +const client = new XataClient()

--- a/packages/adapter-xata/tsconfig.json
+++ b/packages/adapter-xata/tsconfig.json
@@ -1,9 +1,25 @@
 {
-  "extends": "@next-auth/tsconfig/tsconfig.adapters.json",
+  "extends": "@next-auth/tsconfig/tsconfig.base.json",
   "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": ".",
+    "isolatedModules": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": ".",
     "rootDir": "src",
-    "outDir": "dist"
+    "skipDefaultLibCheck": true,
+    "strictNullChecks": true,
+    "stripInternal": true,
+    "declarationMap": true,
+    "declaration": true
   },
-  "include": ["."],
-  "exclude": ["tests", "dist", "jest.config.js"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "*.js",
+    "*.d.ts",
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,18 +519,19 @@ importers:
 
   packages/adapter-xata:
     specifiers:
+      '@auth/core': workspace:*
       '@next-auth/adapter-test': workspace:^0.0.0
       '@next-auth/tsconfig': workspace:^0.0.0
       '@xata.io/client': ^0.13.0
       jest: ^27.4.3
-      next-auth: workspace:*
       typescript: ^4.7.4
+    dependencies:
+      '@auth/core': link:../core
     devDependencies:
       '@next-auth/adapter-test': link:../adapter-test
       '@next-auth/tsconfig': link:../tsconfig
       '@xata.io/client': 0.13.4_typescript@4.7.4
       jest: 27.5.1
-      next-auth: link:../next-auth
       typescript: 4.7.4
 
   packages/core:

--- a/turbo.json
+++ b/turbo.json
@@ -67,7 +67,7 @@
         "@next-auth/supabase-adapter#build",
         "@auth/typeorm-adapter#build",
         "@auth/upstash-redis-adapter#build",
-        "@next-auth/xata-adapter#build",
+        "@auth/xata-adapter#build",
         "^build",
         "next-auth#build"
       ],
@@ -90,7 +90,7 @@
         "@next-auth/supabase-adapter#build",
         "@auth/typeorm-adapter#build",
         "@auth/upstash-redis-adapter#build",
-        "@next-auth/xata-adapter#build",
+        "@auth/xata-adapter#build",
         "^build",
         "next-auth#build"
       ],


### PR DESCRIPTION
Database adapters are not dependent on Next.js features, so it makes sense to republish them under the `@auth/*` scope.

This PR is part of a series to convert adapters, using `@auth/core` for types.

If you are coming from the previous adapter, change your `package.json`:

```diff
-  "@next-auth/xata-adapter": "0.0.0",
+  "@auth/xata-adapter": "0.0.0",
```

And run `npm install`, `yarn install` or `pnpm install` respectively.

**Note:** This packages is published as ESM-only