### PR TITLE
Revert "fixed broken security link on npm docs"

### DIFF
--- a/packages/next-auth/README.md
+++ b/packages/next-auth/README.md
@@ -168,7 +168,7 @@ export default function App({
 
 ## Security
 
-If you think you have found a vulnerability (or not sure) in NextAuth.js or any of the related packages (i.e. Adapters), we ask you to have a read of our [Security Policy](https://github.com/nextauthjs/next-auth/security/policy) to reach out responsibly. Please do not open Pull Requests/Issues/Discussions before consulting with us.
+If you think you have found a vulnerability (or not sure) in NextAuth.js or any of the related packages (i.e. Adapters), we ask you to have a read of our [Security Policy](https://github.com/nextauthjs/next-auth/blob/main/SECURITY.md) to reach out responsibly. Please do not open Pull Requests/Issues/Discussions before consulting with us.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Reverts nextauthjs/next-auth#8710

This needs to be done on the `v4` branch: https://github.com/nextauthjs/next-auth/commit/50eb23f626f25d06ca03e3316c8d1d755d00b6ab