### PR TITLE
fix: add getSetCookie to session cookies if supported

### DIFF
--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -139,7 +139,10 @@ export function initAuth(config: NextAuthConfig) {
       } = (await authResponse.json()) ?? {}
 
       // Preserve cookies set by Auth.js Core
-      const cookies = authResponse.headers.get("set-cookie")
+      const cookies =
+        "getSetCookie" in authResponse.headers
+          ? authResponse.headers.getSetCookie()
+          : authResponse.headers.get("set-cookie")
       if (cookies) response?.setHeader("set-cookie", cookies)
 
       return { user, expires, ...rest } satisfies Session

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -204,7 +204,10 @@ async function handleAuth(
 
   // Preserve cookies set by Auth.js Core
   const finalResponse = new Response(response?.body, response)
-  const authCookies = sessionResponse.headers.get("set-cookie")
+  const authCookies =
+    "getSetCookie" in sessionResponse.headers
+      ? sessionResponse.headers.getSetCookie()
+      : sessionResponse.headers.get("set-cookie")
   if (authCookies) finalResponse.headers.set("set-cookie", authCookies)
 
   return finalResponse

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -139,11 +139,7 @@ export function initAuth(config: NextAuthConfig) {
       } = (await authResponse.json()) ?? {}
 
       // Preserve cookies set by Auth.js Core
-      const cookies =
-        "getSetCookie" in authResponse.headers
-          ? authResponse.headers.getSetCookie()
-          : authResponse.headers.get("set-cookie")
-      if (cookies) response?.setHeader("set-cookie", cookies)
+      cloneSetCookie({ from: authResponse, to: response })
 
       return { user, expires, ...rest } satisfies Session
     })
@@ -205,15 +201,32 @@ async function handleAuth(
     }
   }
 
-  // Preserve cookies set by Auth.js Core
   const finalResponse = new Response(response?.body, response)
-  const authCookies =
-    "getSetCookie" in sessionResponse.headers
-      ? sessionResponse.headers.getSetCookie()
-      : sessionResponse.headers.get("set-cookie")
-  if (authCookies) finalResponse.headers.set("set-cookie", authCookies)
+  // Preserve cookies set by Auth.js Core
+  cloneSetCookie({ from: sessionResponse, to: finalResponse })
 
   return finalResponse
+}
+
+/**
+ * Mutates `to` with the set-cookie from `from`
+ * Uses `getSetCookie` if available, otherwise falls back to `set-cookie`
+ *
+ * getSetCookie is missing from the types, but it's available on many platforms.
+ */
+function cloneSetCookie({ from, to }: { from: Response; to: Response }) {
+  const authCookies =
+    "getSetCookie" in from.headers
+      ? (from.headers.getSetCookie as any)()
+      : from.headers.get("set-cookie")
+
+  if (!authCookies) return
+
+  if (Array.isArray(authCookies)) {
+    authCookies.forEach((cookie) => to.headers.append("set-cookie", cookie))
+  } else {
+    to.headers.set("set-cookie", authCookies)
+  }
 }
 
 /** Check if the request is for a NextAuth.js action. */


### PR DESCRIPTION
## ☕️ Reasoning

I saw that .getSetCookie were finally supported in the edge runtime when deployed to Vercel. This uses `getSetCookie` if supported, otherwise falls back to `.get('set-cookie)`

Deployed a version with this patch here:

Reproduction deployment: [next-auth-error-vercel.vercel.app](https://next-auth-error-vercel.vercel.app/)
Reproduction repo: [edenstrom/next-auth-error-vercel](https://github.com/edenstrom/next-auth-error-vercel)

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

This solves the long standing issue were chunked cookies didn't work when using the edge runtime deployed to Vercel.

https://github.com/nextauthjs/next-auth/pull/7443#issuecomment-1677261203


Related issues:
- https://github.com/vercel/edge-runtime/issues/536
- https://github.com/sidebase/nuxt-auth/issues/293

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
