### PR TITLE
fix (v4): nodemailer imports

### DIFF
--- a/packages/next-auth/src/providers/email.ts
+++ b/packages/next-auth/src/providers/email.ts
@@ -1,16 +1,31 @@
 import { Transport, TransportOptions, createTransport } from "nodemailer"
-import * as JSONTransport from "nodemailer/lib/json-transport.js"
+import * as JSONTransport from "nodemailer/lib/json-transport/index.js"
 import * as SendmailTransport from "nodemailer/lib/sendmail-transport/index.js"
-import * as SESTransport from "nodemailer/lib/ses-transport.js"
+import * as SESTransport from "nodemailer/lib/ses-transport/index.js"
 import * as SMTPPool from "nodemailer/lib/smtp-pool/index.js"
-import * as SMTPTransport from "nodemailer/lib/smtp-transport.js"
-import * as StreamTransport from "nodemailer/lib/stream-transport.js"
+import * as SMTPTransport from "nodemailer/lib/smtp-transport/index.js"
+import * as StreamTransport from "nodemailer/lib/stream-transport/index.js"
 import type { Awaitable } from ".."
 import type { CommonProviderOptions } from "."
 import type { Theme } from "../core/types"
 
 // TODO: Make use of https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html for the string
-type AllTransportOptions = string | SMTPTransport | SMTPTransport.Options | SMTPPool | SMTPPool.Options | SendmailTransport | SendmailTransport.Options | StreamTransport | StreamTransport.Options | JSONTransport | JSONTransport.Options | SESTransport | SESTransport.Options | Transport<any> | TransportOptions
+type AllTransportOptions =
+  | string
+  | SMTPTransport
+  | SMTPTransport.Options
+  | SMTPPool
+  | SMTPPool.Options
+  | SendmailTransport
+  | SendmailTransport.Options
+  | StreamTransport
+  | StreamTransport.Options
+  | JSONTransport
+  | JSONTransport.Options
+  | SESTransport
+  | SESTransport.Options
+  | Transport<any>
+  | TransportOptions
 
 export interface SendVerificationRequestParams {
   identifier: string


### PR DESCRIPTION
## ☕️ Reasoning

fixes nodemailer imports in v4.

these imports are already correct in `@auth/core@0.18.3`, see: https://github.com/nextauthjs/next-auth/blob/8b8806fe51458b90b72cfbbec975b28811b4f73e/packages/core/src/providers/email.ts

i hope the formatting diff is ok - i can't find any way to undo it other than changing the file with prettier off, the offending line is over 300 characters long

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/9213 (already closed, but not resolved)

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
