### PR TITLE
feat: deep-merge cookies options

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -352,9 +352,9 @@ export interface AuthConfig {
    */
   useSecureCookies?: boolean
   /**
-   * You can override the default cookie names and options for any of the cookies used by NextAuth.js.
-   * You can specify one or more cookies with custom properties,
-   * but if you specify custom options for a cookie you must provide all the options for that cookie.
+   * You can override the default cookie names and options for any of the cookies used by Auth.js.
+   * You can specify one or more cookies with custom properties
+   * and missing options will use the default values defined by Auth.js.
    * If you use this feature, you will likely want to create conditional behavior
    * to support setting different cookies policies in development and production builds,
    * as you will be opting out of the built-in dynamic policy.

--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -7,6 +7,7 @@ import { AdapterError, EventError } from "../errors.js"
 import parseProviders from "./utils/providers.js"
 import { logger, type LoggerInstance } from "./utils/logger.js"
 import parseUrl from "./utils/parse-url.js"
+import { merge } from "./utils/merge.js"
 
 import type {
   AuthConfig,
@@ -15,7 +16,6 @@ import type {
   InternalOptions,
   RequestInternal,
 } from "../types.js"
-import { merge } from "./utils/merge.js"
 
 interface InitParams {
   url: URL

--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -106,9 +106,10 @@ export async function init({
     action,
     // @ts-expect-errors
     provider,
-    // Allow user cookie options to deep-override any cookie settings
-    cookies: cookie.makeCookiesOptions(
-      authOptions.useSecureCookies ?? url.protocol === "https:",
+    cookies: merge(
+      cookie.defaultCookies(
+        authOptions.useSecureCookies ?? url.protocol === "https:"
+      ),
       authOptions.cookies
     ),
     providers,

--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -15,6 +15,7 @@ import type {
   InternalOptions,
   RequestInternal,
 } from "../types.js"
+import { merge } from "./utils/merge.js"
 
 interface InitParams {
   url: URL

--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -106,13 +106,11 @@ export async function init({
     action,
     // @ts-expect-errors
     provider,
-    cookies: {
-      ...cookie.defaultCookies(
-        authOptions.useSecureCookies ?? url.protocol === "https:"
-      ),
-      // Allow user cookie options to override any cookie settings above
-      ...authOptions.cookies,
-    },
+    // Allow user cookie options to deep-override any cookie settings
+    cookies: cookie.makeCookiesOptions(
+      authOptions.useSecureCookies ?? url.protocol === "https:",
+      authOptions.cookies
+    ),
     providers,
     // Session options
     session: {

--- a/packages/core/src/lib/utils/cookie.ts
+++ b/packages/core/src/lib/utils/cookie.ts
@@ -1,4 +1,5 @@
 import type {
+  CookieType,
   CookieOption,
   CookiesOptions,
   LoggerInstance,
@@ -118,6 +119,23 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
       },
     },
   }
+}
+
+export function makeCookiesOptions(
+  useSecureCookies: boolean,
+  options?: { [K in CookieType]?: Partial<CookieOption> }
+): CookiesOptions {
+  const cookies = defaultCookies(useSecureCookies)
+
+  if (!options) return cookies
+
+  for (const [key, value] of Object.entries(options)) {
+    const cookie = cookies[key as keyof CookiesOptions]
+    cookie.name = value.name || cookie.name
+    cookie.options = { ...cookie.options, ...value.options }
+  }
+
+  return cookies
 }
 
 export interface Cookie extends CookieOption {

--- a/packages/core/src/lib/utils/cookie.ts
+++ b/packages/core/src/lib/utils/cookie.ts
@@ -1,5 +1,4 @@
 import type {
-  CookieType,
   CookieOption,
   CookiesOptions,
   LoggerInstance,
@@ -119,23 +118,6 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
       },
     },
   }
-}
-
-export function makeCookiesOptions(
-  useSecureCookies: boolean,
-  options?: { [K in CookieType]?: Partial<CookieOption> }
-): CookiesOptions {
-  const cookies = defaultCookies(useSecureCookies)
-
-  if (!options) return cookies
-
-  for (const [key, value] of Object.entries(options)) {
-    const cookie = cookies[key as keyof CookiesOptions]
-    cookie.name = value.name || cookie.name
-    cookie.options = { ...cookie.options, ...value.options }
-  }
-
-  return cookies
 }
 
 export interface Cookie extends CookieOption {

--- a/packages/core/src/lib/utils/cookie.ts
+++ b/packages/core/src/lib/utils/cookie.ts
@@ -55,7 +55,7 @@ export type SessionToken<T extends "jwt" | "database" = "jwt"> = T extends "jwt"
  *
  * @TODO Review cookie settings (names, options)
  */
-export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
+export function defaultCookies(useSecureCookies: boolean) {
   const cookiePrefix = useSecureCookies ? "__Secure-" : ""
   return {
     // default cookie options
@@ -117,7 +117,7 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
         secure: useSecureCookies,
       },
     },
-  }
+  } as const satisfies CookiesOptions
 }
 
 export interface Cookie extends CookieOption {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -340,15 +340,14 @@ export interface CookieOption {
 }
 
 /** [Documentation](https://authjs.dev/reference/core#cookies) */
-export type CookieType =
-  | "sessionToken"
-  | "callbackUrl"
-  | "csrfToken"
-  | "pkceCodeVerifier"
-  | "state"
-  | "nonce"
-
-export type CookiesOptions = Record<CookieType, CookieOption>
+export interface CookiesOptions {
+  sessionToken: CookieOption
+  callbackUrl: CookieOption
+  csrfToken: CookieOption
+  pkceCodeVerifier: CookieOption
+  state: CookieOption
+  nonce: CookieOption
+}
 
 /**
  *  The various event callbacks you can register for from next-auth

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -340,14 +340,15 @@ export interface CookieOption {
 }
 
 /** [Documentation](https://authjs.dev/reference/core#cookies) */
-export interface CookiesOptions {
-  sessionToken: CookieOption
-  callbackUrl: CookieOption
-  csrfToken: CookieOption
-  pkceCodeVerifier: CookieOption
-  state: CookieOption
-  nonce: CookieOption
-}
+export type CookieType =
+  | "sessionToken"
+  | "callbackUrl"
+  | "csrfToken"
+  | "pkceCodeVerifier"
+  | "state"
+  | "nonce"
+
+export type CookiesOptions = Record<CookieType, CookieOption>
 
 /**
  *  The various event callbacks you can register for from next-auth

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -341,12 +341,12 @@ export interface CookieOption {
 
 /** [Documentation](https://authjs.dev/reference/core#cookies) */
 export interface CookiesOptions {
-  sessionToken: CookieOption
-  callbackUrl: CookieOption
-  csrfToken: CookieOption
-  pkceCodeVerifier: CookieOption
-  state: CookieOption
-  nonce: CookieOption
+  sessionToken: Partial<CookieOption>
+  callbackUrl: Partial<CookieOption>
+  csrfToken: Partial<CookieOption>
+  pkceCodeVerifier: Partial<CookieOption>
+  state: Partial<CookieOption>
+  nonce: Partial<CookieOption>
 }
 
 /**
@@ -580,7 +580,7 @@ export interface InternalOptions<TProviderType = ProviderType> {
   events: Partial<EventCallbacks>
   adapter: Required<Adapter> | undefined
   callbacks: CallbacksOptions
-  cookies: CookiesOptions
+  cookies: Record<keyof CookiesOptions, CookieOption>
   callbackUrl: string
   /**
    * If true, the OAuth callback is being proxied by the server to the original URL.

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -11,47 +11,12 @@ import { parse } from "cookie"
 import { defaultCallbacks } from "../src/lib/init.js"
 import { Adapter } from "../src/adapters.js"
 import { randomString } from "../src/lib/utils/web.js"
-import { makeCookiesOptions } from "../lib/utils/cookie"
 
 const authConfig: AuthConfig = {
   providers: [GitHub],
   trustHost: true,
   secret: AUTH_SECRET,
 }
-
-describe("makeCookiesOptions", () => {
-  it("ensure secure defaults", () => {
-    const cookies = makeCookiesOptions(true)
-
-    expect(cookies.sessionToken.name).toBe("__Secure-authjs.session-token")
-    expect(cookies.callbackUrl.name).toBe("__Secure-authjs.callback-url")
-    expect(cookies.csrfToken.name).toBe("__Host-authjs.csrf-token")
-    expect(cookies.pkceCodeVerifier.name).toBe(
-      "__Secure-authjs.pkce.code_verifier"
-    )
-    expect(cookies.state.name).toBe("__Secure-authjs.state")
-    expect(cookies.nonce.name).toBe("__Secure-authjs.nonce")
-
-    for (const cookie of Object.values(cookies)) {
-      expect(cookie.options.httpOnly).toBe(true)
-      expect(cookie.options.secure).toBe(true)
-      expect(cookie.options.sameSite).toBe("lax")
-    }
-  })
-  it("merge options", () => {
-    const cookies = makeCookiesOptions(true, {
-      sessionToken: { options: { domain: ".myapp.com" } },
-      callbackUrl: { name: "myapp.callback-url" },
-    })
-
-    expect(cookies.sessionToken.name).toBe("__Secure-authjs.session-token")
-    expect(cookies.sessionToken.options.httpOnly).toBe(true)
-    expect(cookies.sessionToken.options.secure).toBe(true)
-    expect(cookies.sessionToken.options.sameSite).toBe("lax")
-    expect(cookies.sessionToken.options.domain).toBe(".myapp.com")
-    expect(cookies.callbackUrl.name).toBe("myapp.callback-url")
-  })
-})
 
 describe("JWT session", () => {
   it("should return a valid JWT session response", async () => {


### PR DESCRIPTION
## Context

Recently we had to manually configure the `cookies` in order to get our API service to authenticate with the NextAuth
cookie session token. Because the API lives under `api.example.com` and the NextJS app lives under `example.com` we had
to set the `domain` property of the cookie to `.example.com` in order to get the cookie to be sent to the API.

Here is the relevant code:

```ts
export const authOptions = {
  cookies: {
    sessionToken: {
      name: process.env.NODE_ENV === 'production' ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
      options: {
        httpOnly: true,
        sameSite: 'lax',
        path: '/',
        secure: process.env.NODE_ENV === 'production',
        // this is the important part
        domain: process.env.NEXTAUTH_SESSION_TOKEN_COOKIE_DOMAIN,
      },
    },
    // removed the other cookies for brevity
  },
} satisfies NextAuthOptions;
```

## Concern

In order to accomplish this, **we have to overwrite the entire cookie configuration.** This means that we have to
manually  set the `httpOnly`, `sameSite`, `path`, `secure`, etc. properties. This is not ideal because if the NextAuth
team ever  changes the default values for these properties, we will not get the benefit of those changes.
Or if new sensible defaults are added, we will not get those either.

**It is critical to have secured and sensible defaults for these properties.**

Also notice the error-prone nature of this code since it requires to understand interanlly how NextAuth works and how
cookies work in general. Adding `__Secure-`, `__Host-` (which middlewares in other languages relies on), or extremely
critical, make sure `secure` is set to `true` in production.

## Breaking Change?

Since we must overwrite the entire cookie configuration as of today, this should not be a breaking change as far as I
can tell.

