### PR TITLE
fix: 🎣 remove trailing `?` from signIn url

### DIFF
--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -247,10 +247,7 @@ export async function signIn<
     isCredentials ? "callback" : "signin"
   }/${provider}`
 
-  const _params = authorizationParams
-    ? `?${new URLSearchParams(authorizationParams)}`
-    : ""
-  const _signInUrl = `${signInUrl}${_params}`
+  const _signInUrl = `${signInUrl}${authorizationParams ? `?${new URLSearchParams(authorizationParams)} : ""}`
 
   const res = await fetch(_signInUrl, {
     method: "post",

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -247,7 +247,10 @@ export async function signIn<
     isCredentials ? "callback" : "signin"
   }/${provider}`
 
-  const _signInUrl = `${signInUrl}?${new URLSearchParams(authorizationParams)}`
+  const _params = authorizationParams
+    ? `?${new URLSearchParams(authorizationParams)}`
+    : ""
+  const _signInUrl = `${signInUrl}${_params}`
 
   const res = await fetch(_signInUrl, {
     method: "post",

--- a/packages/next-auth/src/react/index.tsx
+++ b/packages/next-auth/src/react/index.tsx
@@ -247,7 +247,7 @@ export async function signIn<
     isCredentials ? "callback" : "signin"
   }/${provider}`
 
-  const _signInUrl = `${signInUrl}${authorizationParams ? `?${new URLSearchParams(authorizationParams)} : ""}`
+  const _signInUrl = `${signInUrl}${authorizationParams ? `?${new URLSearchParams(authorizationParams)}` : ""}`
 
   const res = await fetch(_signInUrl, {
     method: "post",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

Fixing a weird bug where some URL categorizers that VPNs use will falsely categorize one of the sign-in redirects as phishing since the URL ends in a `?` when no parameters are provided to next-auth/react's `signIn()` function. 

The fix was simply to not include the `?` for query params when none are provided.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
