### PR TITLE
docs: fix incorrect link

### DIFF
--- a/docs/docs/adapters.md
+++ b/docs/docs/adapters.md
@@ -3,7 +3,7 @@ id: adapters
 title: Adapters
 ---
 
-Visit the [authjs.dev](https://authjs.dev/reference/adapters) page for the up-to-date documentation.
+Visit the [authjs.dev](https://authjs.dev/getting-started/adapters) page for the up-to-date documentation.
 
 - [Dgraph](https://authjs.dev/reference/adapter/dgraph)
 - [Drizzle](https://authjs.dev/reference/adapter/drizzle)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

The current link on [this page](https://next-auth.js.org/adapters) leads to a page that does not exist. I am updating the link to the correct page.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: There was not an issues made for this, I just discovered it.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
