### PR TITLE
feat: bump `mongodb` to v6

### DIFF
--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -42,13 +42,13 @@
     "@auth/core": "workspace:*"
   },
   "peerDependencies": {
-    "mongodb": "^5 || ^4"
+    "mongodb": "^6 || ^5 || ^4"
   },
   "devDependencies": {
     "@auth/adapter-test": "workspace:*",
     "@auth/tsconfig": "workspace:*",
     "jest": "^27.4.3",
-    "mongodb": "^4.17.0"
+    "mongodb": "^6.0.0"
   },
   "jest": {
     "preset": "@auth/adapter-test/jest"

--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -42,7 +42,7 @@
     "@auth/core": "workspace:*"
   },
   "peerDependencies": {
-    "mongodb": "^6 || ^5 || ^4"
+    "mongodb": "^6"
   },
   "devDependencies": {
     "@auth/adapter-test": "workspace:*",

--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -193,7 +193,7 @@ export function MongoDBAdapter(
         await db
       ).U.findOneAndUpdate({ _id }, { $set: user }, { returnDocument: "after" })
 
-      return from<AdapterUser>(result.value!)
+      return from<AdapterUser>(result!)
     },
     async deleteUser(id) {
       const userId = _id(id)
@@ -210,7 +210,7 @@ export function MongoDBAdapter(
       return account
     },
     async unlinkAccount(provider_providerAccountId) {
-      const { value: account } = await (
+      const account = await (
         await db
       ).A.findOneAndDelete(provider_providerAccountId)
       return from<AdapterAccount>(account!)
@@ -235,17 +235,17 @@ export function MongoDBAdapter(
     async updateSession(data) {
       const { _id, ...session } = to<AdapterSession>(data)
 
-      const result = await (
+      const updatedSession = await (
         await db
       ).S.findOneAndUpdate(
         { sessionToken: session.sessionToken },
         { $set: session },
         { returnDocument: "after" }
       )
-      return from<AdapterSession>(result.value!)
+      return from<AdapterSession>(updatedSession!)
     },
     async deleteSession(sessionToken) {
-      const { value: session } = await (
+      const session = await (
         await db
       ).S.findOneAndDelete({
         sessionToken,
@@ -257,14 +257,13 @@ export function MongoDBAdapter(
       return data
     },
     async useVerificationToken(identifier_token) {
-      const { value: verificationToken } = await (
+      const verificationToken = await (
         await db
       ).V.findOneAndDelete(identifier_token)
 
       if (!verificationToken) return null
-      // @ts-expect-error
-      delete verificationToken._id
-      return verificationToken
+      const { _id, ...rest } = verificationToken;
+      return rest;
     },
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,8 +515,8 @@ importers:
         specifier: ^27.4.3
         version: 27.5.1
       mongodb:
-        specifier: ^4.17.0
-        version: 4.17.0
+        specifier: ^6.0.0
+        version: 6.0.0
 
   packages/adapter-neo4j:
     dependencies:
@@ -10334,7 +10334,6 @@ packages:
     dependencies:
       sparse-bitfield: 3.0.3
     dev: true
-    optional: true
 
   /@mswjs/cookies@0.2.1:
     resolution: {integrity: sha512-0tDfcPw5/s7QsNQqS3knAvAD5w5PF1nNPagRhKO/yECY+sMbJxoC2sLWnH7Lzmh52mTSVLKDhd1r92Q3kfljnQ==}
@@ -14457,6 +14456,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       buffer: 5.7.1
+    dev: true
+
+  /bson@6.0.0:
+    resolution: {integrity: sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==}
+    engines: {node: '>=16.20.1'}
     dev: true
 
   /btoa-lite@1.0.0:
@@ -25279,7 +25283,6 @@ packages:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
     requiresBuild: true
     dev: true
-    optional: true
 
   /meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
@@ -25701,6 +25704,38 @@ packages:
       '@mongodb-js/saslprep': 1.1.0
     transitivePeerDependencies:
       - aws-crt
+    dev: true
+
+  /mongodb@6.0.0:
+    resolution: {integrity: sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.2.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+    dependencies:
+      '@mongodb-js/saslprep': 1.1.0
+      bson: 6.0.0
+      mongodb-connection-string-url: 2.6.0
     dev: true
 
   /morgan@1.10.0:
@@ -30103,7 +30138,6 @@ packages:
     dependencies:
       memory-pager: 1.5.0
     dev: true
-    optional: true
 
   /spawn-command@0.0.2-1:
     resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

updates to mongodb v6. so we can use the current version. v6 contains a breaking change for all the `findOneAnd` methods in that it returns the object, not a object containing (.value) (🥳).

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
