### PR TITLE
fix(adapters): Add .js file extension to relative imports

### DIFF
--- a/packages/adapter-typeorm/src/index.ts
+++ b/packages/adapter-typeorm/src/index.ts
@@ -21,8 +21,8 @@ import type {
   AdapterSession,
 } from "@auth/core/adapters"
 import { DataSourceOptions, DataSource, EntityManager } from "typeorm"
-import * as defaultEntities from "./entities"
-import { parseDataSourceConfig, updateConnectionEntities } from "./utils"
+import * as defaultEntities from "./entities.js"
+import { parseDataSourceConfig, updateConnectionEntities } from "./utils.js"
 
 export const entities = defaultEntities
 

--- a/packages/adapter-typeorm/src/utils.ts
+++ b/packages/adapter-typeorm/src/utils.ts
@@ -1,5 +1,5 @@
 import type { DataSource, DataSourceOptions } from "typeorm"
-import * as defaultEntities from "./entities"
+import * as defaultEntities from "./entities.js"
 
 /** Ensure configOrString is normalized to an object. */
 export function parseDataSourceConfig(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


## ☕️ Reasoning

Added .js file extension to the relative imports so that node doesn't fail to resolve the internal relative imports in this module (ex: from index.js to ./entities). 

Note that:
1. Node requires file extension to imports in ESM (https://nodejs.org/api/esm.html#mandatory-file-extensions).
2. Typescript does not add/change the file extension of imports when transpiling to js.
3. The other code in this repository is written adding .js extension to relative imports, so this is the convention to use (See for example https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/index.ts).

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
