### PR TITLE
update commands on bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_framework.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_framework.yml
@@ -30,7 +30,9 @@ body:
         Run this command in your project's root folder and paste the result:
 
         ```sh
-        npx envinfo --system --binaries --browsers --npmPackages "next,react,next-auth,@auth/*"
+        npx envinfo --system --binaries --browsers && 
+        npx envinfo --npmPackages "next,react,next-auth" && 
+        npx envinfo --npmPackages "@auth/*"
         ```
         Alternatively, you can manually gather the version information from your package.json for these packages: "next", "react" and "next-auth". Please also mention your OS and Node.js version, as well as the browser you are using.
     validations:

--- a/.github/ISSUE_TEMPLATE/1_bug_framework.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_framework.yml
@@ -11,7 +11,7 @@ body:
 
         ### Important :exclamation:
 
-        _Providing incorrect/insufficient information or skipping steps to reproduce the issue will result in closing the issue and/or converting to a discussion without further explanation._
+        _Providing incorrect/insufficient information or skipping steps to reproduce the issue may result in closing the issue or converting to a discussion without further explanation._
 
         If you have a generic question specific to your project, it is best asked in Discussions under the [Questions category](https://github.com/nextauthjs/next-auth/discussions/new?category=Questions)
   # Let's wait with this until adoption in other frameworks.

--- a/.github/ISSUE_TEMPLATE/2_bug_provider.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_provider.yml
@@ -96,7 +96,9 @@ body:
         Run this command in your project's root folder and paste the result:
 
         ```sh
-        npx envinfo --system --binaries --browsers --npmPackages "next,react,next-auth,@auth/*"
+        npx envinfo --system --binaries --browsers && 
+        npx envinfo --npmPackages "next,react,next-auth" && 
+        npx envinfo --npmPackages "@auth/*"
         ```
         Alternatively, you can manually gather the version information from your package.json for these packages: "next", "react" and "next-auth". Please also mention your OS and Node.js version, as well as the browser you are using.
     validations:

--- a/.github/ISSUE_TEMPLATE/3_bug_adapter.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_adapter.yml
@@ -51,9 +51,11 @@ body:
         Run this command in your project's root folder and paste the result:
 
         ```sh
-        npx envinfo --system --binaries --browsers --npmPackages "next,react,next-auth,@auth/*" && npx envinfo --npmPackages "@next-auth/*"
+        npx envinfo --system --binaries --browsers && 
+        npx envinfo --npmPackages "next,react,next-auth" && 
+        npx envinfo --npmPackages "@auth/*"
         ```
-        Alternatively, if the above command did not work, we need the version of the following packages from your package.json: "next", "react", "next-auth" and your adapter. Please also mention your OS and Node.js version, as well as the browser you are using.
+        Alternatively, you can manually gather the version information from your package.json for these packages: "next", "react" and "next-auth". Please also mention your OS and Node.js version, as well as the browser you are using.
     validations:
       required: true
   - type: input


### PR DESCRIPTION
## ☕️ Reasoning

The commands in the issue template for bugs ( framework, provider, and adapter) to print out `envinfo` does not work as intended. This updates the command into three separate commands that will print out correctly. 

I have also updated the text so the instructions on all three pages are consistent.

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: [issue template has bad envinfo arguments #8644](https://github.com/nextauthjs/next-auth/issues/8644)
