### PR TITLE
Fix `session.updateAge` being ignored when `session.strategy = 'jwt'` in V4

### DIFF
--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -97,7 +97,7 @@ export async function init({
     // JWT options
     jwt: {
       secret, // Use application secret if no keys specified
-      maxAge, // same as session maxAge,
+      maxAge: authOptions.session?.maxAge ?? maxAge, // same as session maxAge,
       encode: jwt.encode,
       decode: jwt.decode,
       ...authOptions.jwt,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

There are two bugs

1. if `session.strategy` uses `jwt`, whenever GET `/api/auth/session` is called, a new jwt will always be signed and set to user's cookie. This is a major security issue since `next-auth` will just ignore the `session.updateAge` and just keep signing a bunch new tokens whenever `getSession()` or `useSession()` hook is called at the front-end. 
2. options `session.maxAge` is not properly copied to  `jwt.maxAge`. If not specifically set `jwt.maxAge`, even if you have the `session.maxAge` set to a value, the token will just apply the default 30 days.

## 🧢 Checklist

- [X] Documentation
- [X] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
