### PR TITLE
fix: Bad intersection caused type to be 'never'

### DIFF
--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -239,7 +239,7 @@ export interface OAuth2Config<Profile>
 export interface OIDCConfig<Profile>
   extends Omit<OAuth2Config<Profile>, "type" | "checks"> {
   type: "oidc"
-  checks?: OAuth2Config<Profile>["checks"] & Array<"nonce">
+  checks?: Array<(Exclude<OAuth2Config<Profile>["checks"], undefined>)[number] | "nonce">
 }
 
 export type OAuthConfig<Profile> = OIDCConfig<Profile> | OAuth2Config<Profile>


### PR DESCRIPTION
## ☕️ Reasoning

See linked issue

## 🧢 Checklist

skipped

## 🎫 Affected issues

Fixes #9092