### PR TITLE
fix(docs): fix failing docs build

### DIFF
--- a/packages/core/src/providers/azure-devops.ts
+++ b/packages/core/src/providers/azure-devops.ts
@@ -116,52 +116,54 @@ export default function AzureDevOpsProvider<P extends AzureDevOpsProfile>(
      * https://docs.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops#scopes
      * @default vso.profile
      */
-    scope?: string;
+    scope?: string
   }
 ): OAuthConfig<P> {
-  const scope = options.scope ?? 'vso.profile';
-  const tokenEndpointUrl = 'https://app.vssps.visualstudio.com/oauth2/authorize';
-  const userInfoEndpointUrl = 'https://app.vssps.visualstudio.com/_apis/profile/profiles/me?details=true&coreAttributes=Avatar&api-version=6.0';
+  const scope = options.scope ?? "vso.profile"
+  const tokenEndpointUrl = "https://app.vssps.visualstudio.com/oauth2/authorize"
+  const userInfoEndpointUrl =
+    "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?details=true&coreAttributes=Avatar&api-version=6.0"
 
   return {
-    id: 'azure-devops',
-    name: 'Azure DevOps',
-    type: 'oauth',
+    id: "azure-devops",
+    name: "Azure DevOps",
+    type: "oauth",
 
     authorization: {
-      url: 'https://app.vssps.visualstudio.com/oauth2/authorize',
-      params: { response_type: 'Assertion', scope }
+      url: "https://app.vssps.visualstudio.com/oauth2/authorize",
+      params: { response_type: "Assertion", scope },
     },
 
     token: {
       url: tokenEndpointUrl,
       async request(context) {
         const response = await fetch(tokenEndpointUrl, {
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          method: 'POST',
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          method: "POST",
           body: new URLSearchParams({
-            client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            client_assertion_type:
+              "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
             client_assertion: context.provider.clientSecret as string,
-            grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
             assertion: context.params.code as string,
-            redirect_uri: context.provider.callbackUrl
-          })
-        });
-        return { tokens: await response.json() };
-      }
+            redirect_uri: context.provider.callbackUrl,
+          }),
+        })
+        return { tokens: await response.json() }
+      },
     },
 
     userinfo: {
       url: userInfoEndpointUrl,
       async request(context) {
-        const accessToken = context.tokens.access_token as string;
+        const accessToken = context.tokens.access_token as string
         const response = await fetch(userInfoEndpointUrl, {
           headers: {
-            Authorization: `Bearer ${accessToken}`
-          }
-        });
-        return response.json();
-      }
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        return response.json()
+      },
     },
 
     profile(profile) {
@@ -169,10 +171,10 @@ export default function AzureDevOpsProvider<P extends AzureDevOpsProfile>(
         id: profile.id,
         name: profile.displayName,
         email: profile.emailAddress,
-        image: `data:image/jpeg;base64,${profile.coreAttributes.Avatar.value.value}`
-      };
+        image: `data:image/jpeg;base64,${profile.coreAttributes.Avatar.value.value}`,
+      }
     },
 
-    options
-  };
+    options,
+  }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
This PR fixes the currently failing `auth-docs` build for repos. The is failing because the regex for grabbing the provider id's is unable to grab the id for [`azure-devops.ts`](https://github.com/nextauthjs/next-auth/blob/578ff21d7e272e7dcb910cb09f7ad005100fada3/packages/core/src/providers/azure-devops.ts#L127) file in the azure devops provider.

The id is not being grabbed becuase the file is not formatted properly to use double-quotes which the regex requires to work! This fixes the issue by formatting the file.

The regex could also be updated to support single-quotes, or we might add CI to ensure all files are appropriately linted! Leaving this open for discussuion before proceeding with such a fix.


## 🧢 Checklist

- [ ] Documentation (N/A)
- [ ] Tests (N/A)
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #8464 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
