### PR TITLE
fix: Build account object with tokens spread as lowest priority

### DIFF
--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -202,10 +202,10 @@ async function getUserAndAccount(
     return {
       user,
       account: {
+        ...tokens,
         provider: provider.id,
         type: provider.type,
         providerAccountId: user.id.toString(),
-        ...tokens,
       },
     }
   } catch (e) {

--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -160,10 +160,10 @@ async function getProfile({
     return {
       profile,
       account: {
+        ...tokens,
         provider: provider.id,
         type: provider.type,
         providerAccountId: profile.id.toString(),
-        ...tokens,
       },
       OAuthProfile,
     }

--- a/packages/next-auth/src/core/lib/oauth/callback.ts
+++ b/packages/next-auth/src/core/lib/oauth/callback.ts
@@ -160,10 +160,10 @@ async function getProfile({
     return {
       profile,
       account: {
-        ...tokens,
         provider: provider.id,
         type: provider.type,
         providerAccountId: profile.id.toString(),
+        ...tokens,
       },
       OAuthProfile,
     }


### PR DESCRIPTION
## ☕️ Reasoning

tokens comes from the provider and could have arbitrary keys, but type, provider, and providerAccountId have reserved meanings to NextAuth that must take priority for correct operation.

I discovered this because I had a tokens endpoint that had a type key in the response, which caused next-auth to fail because it was expecting type to be "oauth". I managed to work around it for now by mutating tokens in the profile callback.

I don't believe that this is a security issue but there's always some chance when untrusted input ends up in the wrong place.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

I didn't find any associated issues and implementing the very small PR was easier than reporting it separately.
