### PR TITLE
feat(drizzle-adapter): custom database's tables naming strategy

### DIFF
--- a/packages/adapter-drizzle/src/lib/utils.ts
+++ b/packages/adapter-drizzle/src/lib/utils.ts
@@ -8,6 +8,28 @@ import type { DefaultSchema as PgSchema } from "./pg.js"
 import type { DefaultSchema as MySqlSchema } from "./mysql.js"
 import type { DefaultSchema as SQLiteSchema } from "./sqlite.js"
 
+// Naming strategy
+export const names = {
+  snake_case: {
+    user: "user",
+    account: "account",
+    session: "session",
+    verificationToken: "verification_token",
+  },
+  camelCase: {
+    user: "user",
+    account: "account",
+    session: "session",
+    verificationToken: "verificationToken",
+  },
+  PascalCase: {
+    user: "User",
+    account: "Account",
+    session: "Session",
+    verificationToken: "VerificationToken",
+  },
+}
+
 export type AnyMySqlDatabase = MySqlDatabase<any, any>
 export type AnyPgDatabase = PgDatabase<any, any, any>
 export type AnySQLiteDatabase = BaseSQLiteDatabase<any, any, any, any>

--- a/packages/adapter-drizzle/src/lib/utils.ts
+++ b/packages/adapter-drizzle/src/lib/utils.ts
@@ -1,7 +1,6 @@
-import { MySqlDatabase } from "drizzle-orm/mysql-core"
-import { PgDatabase } from "drizzle-orm/pg-core"
-import { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
-
+import type { MySqlDatabase } from "drizzle-orm/mysql-core"
+import type { PgDatabase } from "drizzle-orm/pg-core"
+import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
 import type { AnyMySqlTable, MySqlTableFn } from "drizzle-orm/mysql-core"
 import type { AnyPgTable, PgTableFn } from "drizzle-orm/pg-core"
 import type { AnySQLiteTable, SQLiteTableFn } from "drizzle-orm/sqlite-core"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

I'm migrating my database from Prisma to Drizzle, but I got a problem using drizzle adapter cause table names are different (camelCase vs PascalCase). So, I added an option to force the naming strategy :rocket:

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
