### PR TITLE
docs: remove trailing comma

### DIFF
--- a/packages/adapter-hasura/src/index.ts
+++ b/packages/adapter-hasura/src/index.ts
@@ -61,7 +61,7 @@ import {
  *       scope text,
  *       id_token text,
  *       session_state text,
- *       "userId" uuid NOT NULL,
+ *       "userId" uuid NOT NULL
  *   );
  *
  *   CREATE TABLE sessions (


### PR DESCRIPTION
## ☕️ Reasoning

Executing the SQL as it appears in the documentation throws a syntax error due to the trailing comma in the `CREATE TABLE accounts` statement.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
