### PR TITLE
return entire session from session callback

### DIFF
--- a/packages/core/src/lib/routes/session.ts
+++ b/packages/core/src/lib/routes/session.ts
@@ -125,13 +125,7 @@ export async function session(params: {
 
       // Pass Session through to the session callback
       const sessionPayload = await callbacks.session({
-        // By default, only exposes a limited subset of information to the client
-        // as needed for presentation purposes (e.g. "you are logged in as...").
-        session: {
-          // @ts-expect-error missing `id`.
-          user: { name: user.name, email: user.email, image: user.image },
-          expires: session.expires.toISOString(),
-        },
+        session,
         user,
         newSession,
         ...(isUpdate ? { trigger: "update" } : {}),


### PR DESCRIPTION
**proposal only**: 

if you think this is valid i can tidy up the PR and make the tests pass / add more 

---

i've been using this behavior ever since starting to use the v5 alpha way back, as I don't really see the reason for this filtering.

there is no clientside code in @auth/core, so I don't fully understand why it needs to be sanitized? isn't that a job each framework adapter should take.

also, if i'm not mistaken, the default session callback will still only return a subset, so this change should only be apparent to those using a custom session callback and chooses to return more data?