### PR TITLE
docs: correct broken CONTRIBUTING.md link in apps/dev/nextjs-v4

### DIFF
--- a/apps/dev/nextjs-v4/README.md
+++ b/apps/dev/nextjs-v4/README.md
@@ -3,4 +3,4 @@
 This folder contains a Next.js app using NextAuth.js for local development. See the following section on how to start:
 
 [Setting up local environment
-](https://github.com/nextauthjs/next-auth/blob/main/CONTRIBUTING.md#setting-up-local-environment)
+](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md#setting-up-local-environment)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning
CONTRIBUTING.md has moved under the .github folder but the reference link in `apps/dev/nextjs-v4/README.md` is not updated.

Updated the document link in  to point to the correct CONTRIBUTING.md

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
