### PR TITLE
fix: sort cookie chunks correctly

### DIFF
--- a/packages/core/src/lib/cookie.ts
+++ b/packages/core/src/lib/cookie.ts
@@ -162,8 +162,8 @@ export class SessionStore {
    get value() {
     // Sort the chunks by their keys before joining
     const sortedKeys = Object.keys(this.#chunks).sort((a, b) => {
-      const aSuffix = parseInt(a.split(".")[1] || "0");
-      const bSuffix = parseInt(b.split(".")[1] || "0");
+      const aSuffix = parseInt(a.split(".").pop() || "0");
+      const bSuffix = parseInt(b.split(".").pop() || "0");
   
       return aSuffix - bSuffix;
     });

--- a/packages/next-auth/src/core/lib/cookie.ts
+++ b/packages/next-auth/src/core/lib/cookie.ts
@@ -161,8 +161,21 @@ export class SessionStore {
     }
   }
 
-  get value() {
-    return Object.values(this.#chunks)?.join("")
+   /**
+   * The JWT Session or database Session ID
+   * constructed from the cookie chunks.
+   */
+   get value() {
+    // Sort the chunks by their keys before joining
+    const sortedKeys = Object.keys(this.#chunks).sort((a, b) => {
+      const aSuffix = parseInt(a.split(".").pop() || "0");
+      const bSuffix = parseInt(b.split(".").pop() || "0");
+  
+      return aSuffix - bSuffix;
+    });
+  
+    // Use the sorted keys to join the chunks in the correct order
+    return sortedKeys.map(key => this.#chunks[key]).join("");
   }
 
   /** Given a cookie, return a list of cookies, chunked to fit the allowed cookie size. */

--- a/packages/next-auth/src/core/lib/cookie.ts
+++ b/packages/next-auth/src/core/lib/cookie.ts
@@ -161,21 +161,8 @@ export class SessionStore {
     }
   }
 
-   /**
-   * The JWT Session or database Session ID
-   * constructed from the cookie chunks.
-   */
-   get value() {
-    // Sort the chunks by their keys before joining
-    const sortedKeys = Object.keys(this.#chunks).sort((a, b) => {
-      const aSuffix = parseInt(a.split(".").pop() || "0");
-      const bSuffix = parseInt(b.split(".").pop() || "0");
-  
-      return aSuffix - bSuffix;
-    });
-  
-    // Use the sorted keys to join the chunks in the correct order
-    return sortedKeys.map(key => this.#chunks[key]).join("");
+  get value() {
+    return Object.values(this.#chunks)?.join("")
   }
 
   /** Given a cookie, return a list of cookies, chunked to fit the allowed cookie size. */


### PR DESCRIPTION
## ☕️ Reasoning

Depending on the cookie name, cookie chunks will not be correctly sorted. The cookies could be sent in the wrong order. Exactly why I'm not sure, but for us it happens when deployed to Vercel.

Splitting the default cookie name `next-auth.session-token.0` on `.` and taking the second index will get `session-token` for both `0` and `1`.

The merged and released PR https://github.com/nextauthjs/next-auth/pull/7736 contained a bug that was commented but never fixed before merging.

Workaround: Change cookie name to something else without `.`, or merge this PR.

**Note:** Implemented for both `next-auth` and `@auth/core`

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation (NO CHANGE)
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes:

https://github.com/nextauthjs/next-auth/pull/7736
https://github.com/sidebase/nuxt-auth/issues/293

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
