### PR TITLE
Changed the SQL comment syntax from // to -- in index.ts

### DIFF
--- a/packages/adapter-supabase/src/index.ts
+++ b/packages/adapter-supabase/src/index.ts
@@ -260,7 +260,7 @@ export interface SupabaseAdapterOptions {
  * For example, given the following public schema:
  *
  * ```sql
- * // Note: This table contains user data. Users should only be able to view and update their own data.
+ * -- Note: This table contains user data. Users should only be able to view and update their own data.
  * create table users (
  *   -- UUID from next_auth.users
  *   id uuid not null primary key,
@@ -276,7 +276,7 @@ export interface SupabaseAdapterOptions {
  * create policy "Can view own user data." on users for select using (next_auth.uid() = id);
  * create policy "Can update own user data." on users for update using (next_auth.uid() = id);
  *
- * // This trigger automatically creates a user entry when a new user signs up via NextAuth.
+ * -- This trigger automatically creates a user entry when a new user signs up via NextAuth.
  * create function public.handle_new_user()
  * returns trigger as $$
  * begin


### PR DESCRIPTION
Path:
`/next-auth/packages/adapter-supabase/src/index.ts`

## ☕️ Reasoning
I've observed that the SQL comment syntax used in index.ts is **//**, which is non-standard for SQL. The standard single-line comment syntax for SQL is **--**. This pull request corrects the SQL comment syntax to adhere to the standard conventions, improving readability and avoiding potential issues in SQL execution.

## 🧢 Checklist

- [x] Documentation: Not applicable, as this change is a minor syntax correction and doesn't impact the functionality or the existing documentation.
- [x] Tests:  Not applicable, as this is a syntax correction and doesn't alter the logic or behavior of the code.
- [x] Ready to be merged: Pending Review