### PR TITLE
fix(ts): bad intersection caused type to be 'never'

### DIFF
--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -239,9 +239,7 @@ export interface OAuth2Config<Profile>
 export interface OIDCConfig<Profile>
   extends Omit<OAuth2Config<Profile>, "type" | "checks"> {
   type: "oidc"
-  checks?: Array<
-    Exclude<OAuth2Config<Profile>["checks"], undefined>[number] | "nonce"
-  >
+  checks?: Array<NonNullable<OAuth2Config<Profile>["checks"]>[number] | "nonce">
 }
 
 export type OAuthConfig<Profile> = OIDCConfig<Profile> | OAuth2Config<Profile>


### PR DESCRIPTION
There's some magic with unions/intersections resulting in _never_ type with the previous fix.

I tested this change using the nextjs next-auth example project and the google provider

For that project applying the change in these two files made the error go away

node_modules/.pnpm/@auth+core@0.18.4/node_modules/@auth/core/src/providers/oauth.ts
node_modules/.pnpm/@auth+core@0.18.4/node_modules/@auth/core/providers/oauth.d.ts