### PR TITLE
fix: missed .js endfix while import `next/*`

### DIFF
--- a/packages/next-auth/src/index.tsx
+++ b/packages/next-auth/src/index.tsx
@@ -61,7 +61,7 @@ import type {
   NextApiResponse,
 } from "next"
 import type { AppRouteHandlerFn } from "next/dist/server/future/route-modules/app-route/module.js"
-import type { NextRequest } from "next/server"
+import type { NextRequest } from "next/server.js"
 import type { NextAuthConfig, NextAuthRequest } from "./lib/index.js"
 
 export type {

--- a/packages/next-auth/src/lib/actions.ts
+++ b/packages/next-auth/src/lib/actions.ts
@@ -1,6 +1,6 @@
 import { Auth, raw, skipCSRFCheck } from "@auth/core"
-import { headers as nextHeaders, cookies } from "next/headers"
-import { redirect } from "next/navigation"
+import { headers as nextHeaders, cookies } from "next/headers.js"
+import { redirect } from "next/navigation.js"
 
 import { detectOrigin } from "./env.js"
 

--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -1,5 +1,5 @@
-import { NextRequest } from "next/server"
-import type { headers } from "next/headers"
+import { NextRequest } from "next/server.js"
+import type { headers } from "next/headers.js"
 
 import type { NextAuthConfig } from "./index.js"
 

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -1,6 +1,6 @@
 import { Auth, type AuthConfig } from "@auth/core"
-import { headers } from "next/headers"
-import { NextResponse } from "next/server"
+import { headers } from "next/headers.js"
+import { NextResponse } from "next/server.js"
 import { detectOrigin, reqWithEnvUrl } from "./env.js"
 
 import type { AuthAction, Awaitable, Session } from "@auth/core/types"
@@ -9,8 +9,8 @@ import type {
   NextApiRequest,
   NextApiResponse,
 } from "next"
-import type { AppRouteHandlerFn } from "next/dist/server/future/route-modules/app-route/module"
-import type { NextFetchEvent, NextMiddleware, NextRequest } from "next/server"
+import type { AppRouteHandlerFn } from "next/dist/server/future/route-modules/app-route/module.js"
+import type { NextFetchEvent, NextMiddleware, NextRequest } from "next/server.js"
 
 /** Configure NextAuth.js. */
 export interface NextAuthConfig extends AuthConfig {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
