### PR TITLE
Styling adjustments for sponsor ad

### DIFF
--- a/docs/src/components/clerk.js
+++ b/docs/src/components/clerk.js
@@ -18,10 +18,10 @@ export function Clerk() {
     <span className="tailwind">
       <section
         ref={inViewRef}
-        className="h-[360px] w-full overflow-hidden py-8 sm:h-[480px] pb-24 mb-24"
+        className="h-[430px] w-full overflow-hidden py-8 sm:h-[480px] pb-24 mb-24"
       >
         <div className="relative mx-auto flex h-full w-full max-w-6xl flex-col">
-          <div className="absolute top-1 inline-flex w-fit self-center rounded-md border-black/[0.07] px-4 py-1 text-[13px] font-medium tracking-tight text-[#B2B2B2] shadow-[inset_0px_1px_2px_rgba(0,0,0,0.07),inset_1px_0px_2px_rgba(0,0,0,0.07),inset_-1px_0px_2px_rgba(0,0,0,0.07)] [mask:linear-gradient(black,black_50%,transparent)] dark:border-white/[0.07] dark:text-white dark:shadow-[inset_0px_1px_2px_rgba(255,255,255,0.07),inset_1px_0px_2px_rgba(255,255,255,0.07),inset_-1px_0px_2px_rgba(255,255,255,0.07)] ">
+          <div className="absolute -top-1 inline-flex w-fit self-center rounded-md ring-black/[0.07] px-6 pt-1 pb-1.5 text-[12px] font-medium tracking-tighter text-[#B2B2B2] shadow-[inset_0px_1px_1px_rgba(0,0,0,0.07),inset_1px_0px_1px_rgba(0,0,0,0.07),inset_-1px_0px_1px_rgba(0,0,0,0.07)] [mask:linear-gradient(180deg,black,black_54%,transparent)] dark:ring-white/[0.07] dark:text-white dark:shadow-[inset_0px_1px_1px_rgba(255,255,255,0.07),inset_1px_0px_1px_rgba(255,255,255,0.07),inset_-1px_0px_1px_rgba(255,255,255,0.07)] ">
             Sponsored by
           </div>
           <div className="flex flex-1 items-center justify-center">
@@ -50,54 +50,54 @@ export function Clerk() {
               <span className="sr-only">Clerk complete user management</span>
             </h2>
 
-            <p className="text-center text-[17px] leading-relaxed tracking-tight dark:text-white">
+            <p className="text-center text-base leading-tight dark:text-white tracking-tight">
               More than authentication...
               <br />
-              <span className="text-[17px] font-bold text-[#6C47FF] sm:text-[28px]">
+              <span className="text-2xl font-bold text-[#6C47FF] sm:text-[28px]">
                 Complete user management.
               </span>
             </p>
 
             <div className="relative isolate">
-              <a
-                href="https://clerk.com?utm_source=sponsorship&utm_medium=website&utm_campaign=authjs&utm_content=09_01_2023"
-                className="relative isolate inline-flex h-8 items-center gap-1.5 rounded-[8px] px-4 text-[13px] font-semibold text-white before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:shadow-lg before:shadow-[rgb(100_48_247/0.3)] after:absolute after:inset-0 after:rounded-[inherit] after:bg-[#6C47FF] after:shadow-[inset_0px_-8px_16px_-4px_#6430F7,inset_0px_0px_1px_1px_theme(colors.white/4%),inset_0px_1px_0px_theme(colors.white/10%),0px_0px_0px_1px_rgb(72_24_191/0.15)] dark:before:shadow-black"
-              >
-                <span className="z-20 flex items-center gap-1.5 bg-gradient-to-b from-white from-50% to-[#D7D4FF] bg-clip-text text-transparent drop-shadow-[0px_1px_1px_rgb(86_30_227/60%)]">
-                  <span>Get started for free</span>
-                  <ArrowIcon />
-                </span>
-              </a>
+            <a
+              href="https://clerk.com?utm_source=sponsorship&utm_medium=website&utm_campaign=authjs&utm_content=09_01_2023"
+              className="relative isolate inline-flex h-8 items-center gap-1.5 rounded-[8px] px-4 text-[13px] font-semibold text-white before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:shadow-lg before:shadow-[rgb(100_48_247/0.3)] after:absolute after:inset-0 after:rounded-[inherit] after:bg-[#6C47FF] after:shadow-[inset_0px_-8px_16px_-4px_#6430F7,inset_0px_0px_1px_1px_theme(colors.white/4%),inset_0px_1px_0px_theme(colors.white/10%),0px_0px_0px_1px_#6C47FF] dark:before:shadow-black"
+            >
+              <span className="z-20 flex items-center gap-1.5 bg-gradient-to-b from-white from-50% to-[#D7D4FF] bg-clip-text text-transparent drop-shadow-[0px_1px_1px_rgb(86_30_227/60%)]">
+                <span>Get started for free</span>
+                <ArrowIcon />
+              </span>
+            </a>
 
-              {[...Array(4)].map((_, i) => (
-                <motion.div
-                  key={i}
-                  className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[275%] w-[135%] rounded-[22px] border border-[#6C47FF]/[.15] dark:border-[#6C47FF]/25"
-                  style={{ x: "-50%", y: "-50%" }}
-                  initial={{ opacity: 0, scaleX: 0.75, scaleY: 0.4 }}
-                  animate={
-                    isInView
-                      ? {
-                          opacity: [0, 1, 0],
-                          scaleX: 1,
-                          scaleY: 1,
-                        }
-                      : {}
-                  }
-                  transition={
-                    isInView
-                      ? {
-                          delay: i * 1,
-                          duration: 4,
-                          ease: "linear",
-                          repeat: Infinity,
-                          times: [0, 0.1, 1],
-                        }
-                      : {}
-                  }
-                />
-              ))}
-            </div>
+            {[...Array(4)].map((_, i) => (
+              <motion.div
+                key={i}
+                className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[275%] w-[135%] rounded-[22px] border border-[#6C47FF]/[.15] dark:border-[#6C47FF]/25"
+                style={{ x: '-50%', y: '-50%' }}
+                initial={{ opacity: 0, scaleX: 0.75, scaleY: 0.4 }}
+                animate={
+                  isInView
+                    ? {
+                        opacity: [0, 1, 0],
+                        scaleX: 1,
+                        scaleY: 1,
+                      }
+                    : {}
+                }
+                transition={
+                  isInView
+                    ? {
+                        delay: i * 1,
+                        duration: 4,
+                        ease: 'linear',
+                        repeat: Infinity,
+                        times: [0, 0.1, 1],
+                      }
+                    : {}
+                }
+              />
+            ))}
+          </div>
 
             <div className="absolute left-1/2 top-0 -z-10 h-[140px] w-3/4 -translate-x-1/2 -translate-y-1/3 rotate-12 transform-gpu rounded-[50%] bg-gradient-to-r from-[#6C47FF] via-[#4818BF] via-25% to-sky-500 opacity-10 blur-3xl" />
           </div>

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: ['class','[data-theme="dark"]'],
   content: ["./src/**/*.js"],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## ☕️ Reasoning

Configure Tailwind for dark mode and tweaks to the sponsor ad.

Before:
<img width="1270" alt="image" src="https://github.com/nextauthjs/next-auth/assets/16806097/720b8471-8e88-4ca9-861e-82e77d63b667">

<img width="1228" alt="image" src="https://github.com/nextauthjs/next-auth/assets/16806097/0c15244d-c5d5-4146-9d74-5cf2a506bbe1">


After:
<img width="1380" alt="image" src="https://github.com/nextauthjs/next-auth/assets/16806097/44aaf0ff-8be7-4c53-a193-582ccf0e187f">

<img width="1254" alt="image" src="https://github.com/nextauthjs/next-auth/assets/16806097/c2e04da4-e19c-4788-80f6-2caa962aff00">


