### PR TITLE
docs(zoho provider): updated docs with missing account attribute

### DIFF
--- a/docs/docs/providers/zoho.md
+++ b/docs/docs/providers/zoho.md
@@ -3,6 +3,10 @@ id: zoho
 title: Zoho
 ---
 
+:::note
+Zoho returns a field on `Account` called `api_domain` which is a string. See their [docs](https://www.zoho.com/accounts/protocol/oauth/web-apps/access-token.html). Remember to add this field to your database schema, in case if you are using an [Adapter](https://authjs.dev/reference/adapters).
+:::
+
 ## Documentation
 
 https://www.zoho.com/accounts/protocol/oauth/web-server-applications.html


### PR DESCRIPTION
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Updating the Zoho provider docs to note that Zoho returns an api_domain attribute which requires a db schema update.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

No open issue

