### PR TITLE
fix(next): returns correct status for signing in with `redirect: false` for route handler

### DIFF
--- a/packages/next-auth/src/core/lib/cookie.ts
+++ b/packages/next-auth/src/core/lib/cookie.ts
@@ -114,7 +114,7 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
         path: "/",
         secure: useSecureCookies,
       },
-    }
+    },
   }
 }
 
@@ -161,22 +161,22 @@ export class SessionStore {
     }
   }
 
- /**
+  /**
    * The JWT Session or database Session ID
    * constructed from the cookie chunks.
    */
- get value() {
-  // Sort the chunks by their keys before joining
-  const sortedKeys = Object.keys(this.#chunks).sort((a, b) => {
-    const aSuffix = parseInt(a.split(".").pop() || "0")
-    const bSuffix = parseInt(b.split(".").pop() || "0")
+  get value() {
+    // Sort the chunks by their keys before joining
+    const sortedKeys = Object.keys(this.#chunks).sort((a, b) => {
+      const aSuffix = parseInt(a.split(".").pop() ?? "0")
+      const bSuffix = parseInt(b.split(".").pop() ?? "0")
 
-    return aSuffix - bSuffix
-  });
+      return aSuffix - bSuffix
+    })
 
-  // Use the sorted keys to join the chunks in the correct order
-  return sortedKeys.map(key => this.#chunks[key]).join("")
-}
+    // Use the sorted keys to join the chunks in the correct order
+    return sortedKeys.map((key) => this.#chunks[key]).join("")
+  }
 
   /** Given a cookie, return a list of cookies, chunked to fit the allowed cookie size. */
   #chunk(cookie: Cookie): Cookie[] {

--- a/packages/next-auth/src/next/index.ts
+++ b/packages/next-auth/src/next/index.ts
@@ -101,6 +101,7 @@ async function NextAuthRouteHandler(
     response.headers.delete("Location")
     response.headers.set("Content-Type", "application/json")
     return new Response(JSON.stringify({ url: redirect }), {
+      status: internalResponse.status,
       headers: response.headers,
     })
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

When signing in with `next-auth/react` `signIn()` function with `redirect: false`, the status is not correctly set in the response. There are two cases that this bug will return 200 OK instead of the expected status:
1. When signing in with the Credential provider and the `authorize` function returns false or throws an error. Expected status: 401
2. When the `signIn` callback returns false. Expected status: 403

Basically, the bug appears every time we return `status` and `redirect` at the same time for one `return` statement in `packages/next-auth/src/core/routes/callback.ts`.

Note that this bug only affects Route Handler. For API Route, we calls `res: NextApiResponse` instead of returning a new `Response` object.

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #7638, fixes #7725, fixes #8340

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
