### PR TITLE
Sequelize adapter - return session data from deleteSession()

### DIFF
--- a/packages/adapter-sequelize/src/index.ts
+++ b/packages/adapter-sequelize/src/index.ts
@@ -301,10 +301,10 @@ export default function SequelizeAdapter(
     async deleteSession(sessionToken) {
       await sync()
 
-      const foundSession = await Session.findOne({ where: { sessionToken } });
-      const sessionData = foundSession?.get({ plain: true });
-      await Session.destroy({ where: { sessionToken } });
-      return sessionData;
+      const foundSession = await Session.findOne({ where: { sessionToken } })
+      const sessionData = foundSession?.get({ plain: true })
+      await Session.destroy({ where: { sessionToken } })
+      return sessionData
     },
     async createVerificationToken(token) {
       await sync()

--- a/packages/adapter-sequelize/src/index.ts
+++ b/packages/adapter-sequelize/src/index.ts
@@ -301,7 +301,10 @@ export default function SequelizeAdapter(
     async deleteSession(sessionToken) {
       await sync()
 
-      await Session.destroy({ where: { sessionToken } })
+      const foundSession = await Session.findOne({ where: { sessionToken } });
+      const sessionData = foundSession?.get({ plain: true });
+      await Session.destroy({ where: { sessionToken } });
+      return sessionData;
     },
     async createVerificationToken(token) {
       await sync()

--- a/packages/adapter-sequelize/src/index.ts
+++ b/packages/adapter-sequelize/src/index.ts
@@ -301,10 +301,9 @@ export default function SequelizeAdapter(
     async deleteSession(sessionToken) {
       await sync()
 
-      const foundSession = await Session.findOne({ where: { sessionToken } })
-      const sessionData = foundSession?.get({ plain: true })
+      const session = await Session.findOne({ where: { sessionToken } })
       await Session.destroy({ where: { sessionToken } })
-      return sessionData
+      return session?.get({ plain: true })
     },
     async createVerificationToken(token) {
       await sync()


### PR DESCRIPTION
## ☕️ Reasoning

As described [in the documentation](https://next-auth.js.org/configuration/events#signout), the `signOut()` event expects `session` data which the user can then use / act upon. 
For example, (from what I can tell) the visitor data in the User table is not cleared upon sign out, so `signOut()` event can then use the `session.userId` to remove the relevant row from this table.

Currently the Sequelize adapter does not return this session data, so it is null in `signOut`. This PR adds this missing functionality.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

No relevant issues found.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
