### PR TITLE
Expose `id` and `name` for `EmailProvider` config

### DIFF
--- a/packages/core/src/providers/email.ts
+++ b/packages/core/src/providers/email.ts
@@ -51,8 +51,10 @@ export interface SendVerificationRequestParams {
  * [Custom email service with Auth.js](https://authjs.dev/guides/providers/email#custom-email-service)
  */
 export interface EmailUserConfig extends Record<string, unknown> {
+  id?: string
   server?: AllTransportOptions
   type?: "email"
+  name?: string
   /** @default `"Auth.js <no-reply@authjs.dev>"` */
   from?: string
   /**
@@ -102,9 +104,9 @@ export interface EmailUserConfig extends Record<string, unknown> {
 
 export interface EmailConfig extends CommonProviderOptions {
   // defaults
-  id: "email"
+  id: string
   type: "email"
-  name: "Email"
+  name: string
   server: AllTransportOptions
   from: string
   maxAge: number
@@ -362,9 +364,9 @@ export type EmailProviderType = "email"
  */
 export default function Email(config: EmailUserConfig): EmailConfig {
   return {
-    id: "email",
+    id: config.id || "email",
     type: "email",
-    name: "Email",
+    name:  config.name || "Email",
     server: { host: "localhost", port: 25, auth: { user: "", pass: "" } },
     from: "Auth.js <no-reply@authjs.dev>",
     maxAge: 24 * 60 * 60,


### PR DESCRIPTION
Allow multiple `EmailProvider` to be configured that vary by `id`.

## ☕️ Reasoning

In v4.22.1 and before, it was allowed to provide `id` and `name` to the email provider. This enabled multiple email providers to be declared and sign-in to conditionally target which email provider to use:

```ts
const authOptions = {
    ...,
    providers: [
      GoogleProvider({...}),
      EmailProvider({
        server: smtp1,
        sendVerificationRequest: async ({ identifier: email, url, provider: { server, from } }) => {...}
      }),
      EmailProvider({
        id: 'invite-member',
        name: 'Invite Member',
        server: smtp2,
        maxAge: 3 * 24 * 60 * 60,
        sendVerificationRequest: async ({ identifier: email, url, provider: { server, from } }) => {...}
      })
    ],
    ...
} satisfies AuthOptions

// elsewhere

await signIn('email', {
  callbackUrl: `${window.location.origin}/profile`,
  email
});

// or

await signIn('invite-member', {
  callbackUrl: `${window.location.origin}/auth/new-invite`,
  email
});
```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: #8125

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
