### PR TITLE
Update SvelteKitAuth example default import to named import

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -269,7 +269,7 @@ export default function Home() {
 }
 
 const svelteKitCode = `
-import SvelteKitAuth from "@auth/sveltekit"
+import { SvelteKitAuth } from "@auth/sveltekit"
 import GitHub from '@auth/core/providers/github'
 import Facebook from '@auth/core/providers/facebook'
 import Google from '@auth/core/providers/google'


### PR DESCRIPTION
## ☕️ Reasoning

I copied the code from this example directly and ran into an error. It took me a few minutes to realize the SvelteKitAuth function is no longer a default export. This change updates the example to match others found in the documentation.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

I didn't find any open issues addressing this
