### PR TITLE
docs: fix non-closing admonition block in oauth-tutorial.mdx

### DIFF
--- a/docs/docs/getting-started/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/oauth-tutorial.mdx
@@ -391,7 +391,7 @@ Note that, for each provider, the configuration process will be similar to what 
 2. Create create your OAuth application within it
 3. Set the callback URL
 4. Get the Client ID and Generate a Client Secret
-   :::
+:::
 
 ## 3. Wiring all together
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

On https://authjs.dev/getting-started/oauth-tutorial, the closing admonition is misaligned, resulting in the admonition containing more content than intended.

<img width="890" alt="image" src="https://github.com/nextauthjs/next-auth/assets/1315101/eddc34a7-cffb-4d0b-a68a-3b4371e5d8a9">

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
