### PR TITLE
feat(providers): support self-hosted github

### DIFF
--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -69,9 +69,12 @@ export interface GitHubProfile {
 }
 
 /**
- * You can customize GitHub's baseUrl to your own GitHub Enterprise Server.
+ * Configuration for usage with GitHub Enterprise Server.
  */
-export interface GitHubUserConfig extends OAuthUserConfig<GitHubProfile> {
+export interface GitHubEnterpriseServerConfig {
+  /**
+   * Customize our own GitHub Enterprise Server.
+   */
   baseUrl?: string
 }
 
@@ -127,7 +130,7 @@ export interface GitHubUserConfig extends OAuthUserConfig<GitHubProfile> {
  * :::
  */
 export default function GitHub(
-  config: GitHubUserConfig
+  config: OAuthUserConfig<GitHubProfile> & GitHubEnterpriseServerConfig
 ): OAuthConfig<GitHubProfile> {
   const baseUrl = config.baseUrl || "https://github.com"
   const apiBaseUrl = config.baseUrl

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -132,7 +132,7 @@ export interface GitHubEnterpriseServerConfig {
 export default function GitHub(
   config: OAuthUserConfig<GitHubProfile> & GitHubEnterpriseServerConfig
 ): OAuthConfig<GitHubProfile> {
-  const baseUrl = config.baseUrl || "https://github.com"
+  const baseUrl = config.baseUrl ?? "https://github.com"
   const apiBaseUrl = config.baseUrl
     ? `${config.baseUrl}/api/v3`
     : "https://api.github.com"

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -69,16 +69,6 @@ export interface GitHubProfile {
 }
 
 /**
- * Configuration for usage with GitHub Enterprise Server.
- */
-export interface GitHubEnterpriseServerConfig {
-  /**
-   * Customize our own GitHub Enterprise Server.
-   */
-  baseUrl?: string
-}
-
-/**
  * Add GitHub login to your page and make requests to [GitHub APIs](https://docs.github.com/en/rest).
  *
  * ### Setup
@@ -130,11 +120,17 @@ export interface GitHubEnterpriseServerConfig {
  * :::
  */
 export default function GitHub(
-  config: OAuthUserConfig<GitHubProfile> & GitHubEnterpriseServerConfig
+  config: OAuthUserConfig<GitHubProfile> & {
+    /** Configuration for usage with [GitHub Enterprise Server](https://docs.github.com/en/enterprise-server/get-started). */
+    enterprise?: {
+      /** The base URL of your GitHub Enterprise Server instance. */
+      baseUrl?: string
+    }
+  }
 ): OAuthConfig<GitHubProfile> {
-  const baseUrl = config.baseUrl ?? "https://github.com"
-  const apiBaseUrl = config.baseUrl
-    ? `${config.baseUrl}/api/v3`
+  const baseUrl = config.enterprise?.baseUrl ?? "https://github.com"
+  const apiBaseUrl = config.enterprise?.baseUrl
+    ? `${config.enterprise?.baseUrl}/api/v3`
     : "https://api.github.com"
 
   return {


### PR DESCRIPTION
## ☕️ Reasoning

Add `baseUrl` option to existing github provider, to support self-hosted [GitHub Enterprise Server](https://docs.github.com/en/enterprise-server@3.10/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps)

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

None

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
