### PR TITLE
Make middleware not redirect to sign in on newUser page

### DIFF
--- a/packages/next-auth/src/next/middleware.ts
+++ b/packages/next-auth/src/next/middleware.ts
@@ -105,6 +105,7 @@ async function handleMiddleware(
 
   const signInPage = options?.pages?.signIn ?? "/api/auth/signin"
   const errorPage = options?.pages?.error ?? "/api/auth/error"
+  const newUserPage = options?.pages?.newUser
   const authPath = parseUrl(process.env.NEXTAUTH_URL).path
   const publicPaths = ["/_next", "/favicon.ico"]
 
@@ -112,7 +113,7 @@ async function handleMiddleware(
   // on paths that never require authentication
   if (
     `${basePath}${pathname}`.startsWith(authPath) ||
-    [signInPage, errorPage].includes(pathname) ||
+    [signInPage, errorPage, newUserPage].includes(pathname) ||
     publicPaths.some((p) => pathname.startsWith(p))
   ) {
     return

--- a/packages/next-auth/tests/middleware.test.ts
+++ b/packages/next-auth/tests/middleware.test.ts
@@ -39,6 +39,30 @@ it("should not redirect on public paths", async () => {
   expect(res).toBeUndefined()
 })
 
+it("should not redirect on pages", async () => {
+  const options: NextAuthMiddlewareOptions = {
+    pages: {
+      signIn: "/special/signin",
+      newUser: "/special/newuser",
+      error: "/special/error",
+    },
+    secret: "secret",
+  }
+  for (const page of ['signIn', 'error', 'newUser']) {
+    const nextUrl: any = {
+      pathname: options.pages?.[page],
+      search: "",
+      origin: "http://127.0.0.1",
+    }
+
+    const req: any = { nextUrl, headers: { authorization: "" } }
+
+    const handleMiddleware = withAuth(options) as NextMiddleware
+    const res = await handleMiddleware(req, null as any)
+    expect(res).toBeUndefined()
+  }
+})
+
 it("should redirect according to nextUrl basePath", async () => {
   const options: NextAuthMiddlewareOptions = {
     secret: "secret"


### PR DESCRIPTION
## ☕️ Reasoning

When a user is not signed in and visits a protected route (which is implicitly any route except next auth routes) then the next.js middleware redirects them to the sign in page. But if the app has a custom `newUser` page (i.e. registration) the middleware still redirects the user to sign in. A new user cannot sign in if they do not have an account, so it seems like this was an oversight in the middleware?

## 🧢 Checklist

- [ ] Documentation: do we need to add an example of configuring custom routes to [this page](https://next-auth.js.org/tutorials/securing-pages-and-api-routes)? (the published page doesn't appear to be what is in the main branch)
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/7871

