### PR TITLE
fix `jwt` strategy ignoring `updateAge` in v5

### DIFF
--- a/packages/core/src/lib/actions/session.ts
+++ b/packages/core/src/lib/actions/session.ts
@@ -1,9 +1,26 @@
 import { JWTSessionError, SessionTokenError } from "../../errors.js"
 import { fromDate } from "../utils/date.js"
 
-import type { Adapter } from "../../adapters.js"
+import type { Adapter, AdapterUser } from "../../adapters.js"
 import type { InternalOptions, ResponseInternal, Session } from "../../types.js"
 import type { Cookie, SessionStore } from "../utils/cookie.js"
+import { JWT } from "../../jwt.js"
+
+const makeSessionObject = (
+  payload: JWT | AdapterUser,
+  sessionExpireDateString: string
+): Session => {
+  return {
+    // @ts-expect-error
+    user: {
+      name: payload.name,
+      email: payload.email,
+      // @ts-expect-error
+      image: payload.picture ?? payload.image,
+    },
+    expires: sessionExpireDateString,
+  }
+}
 
 /** Return a session object filtered via `callbacks.session` */
 export async function session(
@@ -19,7 +36,11 @@ export async function session(
     events,
     callbacks,
     logger,
-    session: { strategy: sessionStrategy, maxAge: sessionMaxAge },
+    session: {
+      strategy: sessionStrategy,
+      maxAge: sessionMaxAge,
+      updateAge: sessionUpdateAge,
+    },
   } = options
 
   const response: ResponseInternal<Session | null> = {
@@ -32,132 +53,187 @@ export async function session(
 
   if (!sessionToken) return response
 
-  if (sessionStrategy === "jwt") {
-    try {
-      const salt = options.cookies.sessionToken.name
-      const payload = await jwt.decode({ ...jwt, token: sessionToken, salt })
+  switch (sessionStrategy) {
+    case "jwt":
+      try {
+        const salt = options.cookies.sessionToken.name
 
-      if (!payload) throw new Error("Invalid JWT")
-
-      // @ts-expect-error
-      const token = await callbacks.jwt({
-        token: payload,
-        ...(isUpdate && { trigger: "update" }),
-        session: newSession,
-      })
-
-      const newExpires = fromDate(sessionMaxAge)
-
-      if (token !== null) {
-        // By default, only exposes a limited subset of information to the client
-        // as needed for presentation purposes (e.g. "you are logged in as...").
-        const session = {
-          user: { name: token.name, email: token.email, image: token.picture },
-          expires: newExpires.toISOString(),
-        }
-        // @ts-expect-error
-        const newSession = await callbacks.session({ session, token })
-
-        // Return session payload as response
-        response.body = newSession
-
-        // Refresh JWT expiry by re-signing it, with an updated expiry date
-        const newToken = await jwt.encode({ ...jwt, token, salt })
-
-        // Set cookie, to also update expiry date on cookie
-        const sessionCookies = sessionStore.chunk(newToken, {
-          expires: newExpires,
+        const decodedTokenPayload = await jwt.decode({
+          ...jwt,
+          token: sessionToken,
+          salt,
         })
 
-        response.cookies?.push(...sessionCookies)
+        if (!decodedTokenPayload) throw new Error("Invalid JWT")
 
-        await events.session?.({ session: newSession, token })
-      } else {
+        // @ts-expect-error
+        const token = (await callbacks.jwt({
+          token: decodedTokenPayload,
+          trigger: isUpdate ? "update" : undefined,
+          session: newSession,
+        })) as JWT & { exp: number }
+
+        if (!token) throw new Error("Invalid JWT")
+
+        const sessionIsDueToBeUpdatedDate =
+          (token.exp - sessionUpdateAge) * 1000
+
+        // if seesion not yet hit the updateAge
+        if (sessionIsDueToBeUpdatedDate > Date.now()) {
+          const currentSession = await callbacks.session(
+            // @ts-expect-error
+            {
+              session: makeSessionObject(
+                token,
+                new Date(token.exp * 1000).toISOString()
+              ),
+              token,
+            }
+          )
+
+          response.body = currentSession
+
+          await events.session?.({
+            session: currentSession,
+            token,
+          })
+        }
+        // if seesion passed updateAge
+        else {
+          const newExpires = fromDate(sessionMaxAge, Date.now())
+
+          // Refresh JWT expiry by re-signing it, with an updated expiry date
+          const newToken = await jwt.encode({
+            ...jwt,
+            // pass the original user token back
+            token,
+            salt,
+          })
+
+          // must decode the new token for passing back to the session, otherwise the jti, exp, etc. will be previous.
+          const decodedNewTokenPayload = (await jwt.decode({
+            ...jwt,
+            token: newToken,
+            salt,
+          })) as JWT
+
+          // By default, only exposes a limited subset of information to the client
+          // as needed for presentation purposes (e.g. "you are logged in as...").
+          const refreshedSession = await callbacks.session(
+            // @ts-expect-error
+            {
+              session: makeSessionObject(
+                decodedNewTokenPayload,
+                // jti precision is only up to second, so zero out the milli-second
+                new Date(
+                  Math.floor(newExpires.valueOf() / 1000) * 1000
+                ).toISOString()
+              ),
+              token: decodedNewTokenPayload,
+            }
+          )
+
+          // Return session payload as response
+          response.body = refreshedSession
+
+          // Set cookie, to also update expiry date on cookie
+          const sessionCookies = sessionStore.chunk(newToken, {
+            expires: newExpires,
+          })
+
+          response.cookies?.push(...sessionCookies)
+
+          await events.session?.({
+            session: refreshedSession,
+            token: decodedNewTokenPayload,
+          })
+        }
+      } catch (e) {
+        logger.error(new JWTSessionError(e as Error))
+        // If the JWT is not verifiable remove the broken session cookie(s).
         response.cookies?.push(...sessionStore.clean())
       }
-    } catch (e) {
-      logger.error(new JWTSessionError(e as Error))
-      // If the JWT is not verifiable remove the broken session cookie(s).
-      response.cookies?.push(...sessionStore.clean())
-    }
 
-    return response
-  }
+      return response
 
-  // Retrieve session from database
-  try {
-    const { getSessionAndUser, deleteSession, updateSession } =
-      adapter as Required<Adapter>
-    let userAndSession = await getSessionAndUser(sessionToken)
+    case "database":
+      // Retrieve session from database
+      try {
+        const { getSessionAndUser, deleteSession, updateSession } =
+          adapter as Required<Adapter>
+        let userAndSession = await getSessionAndUser(sessionToken)
 
-    // If session has expired, clean up the database
-    if (
-      userAndSession &&
-      userAndSession.session.expires.valueOf() < Date.now()
-    ) {
-      await deleteSession(sessionToken)
-      userAndSession = null
-    }
+        // If session has expired, clean up the database
+        if (
+          userAndSession &&
+          userAndSession.session.expires.valueOf() < Date.now()
+        ) {
+          await deleteSession(sessionToken)
+          userAndSession = null
+        }
 
-    if (userAndSession) {
-      const { user, session } = userAndSession
+        if (userAndSession) {
+          const { user, session } = userAndSession
 
-      const sessionUpdateAge = options.session.updateAge
-      // Calculate last updated date to throttle write updates to database
-      // Formula: ({expiry date} - sessionMaxAge) + sessionUpdateAge
-      //     e.g. ({expiry date} - 30 days) + 1 hour
-      const sessionIsDueToBeUpdatedDate =
-        session.expires.valueOf() -
-        sessionMaxAge * 1000 +
-        sessionUpdateAge * 1000
+          // Calculate last updated date to throttle write updates to database
+          // Formula: ({expiry date} - sessionMaxAge) + sessionUpdateAge
+          //     e.g. ({expiry date} - 30 days) + 1 hour
+          const sessionIsDueToBeUpdatedDate =
+            session.expires.valueOf() -
+            sessionMaxAge * 1000 +
+            sessionUpdateAge * 1000
 
-      const newExpires = fromDate(sessionMaxAge)
-      // Trigger update of session expiry date and write to database, only
-      // if the session was last updated more than {sessionUpdateAge} ago
-      if (sessionIsDueToBeUpdatedDate <= Date.now()) {
-        await updateSession({
-          sessionToken: sessionToken,
-          expires: newExpires,
-        })
+          const newExpires = fromDate(sessionMaxAge)
+          // Trigger update of session expiry date and write to database, only
+          // if the session was last updated more than {sessionUpdateAge} ago
+          if (sessionIsDueToBeUpdatedDate <= Date.now()) {
+            await updateSession({
+              sessionToken: sessionToken,
+              expires: newExpires,
+            })
+          }
+
+          // Pass Session through to the session callback
+          const sessionPayload = await callbacks.session(
+            // @ts-expect-error
+            {
+              // By default, only exposes a limited subset of information to the client
+              // as needed for presentation purposes (e.g. "you are logged in as...").
+              session: makeSessionObject(user, session.expires.toISOString()),
+              user,
+              newSession,
+              ...(isUpdate ? { trigger: "update" } : {}),
+            }
+          )
+
+          // Return session payload as response
+          response.body = sessionPayload
+
+          // Set cookie again to update expiry
+          response.cookies?.push({
+            name: options.cookies.sessionToken.name,
+            value: sessionToken,
+            options: {
+              ...options.cookies.sessionToken.options,
+              expires: newExpires,
+            },
+          })
+
+          // @ts-expect-error
+          await events.session?.({ session: sessionPayload })
+        } else if (sessionToken) {
+          // If `sessionToken` was found set but it's not valid for a session then
+          // remove the sessionToken cookie from browser.
+          response.cookies?.push(...sessionStore.clean())
+        }
+      } catch (e) {
+        logger.error(new SessionTokenError(e as Error))
       }
 
-      // Pass Session through to the session callback
-      const sessionPayload = await callbacks.session({
-        // By default, only exposes a limited subset of information to the client
-        // as needed for presentation purposes (e.g. "you are logged in as...").
-        session: {
-          // @ts-expect-error missing `id`.
-          user: { name: user.name, email: user.email, image: user.image },
-          expires: session.expires.toISOString(),
-        },
-        user,
-        newSession,
-        ...(isUpdate ? { trigger: "update" } : {}),
-      })
-
-      // Return session payload as response
-      response.body = sessionPayload
-
-      // Set cookie again to update expiry
-      response.cookies?.push({
-        name: options.cookies.sessionToken.name,
-        value: sessionToken,
-        options: {
-          ...options.cookies.sessionToken.options,
-          expires: newExpires,
-        },
-      })
-
-      // @ts-expect-error
-      await events.session?.({ session: sessionPayload })
-    } else if (sessionToken) {
-      // If `sessionToken` was found set but it's not valid for a session then
-      // remove the sessionToken cookie from browser.
-      response.cookies?.push(...sessionStore.clean())
-    }
-  } catch (e) {
-    logger.error(new SessionTokenError(e as Error))
+      return response
+    default:
+      throw new Error(
+        `session strategy '${sessionStrategy}' can not be recognized, acceptable values are 'jwt' or 'database'`
+      )
   }
-
-  return response
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

- session strategy `jwt` will ignore `updateAge` and signing new token whenever `/auth/session/`  api is called.  As a result, countless jwt token will be signed to the same user over and over again. 
- also include refactoring of `session.ts` to make it more maintainable.


## 🧢 Checklist

- [X] Documentation
- [X] Tests
  All test passes except one.  keep getting `Error: Must use import to load ES Module` for `@auth/d1-adapter:test`. I saw comment in test for d1-adapter and assume this is actually a bug in test? Therefore, I will consider the test passed.  And I can't add new test to cover the behavior after this fix because I can't find test in the `core`
- [X] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
