### PR TITLE
fix docs - invalid link correction

### DIFF
--- a/packages/next-auth/src/jwt.ts
+++ b/packages/next-auth/src/jwt.ts
@@ -1,6 +1,6 @@
 /**
  * :::warning Deprecated
- * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5/v5#authenticating-server-side
+ * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5#authenticating-server-side
  * :::
  *
  * @module jwt
@@ -9,7 +9,7 @@
 throw new ReferenceError(
   [
     '"next-auth/jwt" is deprecated. If you are not ready to migrate, keep using "next-auth@4".',
-    "Read more on https://authjs.dev/guides/upgrade-to-v5/v5",
+    "Read more on https://authjs.dev/guides/upgrade-to-v5",
   ].join("\n")
 )
 

--- a/packages/next-auth/src/middleware.ts
+++ b/packages/next-auth/src/middleware.ts
@@ -1,6 +1,6 @@
 /**
  * :::warning Deprecated
- * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5/v5#authenticating-server-side
+ * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5#authenticating-server-side
  * :::
  *
  * @module middleware
@@ -9,7 +9,7 @@
 throw new ReferenceError(
   [
     '"next-auth/middleware" is deprecated. If you are not ready to migrate, keep using "next-auth@4".',
-    "Read more on https://authjs.dev/guides/upgrade-to-v5/v5",
+    "Read more on https://authjs.dev/guides/upgrade-to-v5",
   ].join("\n")
 )
 

--- a/packages/next-auth/src/next.ts
+++ b/packages/next-auth/src/next.ts
@@ -1,6 +1,6 @@
 /**
  * :::warning Deprecated
- * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5/v5#authenticating-server-side
+ * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5#authenticating-server-side
  * :::
  *
  * @module next
@@ -9,7 +9,7 @@
 throw new ReferenceError(
   [
     '"next-auth/next" is deprecated. If you are not ready to migrate, keep using "next-auth@4".',
-    "Read more on https://authjs.dev/guides/upgrade-to-v5/v5",
+    "Read more on https://authjs.dev/guides/upgrade-to-v5",
   ].join("\n")
 )
 


### PR DESCRIPTION
## ☕️ Reasoning

I came across invalid links in the documentation, I found these links in the repository and fixed them.

---

Replaces all https://authjs.dev/guides/upgrade-to-v5/v5 
By this url&nbsp;&nbsp;&nbsp;&nbsp;https://authjs.dev/guides/upgrade-to-v5

Fixes: https://github.com/nextauthjs/next-auth/issues/9110