### PR TITLE
docs: change osu! capitalization inside the document

### DIFF
--- a/docs/docs/providers/osu.md
+++ b/docs/docs/providers/osu.md
@@ -13,14 +13,14 @@ https://osu.ppy.sh/home/account/edit#new-oauth-application
 
 ## Options
 
-The **Osu Provider** comes with a set of default options:
+The **osu! Provider** comes with a set of default options:
 
-- [Osu Provider options](https://github.com/nextauthjs/next-auth/blob/v4/packages/next-auth/src/providers/osu.ts)
+- [osu! Provider options](https://github.com/nextauthjs/next-auth/blob/v4/packages/next-auth/src/providers/osu.ts)
 
 You can override any of the options to suit your own use case.
 
 :::note
-Osu! does **not** provide a user email!
+osu! does **not** provide a user email!
 :::
 
 ## Example


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning
I just noticed I left over some other naming mistakes inside the docs document (#8975).
osu! is officially capitalized in lowercase + the exclamation mark
<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
