### PR TITLE
Add more detail to Credentials provider.

### DIFF
--- a/docs/docs/guides/providers/credentials-provider.md
+++ b/docs/docs/guides/providers/credentials-provider.md
@@ -7,11 +7,7 @@ The Credentials provider allows you to handle signing in with arbitrary credenti
 
 It is intended to support use cases where you have an existing system you need to authenticate users against.
 
-It comes with the constraint that users authenticated in this manner are not persisted in the database, and consequently that the Credentials provider can only be used if JSON Web Tokens are enabled for sessions.
-
-:::warning
-The functionality provided for credentials-based authentication is intentionally limited to discourage the use of passwords due to the inherent security risks associated with them and the additional complexity associated with supporting usernames and passwords.
-:::
+It comes with the constraint that users authenticated in this manner are not persisted in the database by default, and consequently, that the Credentials provider can only be used if JSON Web Tokens are enabled for sessions.
 
 ## Options
 
@@ -21,19 +17,43 @@ The **Credentials Provider** comes with a set of default options:
 
 You can override any of the options to suit your own use case.
 
+## Example - Web3 / Signin With Ethereum
+
+The credentials provider can also be used to integrate with a service like [Sign-in With Ethereum](https://login.xyz).
+
+For more information, check out the links below:
+
+- [Tutorial](https://docs.login.xyz/integrations/Auth.js)
+- [Example App Repo](https://github.com/spruceid/siwe-next-auth-example)
+- [Example App Demo](https://siwe-next-auth-example2.vercel.app/)
+
 ## Example - Username / Password
 
-The Credentials provider is specified like other providers, except that you need to define a handler for `authorize()` that accepts credentials submitted via HTTP POST as input and returns either:
+:::caution
+The functionality provided for credentials-based authentication is intentionally limited to discourage the use of passwords due to the inherent security risks of the username-password model.
 
-1. A `user` object, which indicates the credentials are valid.
+OAuth providers spend significant amounts of money, time, and engineering effort to build:
 
-If you return an object it will be persisted to the JSON Web Token and the user will be signed in, unless a custom `signIn()` callback is configured that subsequently rejects it.
+- bot-protection
+- rate-limiting
+- password management
+- data security
 
-2. If you return `null` then an error will be displayed advising the user to check their details.
+and much more for authentication solutions. It is likely that your application would benefit from leveraging these battle-tested solutions rather than try to rebuild them from scratch.
 
-3. If you throw an Error, the user will be sent to the error page with the error message as a query parameter.
+If you'd still like to build password-based authentication for your application despite these risks, Auth.js gives you full control to do so.
 
-The Credentials provider's `authorize()` method also provides the request object as the second parameter (see the example below).
+:::
+
+The Credentials provider is specified like other providers, except that you need to define a handler for `authorize()` that accepts credentials submitted via HTTP POST as input and returns a `user` object, which indicates the credentials are valid.
+
+If you return an object it will be persisted to the JSON Web Token and the user will be signed in (unless a custom `signIn()` callback is configured that subsequently rejects it).
+
+- If you return `null` then an error will be displayed advising the user to check their details.
+
+- If you throw an Error, the user will be sent to the error page with the error message as a query parameter.
+
+The Credentials provider's `authorize()` method also provides the request object as the second parameter. Here's an example that handles these concerns.
 
 ```js title="auth.js"
 import CredentialsProvider from "next-auth/providers/credentials";
@@ -70,7 +90,7 @@ providers: [
 ```
 
 See the [callbacks documentation](/reference/configuration/auth-config#callbacks) for more information on how to interact with the token. For example, you can add additional information to the token by returning an object from the `jwt()` callback:
-  
+
 ```js
 callbacks: {
   async jwt(token, user, account, profile, isNewUser) {
@@ -82,15 +102,27 @@ callbacks: {
 }
 ```
 
-## Example - Web3 / Signin With Ethereum
+### Using a database
 
-The credentials provider can also be used to integrate with a service like [Sign-in With Ethereum](https://login.xyz).
+You can also use the `jwt()` callback to interact with your database to regain some of the functionality from [more powerful providers](reference/core/providers):
 
-For more information, check out the links below:
+```js
+callbacks: {
+  async jwt(token, user) {
+    if (isNewUser) {
+      const userFromDb = await writeNewUserToDb()
+      return { token, user: userFromDb }
+    }
 
-- [Tutorial](https://docs.login.xyz/integrations/Auth.js)
-- [Example App Repo](https://github.com/spruceid/siwe-next-auth-example).
-- [Example App Demo](https://siwe-next-auth-example2.vercel.app/).
+  if (user) {
+   const userFromDb = await getUserFromDb(user.id)
+   return {token, user: userFromDb}
+  }
+
+    throw new Error("A user was not found or was not able to be created.")
+  }
+}
+```
 
 ## Multiple providers
 

--- a/docs/docs/guides/providers/credentials-provider.md
+++ b/docs/docs/guides/providers/credentials-provider.md
@@ -17,16 +17,6 @@ The **Credentials Provider** comes with a set of default options:
 
 You can override any of the options to suit your own use case.
 
-## Example - Web3 / Signin With Ethereum
-
-The credentials provider can also be used to integrate with a service like [Sign-in With Ethereum](https://login.xyz).
-
-For more information, check out the links below:
-
-- [Tutorial](https://docs.login.xyz/integrations/Auth.js)
-- [Example App Repo](https://github.com/spruceid/siwe-next-auth-example)
-- [Example App Demo](https://siwe-next-auth-example2.vercel.app/)
-
 ## Example - Username / Password
 
 :::caution
@@ -123,6 +113,16 @@ callbacks: {
   }
 }
 ```
+
+## Example - Web3 / Signin With Ethereum
+
+The credentials provider can also be used to integrate with a service like [Sign-in With Ethereum](https://login.xyz).
+
+For more information, check out the links below:
+
+- [Tutorial](https://docs.login.xyz/integrations/Auth.js)
+- [Example App Repo](https://github.com/spruceid/siwe-next-auth-example)
+- [Example App Demo](https://siwe-next-auth-example2.vercel.app/)
 
 ## Multiple providers
 


### PR DESCRIPTION
After speaking with the Auth.js maintainers about a change to the Credentials provider documentation, I'm opening this PR to introduce additional information about:
- *Why* the Credentials provider is discouraged
- How to interact with a database using the Credentials provider

While Auth.js does prefer to encourage use of other providers, the username-password model is (despite its flaws) still widely used today. Over time, I know I've personally seen a handful of users ask about the discouragement of the Credentials provider and express discontent with the way it is documented.

With this PR, I'm hoping to (slightly) close the gap on the community's understanding of the Credentials provider. While we can still (in my opinion, properly) discourage use of the username-password model, we can still bring in the understanding that some folks are going to want to opt to take on those risks, anyway.

## Please note

The psuedo-code that I've added in for interacting with a database is most likely wrong at the time of this PRs authorship. I've never used the Credentials provider myself but am aware that the maintainers have seen successful implementations that communicate with a database. Hoping I can get some maintainer help to document that code correctly!