### PR TITLE
fix(adapters): allow async sqlite client libs when using drizzle adapter

### DIFF
--- a/packages/adapter-drizzle/src/lib/sqlite.ts
+++ b/packages/adapter-drizzle/src/lib/sqlite.ts
@@ -74,27 +74,27 @@ export function SQLiteDrizzleAdapter(
     createTables(tableFn)
 
   return {
-    createUser(data) {
+    async createUser(data) {
       return client
         .insert(users)
         .values({ ...data, id: crypto.randomUUID() })
         .returning()
         .get()
     },
-    getUser(data) {
-      return client.select().from(users).where(eq(users.id, data)).get() ?? null
+    async getUser(data) {
+      return (await client.select().from(users).where(eq(users.id, data)).get()) ?? null
     },
-    getUserByEmail(data) {
+    async getUserByEmail(data) {
       return (
-        client.select().from(users).where(eq(users.email, data)).get() ?? null
+        (await client.select().from(users).where(eq(users.email, data)).get()) ?? null
       )
     },
-    createSession(data) {
+    async createSession(data) {
       return client.insert(sessions).values(data).returning().get()
     },
-    getSessionAndUser(data) {
+    async getSessionAndUser(data) {
       return (
-        client
+        (await client
           .select({
             session: sessions,
             user: users,
@@ -102,10 +102,10 @@ export function SQLiteDrizzleAdapter(
           .from(sessions)
           .where(eq(sessions.sessionToken, data))
           .innerJoin(users, eq(users.id, sessions.userId))
-          .get() ?? null
+          .get()) ?? null
       )
     },
-    updateUser(data) {
+    async updateUser(data) {
       if (!data.id) {
         throw new Error("No user id.")
       }
@@ -117,7 +117,7 @@ export function SQLiteDrizzleAdapter(
         .returning()
         .get()
     },
-    updateSession(data) {
+    async updateSession(data) {
       return client
         .update(sessions)
         .set(data)
@@ -125,12 +125,12 @@ export function SQLiteDrizzleAdapter(
         .returning()
         .get()
     },
-    linkAccount(rawAccount) {
-      const updatedAccount = client
+    async linkAccount(rawAccount) {
+      const updatedAccount = await (client
         .insert(accounts)
         .values(rawAccount)
         .returning()
-        .get()
+        .get())
 
       const account: AdapterAccount = {
         ...updatedAccount,
@@ -146,8 +146,8 @@ export function SQLiteDrizzleAdapter(
 
       return account
     },
-    getUserByAccount(account) {
-      const results = client
+    async getUserByAccount(account) {
+      const results = await (client
         .select()
         .from(accounts)
         .leftJoin(users, eq(users.id, accounts.userId))
@@ -157,26 +157,26 @@ export function SQLiteDrizzleAdapter(
             eq(accounts.providerAccountId, account.providerAccountId)
           )
         )
-        .get()
+        .get())
 
       return results?.user ?? null
     },
-    deleteSession(sessionToken) {
+    async deleteSession(sessionToken) {
       return (
-        client
+        (await client
           .delete(sessions)
           .where(eq(sessions.sessionToken, sessionToken))
           .returning()
-          .get() ?? null
+          .get()) ?? null
       )
     },
-    createVerificationToken(token) {
+    async createVerificationToken(token) {
       return client.insert(verificationTokens).values(token).returning().get()
     },
-    useVerificationToken(token) {
+    async useVerificationToken(token) {
       try {
         return (
-          client
+          (await client
             .delete(verificationTokens)
             .where(
               and(
@@ -185,17 +185,17 @@ export function SQLiteDrizzleAdapter(
               )
             )
             .returning()
-            .get() ?? null
+            .get()) ?? null
         )
       } catch (err) {
         throw new Error("No verification token found.")
       }
     },
-    deleteUser(id) {
+    async deleteUser(id) {
       return client.delete(users).where(eq(users.id, id)).returning().get()
     },
-    unlinkAccount(account) {
-      client
+    async unlinkAccount(account) {
+      await client
         .delete(accounts)
         .where(
           and(


### PR DESCRIPTION
## ☕️ Reasoning

Not all Drizzle clients are fully supported. This PR adds 'await' for the queries that return promises.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #8335 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
