### PR TITLE
Docs: Fix GitHubProvider alias in getting-started docs

### DIFF
--- a/docs/docs/getting-started/example.md
+++ b/docs/docs/getting-started/example.md
@@ -30,7 +30,7 @@ If you're using [Next.js 13.2](https://nextjs.org/blog/next-13-2#custom-route-ha
 
 ```javascript title="pages/api/auth/[...nextauth].js" showLineNumbers
 import NextAuth from "next-auth"
-import Github from "next-auth/providers/github"
+import Github as GitHubProvider from "next-auth/providers/github"
 
 export const authOptions = {
   // Configure one or more authentication providers


### PR DESCRIPTION
GitHubProvider was not imported correctly

## ☕️ Reasoning

GitHubProvider alias was not added when importing GitHub in the getting started doc

## 🧢 Checklist

- [x ] Documentation
- [ ] Tests
- [ ] Ready to be merged