### PR TITLE
#8328: Use `default` submodules export in `package.json` to ensure compatibi…

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -29,34 +29,34 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "import": "./index.js"
+      "default": "./index.js"
     },
     "./adapters": {
       "types": "./adapters.d.ts"
     },
     "./jwt": {
       "types": "./jwt/index.d.ts",
-      "import": "./jwt/index.js"
+      "default": "./jwt/index.js"
     },
     "./react": {
       "types": "./react/index.d.ts",
-      "import": "./react/index.js"
+      "default": "./react/index.js"
     },
     "./next": {
       "types": "./next/index.d.ts",
-      "import": "./next/index.js"
+      "default": "./next/index.js"
     },
     "./middleware": {
       "types": "./middleware.d.ts",
-      "import": "./middleware.js"
+      "default": "./middleware.js"
     },
     "./client/_utils": {
       "types": "./client/_utils.d.ts",
-      "import": "./client/_utils.js"
+      "default": "./client/_utils.js"
     },
     "./providers/*": {
       "types": "./providers/*.d.ts",
-      "import": "./providers/*.js"
+      "default": "./providers/*.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
…lity, as specified in https://nodejs.org/api/packages.html#conditional-exports

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
This is a fix for #8328, introduced in version 4.23.0 by commit 05ff6ae221b0434784e056de4bff6e3e45c49552, which  uses `import` to declare submodules exports, leading to some compiler configurations to ignore those modules. Preferably we should be using `default` here to maximize compatibility, as specified in https://nodejs.org/api/packages.html#conditional-exports:
> When using environment branches, always include a "default" condition where possible. Providing a "default" condition ensures that any unknown JS environments are able to use this universal implementation, which helps avoid these JS environments from having to pretend to be existing environments in order to support packages with conditional exports.

## 🧢 Checklist

- [N/A] Documentation
- [N/A] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/8328

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
