### PR TITLE
fix(custom): incorrect cookie names

### DIFF
--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -108,8 +108,8 @@ export async function getToken(
   const {
     secureCookie,
     cookieName = secureCookie
-      ? "__Secure-auth.session-token"
-      : "auth.session-token",
+      ? "__Secure-authjs.session-token"
+      : "authjs.session-token",
     decode: _decode = decode,
     salt = cookieName,
     secret,


### PR DESCRIPTION
## ☕️ Reasoning
`getToken` from `@auth/core/jwt` always return null, because the cookie names incorrect. 
Cookies name as `authjs.session-token`, keep them as same.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Ref: #9111

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
