### PR TITLE
fix: rm .js from imports

### DIFF
--- a/packages/next-auth/src/index.tsx
+++ b/packages/next-auth/src/index.tsx
@@ -120,7 +120,7 @@
  */
 
 import { Auth, skipCSRFCheck, raw } from "@auth/core"
-import { cookies, headers } from "next/headers.js"
+import { cookies, headers } from "next/headers"
 import { detectOrigin, reqWithEnvUrl, setEnvDefaults } from "./lib/env.js"
 import { initAuth } from "./lib/index.js"
 

--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -1,5 +1,5 @@
-import { NextRequest } from "next/server.js"
-import type { headers } from "next/headers.js"
+import { NextRequest } from "next/server"
+import type { headers } from "next/headers"
 
 import type { NextAuthConfig } from "./index.js"
 


### PR DESCRIPTION
apparently importing from "next/server.js" forces a cjs import which causes vercel/og to not be treeshaken