### PR TITLE
Fix redirect for protected pages

### DIFF
--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -43,11 +43,12 @@ export function detectOrigin(h: Headers | ReturnType<typeof headers>) {
 export function reqWithEnvUrl(req: NextRequest): NextRequest {
   const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL
   if (!url) return req
-  const nonBase = req.nextUrl.href.replace(req.nextUrl.origin, "")
+  // const nonBase = req.nextUrl.href.replace(req.nextUrl.origin, "")
   const base = new URL(url).origin
   // REVIEW: Bug in Next.js?: TypeError: next_dist_server_web_exports_next_request__WEBPACK_IMPORTED_MODULE_0__ is not a constructor
   // return new NextRequest(new URL(nonBase, base), req)
-  const _url = new URL(nonBase, base)
+  const _url = req.nextUrl.clone()
+  _url.href = req.nextUrl.href.replace(req.nextUrl.origin, base)
   const _req = new Request(_url, req) as any
   _req.nextUrl = _url
   return _req

--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -43,7 +43,6 @@ export function detectOrigin(h: Headers | ReturnType<typeof headers>) {
 export function reqWithEnvUrl(req: NextRequest): NextRequest {
   const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL
   if (!url) return req
-  // const nonBase = req.nextUrl.href.replace(req.nextUrl.origin, "")
   const base = new URL(url).origin
   // REVIEW: Bug in Next.js?: TypeError: next_dist_server_web_exports_next_request__WEBPACK_IMPORTED_MODULE_0__ is not a constructor
   // return new NextRequest(new URL(nonBase, base), req)

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -191,7 +191,7 @@ async function handleAuth(
       NextResponse.next()
   } else if (!authorized) {
     const signInPage =
-      config.pages?.signIn ?? `${request.nextUrl.basePath}/signin`
+      config.pages?.signIn ?? `${request.nextUrl.basePath}/api/auth/signin`
     if (request.nextUrl.pathname !== signInPage) {
       // Redirect to signin page by default if not authorized
       request.nextUrl.pathname = signInPage

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -190,13 +190,13 @@ async function handleAuth(
       (await userMiddlewareOrRoute(augmentedReq, args[1])) ??
       NextResponse.next()
   } else if (!authorized) {
-    const signInPage =
-      config.pages?.signIn ?? `${request.nextUrl.basePath}/api/auth/signin`
+    const signInPage = config.pages?.signIn ?? "/api/auth/signin"
     if (request.nextUrl.pathname !== signInPage) {
       // Redirect to signin page by default if not authorized
-      request.nextUrl.pathname = signInPage
-      request.nextUrl.searchParams.set("callbackUrl", request.nextUrl.href)
-      response = NextResponse.redirect(request.nextUrl)
+      const signInUrl = request.nextUrl.clone()
+      signInUrl.pathname = signInPage
+      signInUrl.searchParams.set("callbackUrl", request.nextUrl.href)
+      response = NextResponse.redirect(signInUrl)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

This PR fixes several issues related to redirect behavior for middleware protected pages:

1. Incorrect default redirect URL
   - Unauthorized users were redirected to `/signin` when accessing protected pages.  
   - This PR changes the default redirect URL to `/api/auth/signin` (built-in sign-in page) instead.
   
2. Invalid redirect URL when `AUTH_URL` is set
   - The `reqWithEnvUrl` function, which overrides request when `AUTH_URL` is set, used Web API's `URL` instead of `NextURL` for `nextUrl` property, breaking the redirect URL.
   - This PR uses `NextURL` for `nextUrl` property.
   
3. Not redirect back to original protected page after login
   - The callback URL was set to the signin page itself.
   - This PR fixes the callback URL parameter to redirect back to the original requested page.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: #9144 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
