### PR TITLE
fix(provider): 42 changed their way to return images

### DIFF
--- a/packages/core/src/providers/42-school.ts
+++ b/packages/core/src/providers/42-school.ts
@@ -144,6 +144,17 @@ export interface CampusUser {
   created_at: string
   updated_at: string | null
 }
+
+export interface Image {
+  link: string,
+  versions: {
+    micro: string,
+    small: string,
+    medium: string,
+    large: string,
+  }
+}
+
 export interface FortyTwoProfile extends UserData, Record<string, any> {
   groups: Array<{ id: string; name: string }>
   cursus_users: CursusUser[]
@@ -159,6 +170,7 @@ export interface FortyTwoProfile extends UserData, Record<string, any> {
   roles: Array<{ id: string; name: string }>
   campus: Campus[]
   campus_users: CampusUser[]
+  image: Image
   user: any | null
 }
 
@@ -231,7 +243,7 @@ export default function FortyTwo<P extends FortyTwoProfile>(
         id: profile.id.toString(),
         name: profile.usual_full_name,
         email: profile.email,
-        image: profile.image_url,
+        image: profile.image.link,
       }
     },
     options,


### PR DESCRIPTION
## ☕️ Reasoning

42API is no longer sending a unique image_url link but multiple versions of the images. I propose this PR just to make sure the profile session returns the image and that should not cause any breaking change.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)


Hey @ndom91 

I got confused with the other PR ( https://github.com/nextauthjs/next-auth/pull/8270 ) So I recreated another PR here. 

Sorry for the disturbance, and thank you for your time.