### PR TITLE
Fix: session deletion throws an error, if user has already been deleted

### DIFF
--- a/packages/core/src/lib/callback-handler.ts
+++ b/packages/core/src/lib/callback-handler.ts
@@ -98,7 +98,11 @@ export async function handleLogin(
         // Delete existing session if they are currently signed in as another user.
         // This will switch user accounts for the session in cases where the user was
         // already logged in with a different account.
-        await deleteSession(sessionToken)
+        // Catch any errors in case the other user is already deleted in the database
+        // and therefore the session does not exist anymore.
+        try {
+          await deleteSession(sessionToken)
+        } catch { }
       }
 
       // Update emailVerified property on the user object


### PR DESCRIPTION
# Scenario
A user closes his account by deleting himself from the database and all his sessions with it.
Another user in the same browser tries to log in via email.
The client will send the old session token to the server, who is correctly identifying it as the wrong one and wants to delete it:
https://github.com/nextauthjs/next-auth/blob/a79774f6e890b492ae30201f24b3f7024d0d7c9d/packages/core/src/lib/callback-handler.ts#L95-L102
This works well in cases where the first user just logs out, but when the first user deletes his account, the function `deleteSession(...)` will fail on the login attempt of the second user.  

**Thank you so much for creating this awesome library, it is really a joy to work with 😀**
  
## ☕️ Reasoning

My proposed solution is a simple `try catch` block around that statement.

## 🧢 Checklist

- [ ] Documentation (not needed)
- [ ] Tests (not needed)
- [x] Ready to be merged

## 🎫 Affected issues

A similar issue is this one #4495.
Although the issue is closed, the proposed solution (deleting the user via the adapter) does not work in my case.
It still keeps the session token on the client side and throws this error.

Fixes: #4495 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
