### PR TITLE
fix: pass options param to openid client instance

### DIFF
--- a/packages/next-auth/src/core/lib/oauth/client.ts
+++ b/packages/next-auth/src/core/lib/oauth/client.ts
@@ -36,7 +36,8 @@ export async function openidClient(
       redirect_uris: [provider.callbackUrl],
       ...provider.client,
     },
-    provider.jwks
+    provider.jwks,
+    provider.client?.options,
   )
 
   // allow a 10 second skew


### PR DESCRIPTION
## ☕️ Reasoning

Currently it is not possible to pass `additionalAuthorizedParties` in the options argument, as it is required in some cases, e.g. when using hybrid applications and validating multiple audiences.

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

https://github.com/nextauthjs/next-auth/discussions/6966

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
