### PR TITLE
Update azure-ad.md

### DIFF
--- a/docs/docs/providers/azure-ad.md
+++ b/docs/docs/providers/azure-ad.md
@@ -66,7 +66,7 @@ providers: [
   AzureADProvider({
     clientId: process.env.AZURE_AD_CLIENT_ID,
     clientSecret: process.env.AZURE_AD_CLIENT_SECRET,
-    tenantId: process.env.AZURE_AD_TENANT_ID,
+    tenantId: process.env.AZURE_AD_TENANT_ID, // optional, only required for limiting access to a specific tenant
   }),
 ]
 ...


### PR DESCRIPTION
Specifying that tenants are not necessarily a required declaration and reminding users that the argument is optional, in order to avoid confusion.

## ☕️ Reasoning

The documentation is unclear about the purpose of the tenant id, and why it is included in the default example,
this PR aims to remind users about the fact that it is indeed optional

## 🧢 Checklist

- [ NA ] Documentation
- [ NO ] Tests // its a single line in the docs, no further testing required
- [ YES ] Ready to be merged
