### PR TITLE
Fixes broken link on v4 auth0 provider page

### DIFF
--- a/docs/docs/providers/auth0.md
+++ b/docs/docs/providers/auth0.md
@@ -15,7 +15,7 @@ https://manage.auth0.com/dashboard
 
 The **Auth0 Provider** comes with a set of default options:
 
-- [Auth0 Provider options](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/auth0.ts)
+- [Auth0 Provider options](https://github.com/nextauthjs/next-auth/blob/v4/packages/next-auth/src/providers/auth0.ts)
 
 You can override any of the options to suit your own use case.
 


### PR DESCRIPTION
## ☕️ Reasoning

Fixes a broken link by referencing the proper version from GitHub.

## 🧢 Checklist

- [x] Markdown checked
- [x] Tested link works on preview in GitHub

## 🎫 Affected issues

Fixes: #8990 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
