### PR TITLE
Descope provider

### DIFF
--- a/packages/core/src/providers/descope.ts
+++ b/packages/core/src/providers/descope.ts
@@ -13,17 +13,25 @@
 
 import type { OIDCConfig, OIDCUserConfig } from "./index.js"
 
-/** The returned user profile from Descope when using the profile callback. */
+/** The returned user profile from Descope when using the profile callback. 
+ * [See Load User](https://docs.descope.com/api/openapi/usermanagement/operation/LoadUser/)
+*/
 export interface DescopeProfile {
-  /** The user Descope ID */
+  /** The user's unique Descope ID */
   sub: string
+  /** The user's name */
   name: string
+  /** The user's email */
   email: string
+  /** A boolean indicating if the user's email is verified */
   email_verified: boolean
+  /** The user's phone number */
   phone_number: string
+  /** A boolean indicating if the user's phone number is verified */
   phone_number_verified: boolean
+  /** The user's picture */
   picture: string
-  /** Custom user's attributes */
+  /** The user's custom attributes */
   [claim: string]: unknown
 }
 
@@ -97,7 +105,7 @@ export default function Descope(
     id: "descope",
     name: "Descope",
     type: "oidc",
-    clientId: `https://api.descope.com/${config.clientId}`,
+    issuer: `https://api.descope.com/${config.clientId}`,
     style: {
       logo: "/descope.svg",
       logoDark: "/descope.svg",


### PR DESCRIPTION
Update Descope provider:
1. fix configuration to set issuer instead of clientId
2. add documentation profile parameters

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
