### PR TITLE
Add provider index to entry point exports

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -54,6 +54,10 @@
       "types": "./client/_utils.d.ts",
       "default": "./client/_utils.js"
     },
+    "./providers": {
+      "types": "./providers/index.d.ts",
+      "default": "./providers/index.js"
+    },
     "./providers/*": {
       "types": "./providers/*.d.ts",
       "default": "./providers/*.js"


### PR DESCRIPTION
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

When using `modueResolution` of type `Bundler` and you want to import from `providers/index.ts`, you'd have to type `import { ... } from "next-auth/providers/index"`. However, when using `moduleResolution` of type `Node`, you could import using `import { ... } from "next-auth/providers"`.

This PR fixes these differences by specifying an explicit entry point for the index file. If there's better sugar available, feel free to teach me.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
