### PR TITLE
fix: correct `actions` import

### DIFF
--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -2,7 +2,7 @@ import { UnknownAction } from "../errors.js"
 import { SessionStore } from "./utils/cookie.js"
 import { init } from "./init.js"
 import renderPage from "./pages/index.js"
-import * as actions from "./actions"
+import * as actions from "./actions/index.js"
 import { validateCSRF } from "./actions/callback/oauth/csrf-token.js"
 
 import type { AuthConfig, RequestInternal, ResponseInternal } from "../types.js"


### PR DESCRIPTION
## ☕️ Reasoning

Fixing action import in @auth/core. When using with SvelteKit and typescript, the missing index.js causes the import to fail.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes #9202

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
