### PR TITLE
fix: 🏷️ Include types required by solid-start framework

### DIFF
--- a/packages/frameworks-solid-start/src/client.ts
+++ b/packages/frameworks-solid-start/src/client.ts
@@ -1,13 +1,49 @@
 import type {
-  LiteralUnion,
-  SignInOptions,
-  SignInAuthorizationParams,
-  SignOutParams,
-} from "next-auth/react"
-import type {
   BuiltInProviderType,
+  ProviderType,
   RedirectableProviderType,
 } from "@auth/core/providers"
+
+/**
+ * Util type that matches some strings literally, but allows any other string as well.
+ * @source https://github.com/microsoft/TypeScript/issues/29729#issuecomment-832522611
+ */
+export type LiteralUnion<T extends U, U = string> =
+  | T
+  | (U & Record<never, never>)
+
+export interface ClientSafeProvider {
+  id: LiteralUnion<BuiltInProviderType>
+  name: string
+  type: ProviderType
+  signinUrl: string
+  callbackUrl: string
+}
+
+export interface SignInOptions extends Record<string, unknown> {
+  /**
+   * Specify to which URL the user will be redirected after signing in. Defaults to the page URL the sign-in is initiated from.
+   *
+   * [Documentation](https://next-auth.js.org/getting-started/client#specifying-a-callbackurl)
+   */
+  callbackUrl?: string
+  /** [Documentation](https://next-auth.js.org/getting-started/client#using-the-redirect-false-option) */
+  redirect?: boolean
+}
+
+/** Match `inputType` of `new URLSearchParams(inputType)` */
+export type SignInAuthorizationParams =
+  | string
+  | string[][]
+  | Record<string, string>
+  | URLSearchParams
+
+export interface SignOutParams<R extends boolean = true> {
+  /** [Documentation](https://next-auth.js.org/getting-started/client#specifying-a-callbackurl-1) */
+  callbackUrl?: string
+  /** [Documentation](https://next-auth.js.org/getting-started/client#using-the-redirect-false-option-1 */
+  redirect?: R
+}
 
 /**
  * Client-side method to initiate a signin flow


### PR DESCRIPTION
## ☕️ Reasoning

Adding types & interfaces previously referenced from an un-included dependency (`next-auth/react`) to `client.ts` for the framework solid-start.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: [#8301](https://github.com/nextauthjs/next-auth/issues/8301)

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
