### PR TITLE
example which shows how to add more scopes and permission

### DIFF
--- a/docs/docs/providers/discord.md
+++ b/docs/docs/providers/discord.md
@@ -33,7 +33,7 @@ providers: [
 ...
 ```
 
-Here is an example on how you can add more score and permission.
+Here is an example on how you can add more scopes and permissions.
 
 ## Example
 

--- a/docs/docs/providers/discord.md
+++ b/docs/docs/providers/discord.md
@@ -32,3 +32,21 @@ providers: [
 ]
 ...
 ```
+
+Here is an example on how you can add more score and permission.
+
+## Example
+
+```js
+import DiscordProvider from "next-auth/providers/discord";
+...
+providers: [
+  DiscordProvider({
+    clientId: process.env.DISCORD_CLIENT_ID,
+    clientSecret: process.env.DISCORD_CLIENT_SECRET,
+    authorization:
+        "Url with extra scopes an permissions for your application to function",
+  })
+]
+...
+```


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

When I was using nextauth for authentication via discord, I wanted to get more permissions from the discord. But the default permissions are only `email` and `identify`. Didn't find documentation where I can add the custom link which give my app more permissions. So to make it easy for future novice developers adding this example here.

Open to suggestions.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
