### PR TITLE
feat(core): Support HTTP options for OAuth2 requests

### DIFF
--- a/packages/core/src/lib/oauth/callback.ts
+++ b/packages/core/src/lib/oauth/callback.ts
@@ -105,7 +105,8 @@ export async function handleOAuth(
     client,
     codeGrantParams,
     redirect_uri,
-    codeVerifier ?? "auth" // TODO: review fallback code verifier
+    codeVerifier ?? "auth", // TODO: review fallback code verifier
+    provider.httpOptions
   )
 
   if (provider.token?.conform) {
@@ -159,7 +160,8 @@ export async function handleOAuth(
       const userinfoResponse = await o.userInfoRequest(
         as,
         client,
-        (tokens as any).access_token
+        (tokens as any).access_token,
+        provider.httpOptions
       )
       profile = await userinfoResponse.json()
     } else {

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -1,4 +1,4 @@
-import type { Client } from "oauth4webapi"
+import type { Client, HttpRequestOptions } from "oauth4webapi"
 import type { CommonProviderOptions } from "../providers/index.js"
 import type {
   AuthConfig,
@@ -221,6 +221,7 @@ export interface OAuth2Config<Profile>
    */
   allowDangerousEmailAccountLinking?: boolean
   redirectProxyUrl?: AuthConfig["redirectProxyUrl"]
+  httpOptions?: HttpRequestOptions
   /**
    * The options provided by the user.
    * We will perform a deep-merge of these values


### PR DESCRIPTION
## ☕️ Reasoning

It would be great if we can inject some HTTP header(s) for protected (internal) OAuth providers .

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

N/A

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
