### PR TITLE
Removed typesafety statement `as string` from Configuring Auth.js of …

### DIFF
--- a/packages/adapter-dynamodb/src/index.ts
+++ b/packages/adapter-dynamodb/src/index.ts
@@ -56,8 +56,8 @@ export interface DynamoDBAdapterOptions {
  *
  * const config: DynamoDBClientConfig = {
  *   credentials: {
- *     accessKeyId: process.env.NEXT_AUTH_AWS_ACCESS_KEY as string,
- *     secretAccessKey: process.env.NEXT_AUTH_AWS_SECRET_KEY as string,
+ *     accessKeyId: process.env.NEXT_AUTH_AWS_ACCESS_KEY,
+ *     secretAccessKey: process.env.NEXT_AUTH_AWS_SECRET_KEY,
  *   },
  *   region: process.env.NEXT_AUTH_AWS_REGION,
  * };


### PR DESCRIPTION
…/adapter-dynamodb

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Removed Typesafety statements `as string` for Environment variables `NEXT_AUTH_AWS_ACCESS_KEY` and `NEXT_AUTH_AWS_SECRET_KEY` in next-auth's dynamodb-adapter documentation.

- link of page that has the typo - [visit](https://authjs.dev/reference/adapter/dynamodb#configuring-authjs)

## 🧢 Checklist

- [✅] Documentation
- [✅ ] Tests
- [✅ ] Ready to be merged

## 🎫 Affected issues
Removed Typesafety statements `as string` for Environment variables `NEXT_AUTH_AWS_ACCESS_KEY` and `NEXT_AUTH_AWS_SECRET_KEY` in next-auth's dynamodb-adapter documentation.