### PR TITLE
fix(ts): compatibility with `next-auth` v4 types

### DIFF
--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -274,8 +274,14 @@ export interface Adapter {
 // For compatibility with older versions of NextAuth.js
 // @ts-expect-error
 declare module "next-auth/adapters" {
-  export interface AdapterAccount {
-    type: any
-    [key: string]: any
+  type JsonObject = {
+    [Key in string]?: JsonValue
+  }
+  type JsonArray = JsonValue[]
+  type JsonPrimitive = string | number | boolean | null
+  type JsonValue = JsonPrimitive | JsonObject | JsonArray
+  interface AdapterAccount {
+    type: "oauth" | "email" | "oidc"
+    [key: string]: JsonValue | undefined
   }
 }

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -223,7 +223,9 @@ export interface Adapter {
   getUserByAccount?(
     providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">
   ): Awaitable<AdapterUser | null>
-  updateUser?(user: Partial<AdapterUser> & Pick<AdapterUser, 'id'>): Awaitable<AdapterUser>
+  updateUser?(
+    user: Partial<AdapterUser> & Pick<AdapterUser, "id">
+  ): Awaitable<AdapterUser>
   /** @todo This method is currently not invoked yet. */
   deleteUser?(
     userId: string
@@ -269,4 +271,13 @@ export interface Adapter {
     identifier: string
     token: string
   }): Awaitable<VerificationToken | null>
+}
+
+// For compatibility with older versions of NextAuth.js
+// @ts-expect-error
+declare module "next-auth/adapters" {
+  export interface AdapterAccount {
+    type: any
+    [key: string]: any
+  }
 }

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -223,9 +223,7 @@ export interface Adapter {
   getUserByAccount?(
     providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">
   ): Awaitable<AdapterUser | null>
-  updateUser?(
-    user: Partial<AdapterUser> & Pick<AdapterUser, "id">
-  ): Awaitable<AdapterUser>
+  updateUser?(user: Partial<AdapterUser> & Pick<AdapterUser, 'id'>): Awaitable<AdapterUser>
   /** @todo This method is currently not invoked yet. */
   deleteUser?(
     userId: string


### PR DESCRIPTION
Fixes #8283

`@auth/core/adapters` have some incompatible types with `next-auth/adapters` since it's a bit stricter. This PR aims to smoothen out the transition to `@auth/*` packages (as well as `next-auth` v5 #7443)

This is achieved by loosening the `next-auth/adapters` types whenever an `@auth/*-adapter` is imported into a project. When only using `@auth/*` packages or `next-auth` v5 from #7443, this module augmentation will have no effect.