### PR TITLE
update link to providers list

### DIFF
--- a/docs/docs/getting-started/providers/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/providers/oauth-tutorial.mdx
@@ -16,7 +16,7 @@ The goal of Auth.js is that you can add authentication easily to your project wi
 The fastest way to set up Auth.js is with an [OAuth](/concepts/oauth) provider. In this tutorial, we'll be setting Auth.js in a web application to be able to log in with **GitHub**.
 
 :::info
-Auth.js comes with a list of [built-in providers](/reference/providers/oauth-builtin) (Google, Facebook, Twitter, etc.). You can also integrate it with your OAuth service by [building a custom provider](/guides/providers/custom-provider).
+Auth.js comes with a list of [built-in providers](/getting-started/providers) (Google, Facebook, Twitter, etc.). You can also integrate it with your OAuth service by [building a custom provider](/guides/providers/custom-provider).
 :::
 
 ## 1. Configuring Auth.js


### PR DESCRIPTION
## ☕️ Reasoning

The PR edits the broken link to index page that contains the list providers. Full link below: 

https://authjs.dev/getting-started/providers

![CleanShot 2023-10-26 at 16 51 31](https://github.com/nextauthjs/next-auth/assets/12041898/08405465-f67c-4a02-8129-b291194c3c00)

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: [Broken link to built-in providers](https://github.com/nextauthjs/next-auth/issues/8703)
