### PR TITLE
fix(EmailProvider): proper required fields and allow all nodemailer types

### DIFF
--- a/docs/docs/configuration/providers/email.md
+++ b/docs/docs/configuration/providers/email.md
@@ -44,7 +44,7 @@ The email provider requires a database, it cannot be used without one.
 |           id            |                             Unique ID for the provider                              |             `string`             |    No    |
 |          name           |                          Descriptive name for the provider                          |             `string`             |    No    |
 |          type           |                       Type of provider, in this case `email`                        |            `"email"`             |    No    |
-|         server          |                     Path or object pointing to the email server                     |       `string` or `Object`       |   Yes    |
+|         server          |                     Path or object pointing to the email server                     |       `string` or `Object`       |   No    |
 | sendVerificationRequest |     Callback to execute to send a verification request, default uses nodemailer     | `(params) => Promise<undefined>` |    No    |
 |          from           |   The email address from which emails are sent, default: "<no-reply@example.com>"   |             `string`             |    No    |
 |         maxAge          | How long until the e-mail can be used to log the user in seconds. Defaults to 1 day |             `number`             |    No    |

--- a/docs/docs/configuration/providers/email.md
+++ b/docs/docs/configuration/providers/email.md
@@ -41,10 +41,10 @@ The email provider requires a database, it cannot be used without one.
 
 |          Name           |                                     Description                                     |               Type               | Required |
 | :---------------------: | :---------------------------------------------------------------------------------: | :------------------------------: | :------: |
-|           id            |                             Unique ID for the provider                              |             `string`             |   Yes    |
-|          name           |                          Descriptive name for the provider                          |             `string`             |   Yes    |
-|          type           |                       Type of provider, in this case `email`                        |            `"email"`             |   Yes    |
+|           id            |                             Unique ID for the provider                              |             `string`             |    No    |
+|          name           |                          Descriptive name for the provider                          |             `string`             |    No    |
+|          type           |                       Type of provider, in this case `email`                        |            `"email"`             |    No    |
 |         server          |                     Path or object pointing to the email server                     |       `string` or `Object`       |   Yes    |
-| sendVerificationRequest |               Callback to execute when a verification request is sent               | `(params) => Promise<undefined>` |   Yes    |
+| sendVerificationRequest |     Callback to execute to send a verification request, default uses nodemailer     | `(params) => Promise<undefined>` |    No    |
 |          from           |   The email address from which emails are sent, default: "<no-reply@example.com>"   |             `string`             |    No    |
 |         maxAge          | How long until the e-mail can be used to log the user in seconds. Defaults to 1 day |             `number`             |    No    |

--- a/docs/docs/providers/email.md
+++ b/docs/docs/providers/email.md
@@ -36,7 +36,7 @@ You can override any of the options to suit your own use case.
 2. You will need an SMTP account; ideally for one of the [services known to work with `nodemailer`](https://community.nodemailer.com/2-0-0-beta/setup-smtp/well-known-services/).
 3. There are two ways to configure the SMTP server connection.
 
-You can either use a connection string or a `nodemailer` configuration object.
+You can either use a connection string or a `nodemailer` configuration object or transport.
 
 2.1 **Using a connection string**
 

--- a/packages/next-auth/src/providers/email.ts
+++ b/packages/next-auth/src/providers/email.ts
@@ -22,7 +22,7 @@ export interface SendVerificationRequestParams {
 }
 
 export interface EmailUserConfig {
-  server: AllTransportOptions
+  server?: AllTransportOptions
   type?: "email"
   /** @default "NextAuth <no-reply@example.com>" */
   from?: string

--- a/packages/next-auth/src/providers/email.ts
+++ b/packages/next-auth/src/providers/email.ts
@@ -1,9 +1,16 @@
-import { createTransport } from "nodemailer"
-
-import type { CommonProviderOptions } from "."
-import type { Options as SMTPTransportOptions } from "nodemailer/lib/smtp-transport"
+import { Transport, TransportOptions, createTransport } from "nodemailer"
+import * as JSONTransport from "nodemailer/lib/json-transport.js"
+import * as SendmailTransport from "nodemailer/lib/sendmail-transport/index.js"
+import * as SESTransport from "nodemailer/lib/ses-transport.js"
+import * as SMTPPool from "nodemailer/lib/smtp-pool/index.js"
+import * as SMTPTransport from "nodemailer/lib/smtp-transport.js"
+import * as StreamTransport from "nodemailer/lib/stream-transport.js"
 import type { Awaitable } from ".."
+import type { CommonProviderOptions } from "."
 import type { Theme } from "../core/types"
+
+// TODO: Make use of https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html for the string
+type AllTransportOptions = string | SMTPTransport | SMTPTransport.Options | SMTPPool | SMTPPool.Options | SendmailTransport | SendmailTransport.Options | StreamTransport | StreamTransport.Options | JSONTransport | JSONTransport.Options | SESTransport | SESTransport.Options | Transport<any> | TransportOptions
 
 export interface SendVerificationRequestParams {
   identifier: string
@@ -14,10 +21,9 @@ export interface SendVerificationRequestParams {
   theme: Theme
 }
 
-export interface EmailConfig extends CommonProviderOptions {
-  type: "email"
-  // TODO: Make use of https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
-  server: string | SMTPTransportOptions
+export interface EmailUserConfig {
+  server: AllTransportOptions
+  type?: "email"
   /** @default "NextAuth <no-reply@example.com>" */
   from?: string
   /**
@@ -27,7 +33,7 @@ export interface EmailConfig extends CommonProviderOptions {
    */
   maxAge?: number
   /** [Documentation](https://next-auth.js.org/providers/email#customizing-emails) */
-  sendVerificationRequest: (
+  sendVerificationRequest?: (
     params: SendVerificationRequestParams
   ) => Awaitable<void>
   /**
@@ -61,10 +67,31 @@ export interface EmailConfig extends CommonProviderOptions {
    * [Documentation](https://next-auth.js.org/providers/email#normalizing-the-e-mail-address) | [RFC 2821](https://tools.ietf.org/html/rfc2821) | [Email syntax](https://en.wikipedia.org/wiki/Email_address#Syntax)
    */
   normalizeIdentifier?: (identifier: string) => string
-  options: EmailUserConfig
 }
 
-export type EmailUserConfig = Partial<Omit<EmailConfig, "options">>
+export interface EmailConfig extends CommonProviderOptions {
+  // defaults
+  id: "email"
+  type: "email"
+  name: "Email"
+  server: AllTransportOptions
+  from: string
+  maxAge: number
+  sendVerificationRequest: (
+    params: SendVerificationRequestParams
+  ) => Awaitable<void>
+
+  /**
+   * This is copied into EmailConfig in parseProviders() don't use elsewhere
+   */
+  options: EmailUserConfig
+
+  // user options
+  // TODO figure out a better way than copying from EmailUserConfig
+  secret?: string
+  generateVerificationToken?: () => Awaitable<string>
+  normalizeIdentifier?: (identifier: string) => string
+}
 
 export type EmailProvider = (options: EmailUserConfig) => EmailConfig
 

--- a/packages/next-auth/src/providers/index.ts
+++ b/packages/next-auth/src/providers/index.ts
@@ -18,7 +18,7 @@ export interface CommonProviderOptions {
   id: string
   name: string
   type: ProviderType
-  options?: Record<string, unknown>
+  options?: any
 }
 
 export type Provider = OAuthConfig<any> | EmailConfig | CredentialsConfig


### PR DESCRIPTION
## ☕️ Reasoning

I was trying to setup the `EmailProvider` with aws's `SES` and noticed the types didn't allow that, and even if I was using a normal smtp server it had incorrect required and optional fields. This change allows all types for nodemailer's `createTransport()` function including premade transports (which is handy if you're using `nodemailer.createTestAccount()`)


## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Related: https://github.com/nextauthjs/next-auth/pull/5618 (related to but doesn't replace)
