### PR TITLE
Add callbackUrl field to credentials signin form

### DIFF
--- a/packages/core/src/lib/pages/signin.tsx
+++ b/packages/core/src/lib/pages/signin.tsx
@@ -210,6 +210,13 @@ export default function SigninPage(props: {
               {provider.type === "credentials" && (
                 <form action={provider.callbackUrl} method="POST">
                   <input type="hidden" name="csrfToken" value={csrfToken} />
+                  {callbackUrl && (
+                    <input
+                      type="hidden"
+                      name="callbackUrl"
+                      value={callbackUrl}
+                    />
+                  )}
                   {Object.keys(provider.credentials).map((credential) => {
                     return (
                       <div key={`input-group-${provider.id}`}>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
The bug:
1. Visit the signin page with a callback URL (e.g., `/auth/signin?callbackUrl=/test`).
2. In parallel visit another URL which also redirects to sign in (e.g. the browser automatically requests `/favicon.ico` and is redirected to `/auth/signin?callbackUrl=/favicon.ico` which saves `/favicon.ico` into callbackUrl cookie).
3. Now fill in credentials and sign into the first page - it redirects to `/favicon.ico` instead of `/test`. That's because the `callbackUrl` from the query string is lost for the credentials provider (this PR should fix that) and the cookie is used instead.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
