### PR TITLE
Add callbackUrl usage snippet for POST request

### DIFF
--- a/docs/docs/getting-started/client.md
+++ b/docs/docs/getting-started/client.md
@@ -421,6 +421,19 @@ e.g.
 
 The URL must be considered valid by the [redirect callback handler](/configuration/callbacks#redirect-callback). By default it requires the URL to be an absolute URL at the same host name, or a relative url starting with a slash. If it does not match it will redirect to the homepage. You can define your own [redirect callback](/configuration/callbacks#redirect-callback) to allow other URLs.
 
+#### Redirecting using a POST request
+
+The `callbackUrl` can also be sent using an HTML <form> POST request.
+
+```html
+<form
+  method="post"
+  action="/api/auth/signin/email"
+>
+  <input name="callbackUrl" type="hidden" defaultValue="/foo" />
+</form>
+```
+
 ### Using the `redirect: false` option
 
 :::note


### PR DESCRIPTION
In using the `signIn` and `signOut` functionality it is simple to add redirection via `callbackUrl`, which is well documented. 

This commit adds `callbackUrl` usage to the documentation for users that customize authentication pages, calling the API directly with a csrf token (via `getCsrfToken`).

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

I needed documentation for `callbackUrl` usage today when customizing an application today that uses custom login pages, i.e. grabs a csrf token using `getCsrfToken` and submits that with other form data in a POST request from the client. 

In addition to a Stackoverflow answer, this PR adds how to do this to the documentation. This might be in the wrong place within the docs so please let me know if that's the case. 

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

I searched a few terms and found none specifically targeting missing documentation on this use case.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)

If this PR is in any way burdensome, please close. And thanks for all the awesome hard work on this library! 