### PR TITLE
chore: remove extra 'if' in comment

### DIFF
--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -173,7 +173,7 @@ export type WithAuthArgs =
 
 /**
  * Middleware that checks if the user is authenticated/authorized.
- * If if they aren't, they will be redirected to the login page.
+ * If they aren't, they will be redirected to the login page.
  * Otherwise, continue.
  *
  * @example


### PR DESCRIPTION
Removed the extra 'if' word from the comment of function `withAuth ` to correct a typo and improve the accuracy of the documentation.