### PR TITLE
fix: client-side baseUrl is a path

### DIFF
--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -276,7 +276,7 @@ export async function signIn<
     return
   }
 
-  const error = new URL(data.url, baseUrl).searchParams.get("error")
+  const error = new URLSearchParams(data.url?.split("?")[1]).get("error")
 
   if (res.ok) {
     await __NEXTAUTH._getSession({ event: "storage" })

--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -276,7 +276,7 @@ export async function signIn<
     return
   }
 
-  const error = new URL(data.url).get("error")
+  const error = new URL(data.url).searchParams.get("error")
 
   if (res.ok) {
     await __NEXTAUTH._getSession({ event: "storage" })

--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -276,7 +276,7 @@ export async function signIn<
     return
   }
 
-  const error = new URLSearchParams(data.url?.split("?")[1]).get("error")
+  const error = new URL(data.url).get("error")
 
   if (res.ok) {
     await __NEXTAUTH._getSession({ event: "storage" })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

Maintains the existing behaviour without using baseUrl which can be either a URL (server-side) or a path (client-side). Since baseUrl is used elsewhere in the function, and the aforementioned behaviour seems to work for the rest of the function body, it seemed easier to just skip trying to make a URL out of the response when what we really wanted was just a query parameter.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: https://github.com/nextauthjs/next-auth/issues/9279

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
