### PR TITLE
fix(docs): broken link in d1 adapter's docs

### DIFF
--- a/packages/adapter-d1/src/index.ts
+++ b/packages/adapter-d1/src/index.ts
@@ -239,8 +239,8 @@ export async function deleteRecord(
  * ```
  *
  *
- * You can also initialize your tables manually.  Look in [init.ts](https://github.com/nextauthjs/next-auth/packages/adapter-d1/src/migrations/init.ts) for the relevant sql.
- * Paste and run the SQL into your D1 dashboard query tool.
+ * You can also initialize your tables manually.  Look in [migrations.ts](https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-d1/src/migrations.ts) for the relevant sql.
+ * Paste and execute the SQL from within your D1 database's console in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/d1).
  *
  **/
 export function D1Adapter(db: D1Database): Adapter {


### PR DESCRIPTION
## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
- The link is broken, so this fixes it with the correct link
- It also rewords the instructions for manually running the D1 initialization/setup and adds a deep link into the Cloudflare dashboard to make it easier for users to find their DB's console.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests - requires maintainer approval to run
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: N/A
