### PR TITLE
Remove asterisk that causes build error in oauth-tutorial.mdx

### DIFF
--- a/docs/docs/getting-started/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/oauth-tutorial.mdx
@@ -205,7 +205,7 @@ Create the following [Server hook](https://kit.svelte.dev/docs/hooks) file. This
 import { SvelteKitAuth } from "@auth/sveltekit"
 import GitHub from "@auth/core/providers/github"
 import { GITHUB_ID, GITHUB_SECRET } from "$env/static/private"
- *
+
 export const handle = SvelteKitAuth({
   providers: [GitHub({ clientId: GITHUB_ID, clientSecret: GITHUB_SECRET })],
 })


### PR DESCRIPTION
Remove * from example that's causing an unexpected character error

## ☕️ Reasoning

Before this change, copy and pasting the code example would result in an error from the unexpected asterisk.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
