### PR TITLE
fix: remove extra brace from sign-in URL for protected pages

### DIFF
--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -191,7 +191,7 @@ async function handleAuth(
       NextResponse.next()
   } else if (!authorized) {
     const signInPage =
-      config.pages?.signIn ?? `${request.nextUrl.basePath}}/signin`
+      config.pages?.signIn ?? `${request.nextUrl.basePath}/signin`
     if (request.nextUrl.pathname !== signInPage) {
       // Redirect to signin page by default if not authorized
       request.nextUrl.pathname = signInPage


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

The template literal to create the redirect URL to the sign-in page contains an extra `}` brace (typo?) which causes an invalid redirect URL like `/}/signin` for protected page when not logged-in.

This is a partial fix for issue #9144.
However, it doesn't fully resolve the correct redirect behavior as it still creates redirect to a non-existent page (`/signin`) instead of builtin sign-in page (`/api/auth/signin`).
Additional changes would be needed to handle the redirect properly.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes partially: #9144

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
