### PR TITLE
Wrong route for nextauth in documentation

### DIFF
--- a/docs/docs/getting-started/providers/credentials-tutorial.mdx
+++ b/docs/docs/getting-started/providers/credentials-tutorial.mdx
@@ -22,7 +22,7 @@ Integrating the Credentials Provider is as simple as initializing it in the Auth
 <Tabs groupId="frameworks" queryString>
   <TabItem value="next" label="Next.js" default>
 
-  ```ts title="pages/api/auth/[...nextauth].ts"
+  ```ts title="pages/api/auth/[...nextauth]/route.ts"
   import NextAuth from "next-auth"
   import CredentialsProvider from "next-auth/providers/credentials"
 


### PR DESCRIPTION
I tried this in many ways and none of them worked, until I found that the actual route it was `pages/api/auth/[...nextauth]/route.ts`

That worked perfectly.

source: https://stackoverflow.com/questions/76522472/unable-to-get-session-in-nextauth/76525466#76525466?newreg=ac1ab7a5d65d440f9c5f9ee06da6b462

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
