### PR TITLE
fix: remove return value from api handler

### DIFF
--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -55,7 +55,8 @@ async function NextAuthApiHandler(
       // Could chain. .end() when lowest target is Node 14
       // https://github.com/nodejs/node/issues/33148
       res.status(302).setHeader("Location", handler.redirect)
-      return res.end()
+      res.end()
+      return
     }
     return res.json({ url: handler.redirect })
   }


### PR DESCRIPTION
fixes #7963 by not returning the res.end() return value in API handlers. 

## ☕️ Reasoning
Nextjs started raising warnings in ~v13.3 about this. 
Since the return value should not serve any function, it should be safe to remove them.
I have tested this in a local app and it stopped the warning from popping up, while retaining functionality.

Note: I could not replicate the warning on signout like [one user in #7963](https://github.com/nextauthjs/next-auth/issues/7963#issuecomment-1636662210), only on signin.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged (or is it?)

## 🎫 Affected issues

Fixes: #7963

## Related Links

https://github.com/vercel/next.js/discussions/48951

## Other

It could maybe be argued that since this changes what a method returns in some circumstances, it might be a breaking change. I did not see any documentation stating anything about the return values of NextAuth(), so I think it should be fine to leave it at fix semver?!