### PR TITLE
fix(ts): add overloads to withAuth middleware

### DIFF
--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -186,7 +186,43 @@ export type WithAuthArgs =
  * ---
  * [Documentation](https://next-auth.js.org/configuration/nextjs#middleware)
  */
-export function withAuth(...args: WithAuthArgs) {
+
+export function withAuth(): ReturnType<NextMiddlewareWithAuth>
+
+export function withAuth(
+  req: NextRequestWithAuth
+): ReturnType<NextMiddlewareWithAuth>
+
+export function withAuth(
+  req: NextRequestWithAuth,
+  event: NextFetchEvent
+): ReturnType<NextMiddlewareWithAuth>
+
+export function withAuth(
+  req: NextRequestWithAuth,
+  options: NextAuthMiddlewareOptions
+): ReturnType<NextMiddlewareWithAuth>
+
+export function withAuth(
+  req: NextRequestWithAuth
+): ReturnType<NextMiddlewareWithAuth>
+
+export function withAuth(
+  middleware: NextMiddlewareWithAuth,
+  options: NextAuthMiddlewareOptions
+): NextMiddlewareWithAuth
+
+export function withAuth(
+  middleware: NextMiddlewareWithAuth
+): NextMiddlewareWithAuth
+
+export function withAuth(
+  options: NextAuthMiddlewareOptions
+): NextMiddlewareWithAuth
+
+export function withAuth(
+  ...args: WithAuthArgs
+): ReturnType<NextMiddlewareWithAuth> | NextMiddlewareWithAuth {
   if (!args.length || args[0] instanceof Request) {
     // @ts-expect-error
     return handleMiddleware(...args)

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -209,21 +209,21 @@ export function withAuth(
 ): <Req extends Request = NextRequestWithAuth>(
   request: Req,
   event: NextFetchEvent
-) => NextMiddlewareResult | Promise<NextMiddlewareResult>
+) => ReturnType<NextMiddlewareWithAuth>
 
 export function withAuth(
   middleware: NextMiddlewareWithAuth
 ): <Req extends Request = NextRequestWithAuth>(
   request: Req,
   event: NextFetchEvent
-) => NextMiddlewareResult | Promise<NextMiddlewareResult>
+) => ReturnType<NextMiddlewareWithAuth>
 
 export function withAuth(
   options: NextAuthMiddlewareOptions
 ): <Req extends Request = NextRequestWithAuth>(
   request: Req,
   event: NextFetchEvent
-) => NextMiddlewareResult | Promise<NextMiddlewareResult>
+) => ReturnType<NextMiddlewareWithAuth>
 
 export function withAuth(
   ...args: WithAuthArgs

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -189,36 +189,41 @@ export type WithAuthArgs =
 
 export function withAuth(): ReturnType<NextMiddlewareWithAuth>
 
-export function withAuth(
-  req: NextRequestWithAuth
+export function withAuth<Req extends Request = NextRequestWithAuth>(
+  req: Req
 ): ReturnType<NextMiddlewareWithAuth>
 
-export function withAuth(
-  req: NextRequestWithAuth,
+export function withAuth<Req extends Request = NextRequestWithAuth>(
+  req: Req,
   event: NextFetchEvent
 ): ReturnType<NextMiddlewareWithAuth>
 
-export function withAuth(
-  req: NextRequestWithAuth,
+export function withAuth<Req extends Request = NextRequestWithAuth>(
+  req: Req,
   options: NextAuthMiddlewareOptions
-): ReturnType<NextMiddlewareWithAuth>
-
-export function withAuth(
-  req: NextRequestWithAuth
 ): ReturnType<NextMiddlewareWithAuth>
 
 export function withAuth(
   middleware: NextMiddlewareWithAuth,
   options: NextAuthMiddlewareOptions
-): NextMiddlewareWithAuth
+): <Req extends Request = NextRequestWithAuth>(
+  request: Req,
+  event: NextFetchEvent
+) => NextMiddlewareResult | Promise<NextMiddlewareResult>
 
 export function withAuth(
   middleware: NextMiddlewareWithAuth
-): NextMiddlewareWithAuth
+): <Req extends Request = NextRequestWithAuth>(
+  request: Req,
+  event: NextFetchEvent
+) => NextMiddlewareResult | Promise<NextMiddlewareResult>
 
 export function withAuth(
   options: NextAuthMiddlewareOptions
-): NextMiddlewareWithAuth
+): <Req extends Request = NextRequestWithAuth>(
+  request: Req,
+  event: NextFetchEvent
+) => NextMiddlewareResult | Promise<NextMiddlewareResult>
 
 export function withAuth(
   ...args: WithAuthArgs

--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -189,41 +189,32 @@ export type WithAuthArgs =
 
 export function withAuth(): ReturnType<NextMiddlewareWithAuth>
 
-export function withAuth<Req extends Request = NextRequestWithAuth>(
-  req: Req
+export function withAuth(
+  req: NextRequestWithAuth
 ): ReturnType<NextMiddlewareWithAuth>
 
-export function withAuth<Req extends Request = NextRequestWithAuth>(
-  req: Req,
+export function withAuth(
+  req: NextRequestWithAuth,
   event: NextFetchEvent
 ): ReturnType<NextMiddlewareWithAuth>
 
-export function withAuth<Req extends Request = NextRequestWithAuth>(
-  req: Req,
+export function withAuth(
+  req: NextRequestWithAuth,
   options: NextAuthMiddlewareOptions
 ): ReturnType<NextMiddlewareWithAuth>
 
 export function withAuth(
   middleware: NextMiddlewareWithAuth,
   options: NextAuthMiddlewareOptions
-): <Req extends Request = NextRequestWithAuth>(
-  request: Req,
-  event: NextFetchEvent
-) => ReturnType<NextMiddlewareWithAuth>
+): NextMiddlewareWithAuth
 
 export function withAuth(
   middleware: NextMiddlewareWithAuth
-): <Req extends Request = NextRequestWithAuth>(
-  request: Req,
-  event: NextFetchEvent
-) => ReturnType<NextMiddlewareWithAuth>
+): NextMiddlewareWithAuth
 
 export function withAuth(
   options: NextAuthMiddlewareOptions
-): <Req extends Request = NextRequestWithAuth>(
-  request: Req,
-  event: NextFetchEvent
-) => ReturnType<NextMiddlewareWithAuth>
+): NextMiddlewareWithAuth
 
 export function withAuth(
   ...args: WithAuthArgs


### PR DESCRIPTION
## ☕️ Reasoning

The `withAuth` middleware returns different values depending on provided arguments. In the current implementation it returns a union such as:`NextMiddlewareWithAuth | NextMiddlewareResult | ...`.

This union is type is not narrow enough for use in scenarios where we expect a callable `NextMiddlewareWithAuth` that we can invoke later after getting some outside context from the middleware `request` object. 

In summary, when we want to do something like this:
```ts
export default middleware(req: Request, event: NextFetchEvent){
   // ...do something with Request
   const response = withAuth({...})(req, event)
   // ...do something with Response?
  return response
}

// Side note: This PR also resolves type issues that would arise from doing this instead 
// (for the reason that Request does not extend `NextRequestWithAuth`:
// const response = withAuth(req, {...})
```

**Solution**: This PR adds type overloads such that the types narrow down as expected depending on the arguments supplied to `withAuth`. This lets us do the above without any type issues.

## 🧢 Checklist

- [x] Documentation (N/A)
- [x] Tests (N/A)
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: https://github.com/nextauthjs/next-auth/issues/7997

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
