### PR TITLE
fix: use pk and sk from DynamoDB adapter options when deleting session

### DIFF
--- a/packages/adapter-dynamodb/src/index.ts
+++ b/packages/adapter-dynamodb/src/index.ts
@@ -438,11 +438,12 @@ export function DynamoDBAdapter(
       })
       if (!data?.Items?.length) return null
 
-      const { pk, sk } = data.Items[0]
+      const { [pk]: partitionKeyToDelete, [sk]: sortKeyToDelete } =
+        data.Items[0]
 
       const res = await client.delete({
         TableName,
-        Key: { pk, sk },
+        Key: { [pk]: partitionKeyToDelete, [sk]: sortKeyToDelete },
         ReturnValues: "ALL_OLD",
       })
       return format.from<AdapterSession>(res.Attributes)


### PR DESCRIPTION
## ☕️ Reasoning

The function `deleteSession` in the DynamoDB adapter fails when using a custom partition key (PK) and sort key (SK) attribute name, because the custom PK and SK doesn't get used.

A `ValidationException` occurs because the PK and SK attribute name is incorrect.

```
[next-auth][error][adapter_error_deleteSession]
https://next-auth.js.org/errors#adapter_error_deletesession The number of conditions on the keys is invalid {
  message: 'The number of conditions on the keys is invalid',
  stack: 'ValidationException: The number of conditions on the keys is invalid\n' +
    '    at throwDefaultError (/home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@smithy+smithy-client@1.0.4/node_modules/@smithy/smithy-client/dist-cjs/default-error-handler.js:8:22)\n' +
    '    at /home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@smithy+smithy-client@1.0.4/node_modules/@smithy/smithy-client/dist-cjs/default-error-handler.js:18:39\n' +
    '    at de_DeleteItemCommandError (/home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@aws-sdk+client-dynamodb@3.363.0/node_modules/@aws-sdk/client-dynamodb/dist-cjs/protocols/Aws_json1_0.js:741:20)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
    '    at async /home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@smithy+middleware-serde@1.0.2/node_modules/@smithy/middleware-serde/dist-cjs/deserializerMiddleware.js:7:24\n' +
    '    at async /home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@aws-sdk+lib-dynamodb@3.365.0_@aws-sdk+client-dynamodb@3.363.0_@aws-sdk+types@3.357.0/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/baseCommand/DynamoDBDocumentClientCommand.js:26:34\n' +
    '    at async /home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@aws-sdk+middleware-signing@3.363.0/node_modules/@aws-sdk/middleware-signing/dist-cjs/awsAuthMiddleware.js:14:20\n' +
    '    at async /home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@smithy+middleware-retry@1.0.4/node_modules/@smithy/middleware-retry/dist-cjs/retryMiddleware.js:27:46\n' +
    '    at async /home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@aws-sdk+middleware-logger@3.363.0/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26\n' +
    '    at async deleteSession (file:///home/arvl/src/nextauth-bug-repro-dynamodb-delete-session/node_modules/.pnpm/@auth+dynamodb-adapter@1.0.0_@aws-sdk+client-dynamodb@3.363.0_@aws-sdk+lib-dynamodb@3.365.0/node_modules/@auth/dynamodb-adapter/index.js:410:25)',
  name: 'ValidationException'
}
```

The fix is quite simple: make the function use the PK and SK from the config, so that this error doesn't occur.

## 🧢 Checklist

- [x] Documentation (N/A)
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: https://github.com/nextauthjs/next-auth/issues/7973

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
