### PR TITLE
feat(adapters): standardize default table names to be singular

### DIFF
--- a/packages/adapter-drizzle/src/index.ts
+++ b/packages/adapter-drizzle/src/index.ts
@@ -77,7 +77,7 @@ import type { Adapter } from "@auth/core/adapters"
  * } from "drizzle-orm/pg-core"
  * import type { AdapterAccount } from '@auth/core/adapters'
  *
- * export const users = pgTable("users", {
+ * export const users = pgTable("user", {
  *  id: text("id").notNull().primaryKey(),
  *  name: text("name"),
  *  email: text("email").notNull(),
@@ -86,7 +86,7 @@ import type { Adapter } from "@auth/core/adapters"
  * })
  *
  * export const accounts = pgTable(
- * "accounts",
+ * "account",
  * {
  *   userId: text("userId")
  *     .notNull()
@@ -107,7 +107,7 @@ import type { Adapter } from "@auth/core/adapters"
  * })
  * )
  *
- * export const sessions = pgTable("sessions", {
+ * export const sessions = pgTable("session", {
  *  sessionToken: text("sessionToken").notNull().primaryKey(),
  *  userId: text("userId")
  *    .notNull()
@@ -140,7 +140,7 @@ import type { Adapter } from "@auth/core/adapters"
  * } from "drizzle-orm/mysql-core"
  * import type { AdapterAccount } from "@auth/core/adapters"
  *
- * export const users = mysqlTable("users", {
+ * export const users = mysqlTable("user", {
  *  id: varchar("id", { length: 255 }).notNull().primaryKey(),
  *  name: varchar("name", { length: 255 }),
  *  email: varchar("email", { length: 255 }).notNull(),
@@ -149,7 +149,7 @@ import type { Adapter } from "@auth/core/adapters"
  * })
  *
  * export const accounts = mysqlTable(
- *  "accounts",
+ *  "account",
  *   {
  *    userId: varchar("userId", { length: 255 })
  *       .notNull()
@@ -170,7 +170,7 @@ import type { Adapter } from "@auth/core/adapters"
  * })
  * )
  *
- * export const sessions = mysqlTable("sessions", {
+ * export const sessions = mysqlTable("session", {
  *  sessionToken: varchar("sessionToken", { length: 255 }).notNull().primaryKey(),
  *  userId: varchar("userId", { length: 255 })
  *    .notNull()
@@ -197,7 +197,7 @@ import type { Adapter } from "@auth/core/adapters"
  * import { integer, sqliteTable, text, primaryKey } from "drizzle-orm/sqlite-core"
  * import type { AdapterAccount } from "@auth/core/adapters"
  *
- * export const users = sqliteTable("users", {
+ * export const users = sqliteTable("user", {
  *  id: text("id").notNull().primaryKey(),
  *  name: text("name"),
  *  email: text("email").notNull(),
@@ -206,7 +206,7 @@ import type { Adapter } from "@auth/core/adapters"
  * })
  *
  * export const accounts = sqliteTable(
- *  "accounts",
+ *  "account",
  *  {
  *    userId: text("userId")
  *      .notNull()
@@ -227,7 +227,7 @@ import type { Adapter } from "@auth/core/adapters"
  *  })
  * )
  *
- * export const sessions = sqliteTable("sessions", {
+ * export const sessions = sqliteTable("session", {
  * sessionToken: text("sessionToken").notNull().primaryKey(),
  * userId: text("userId")
  *   .notNull()

--- a/packages/adapter-drizzle/src/lib/mysql.ts
+++ b/packages/adapter-drizzle/src/lib/mysql.ts
@@ -12,7 +12,7 @@ import type { Adapter, AdapterAccount } from "@auth/core/adapters"
 import type { MySql2Database } from "drizzle-orm/mysql2"
 
 export function createTables(mySqlTable: MySqlTableFn) {
-  const users = mySqlTable("users", {
+  const users = mySqlTable("user", {
     id: varchar("id", { length: 255 }).notNull().primaryKey(),
     name: varchar("name", { length: 255 }),
     email: varchar("email", { length: 255 }).notNull(),
@@ -24,7 +24,7 @@ export function createTables(mySqlTable: MySqlTableFn) {
   })
 
   const accounts = mySqlTable(
-    "accounts",
+    "account",
     {
       userId: varchar("userId", { length: 255 })
         .notNull()
@@ -49,7 +49,7 @@ export function createTables(mySqlTable: MySqlTableFn) {
     })
   )
 
-  const sessions = mySqlTable("sessions", {
+  const sessions = mySqlTable("session", {
     sessionToken: varchar("sessionToken", { length: 255 })
       .notNull()
       .primaryKey(),
@@ -187,7 +187,7 @@ export function mySqlDrizzleAdapter(
         return null
       }
 
-      return dbAccount.users
+      return dbAccount.user
     },
     async deleteSession(sessionToken) {
       const session =

--- a/packages/adapter-drizzle/src/lib/pg.ts
+++ b/packages/adapter-drizzle/src/lib/pg.ts
@@ -12,7 +12,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Adapter, AdapterAccount } from "@auth/core/adapters"
 
 export function createTables(pgTable: PgTableFn) {
-  const users = pgTable("users", {
+  const users = pgTable("user", {
     id: text("id").notNull().primaryKey(),
     name: text("name"),
     email: text("email").notNull(),
@@ -21,7 +21,7 @@ export function createTables(pgTable: PgTableFn) {
   })
 
   const accounts = pgTable(
-    "accounts",
+    "account",
     {
       userId: text("userId")
         .notNull()
@@ -42,7 +42,7 @@ export function createTables(pgTable: PgTableFn) {
     })
   )
 
-  const sessions = pgTable("sessions", {
+  const sessions = pgTable("session", {
     sessionToken: text("sessionToken").notNull().primaryKey(),
     userId: text("userId")
       .notNull()
@@ -174,7 +174,7 @@ export function pgDrizzleAdapter(
         return null
       }
 
-      return dbAccount.users
+      return dbAccount.user
     },
     async deleteSession(sessionToken) {
       const session = await client

--- a/packages/adapter-drizzle/src/lib/sqlite.ts
+++ b/packages/adapter-drizzle/src/lib/sqlite.ts
@@ -11,7 +11,7 @@ import {
 import type { Adapter, AdapterAccount } from "@auth/core/adapters"
 
 export function createTables(sqliteTable: SQLiteTableFn) {
-  const users = sqliteTable("users", {
+  const users = sqliteTable("user", {
     id: text("id").notNull().primaryKey(),
     name: text("name"),
     email: text("email").notNull(),
@@ -20,7 +20,7 @@ export function createTables(sqliteTable: SQLiteTableFn) {
   })
 
   const accounts = sqliteTable(
-    "accounts",
+    "account",
     {
       userId: text("userId")
         .notNull()
@@ -41,7 +41,7 @@ export function createTables(sqliteTable: SQLiteTableFn) {
     })
   )
 
-  const sessions = sqliteTable("sessions", {
+  const sessions = sqliteTable("session", {
     sessionToken: text("sessionToken").notNull().primaryKey(),
     userId: text("userId")
       .notNull()
@@ -159,7 +159,7 @@ export function SQLiteDrizzleAdapter(
         )
         .get()
 
-      return results?.users ?? null
+      return results?.user ?? null
     },
     deleteSession(sessionToken) {
       return (


### PR DESCRIPTION
## ☕️ Reasoning
Standardizes table naming to be singular - Like the other adapters

**NOTE from the maintainer (@balazsorban44):** This is potentially a breaking change for early adaptors, but since we are under v1, I believe this is worthwhile doing now.

## 🧢 Checklist

- [X] Documentation
- [X] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/8271

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
