### PR TITLE
fix: change `@auth/core` dependency to non-experimental

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -72,7 +72,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@auth/core": "workspace:experimental"
+    "@auth/core": "workspace:*"
   },
   "peerDependencies": {
     "next": "^14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,7 +953,7 @@ importers:
   packages/next-auth:
     dependencies:
       '@auth/core':
-        specifier: workspace:experimental
+        specifier: workspace:*
         version: link:../core
     devDependencies:
       '@types/react':


### PR DESCRIPTION
Update @auth/core dependency specifier in package.json and pnpm-lock.yaml

self-explanatory - not sure if there's a rationale why this was set to experimental but it prevents this package from getting the latest updates when core package updates (unless you use a package manager where you can do nested overrides)

