### PR TITLE
docs: update localhost to actual domain

### DIFF
--- a/packages/adapter-pg/src/index.ts
+++ b/packages/adapter-pg/src/index.ts
@@ -34,7 +34,7 @@ export function mapExpiresAt(account: any): any {
 /**
  * ## Setup
  *
- * The SQL schema for the tables used by this adapter is as follows. Learn more about the models at our doc page on [Database Models](http://localhost:3000/reference/adapters#models).
+ * The SQL schema for the tables used by this adapter is as follows. Learn more about the models at our doc page on [Database Models](https://authjs.dev/reference/adapters#models).
  * ```sql
  * CREATE TABLE verification_token
  * (


### PR DESCRIPTION
Updated documentation reference to the actual domain [authjs.dev].

## ☕️ Reasoning
- I noticed the documentation reference link took me to my local host while reading the docs.
- This will improve the accuracy and usability of the documentation for users.
<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation