### PR TITLE
fix(types): createUser should not require id as argument

### DIFF
--- a/packages/adapter-typeorm/src/index.ts
+++ b/packages/adapter-typeorm/src/index.ts
@@ -314,7 +314,7 @@ export function TypeORMAdapter(
     createUser: async (data) => {
       const m = await getManager(c)
       const user = await m.save(UserEntityName, data)
-      return user
+      return user as AdapterUser
     },
     // @ts-expect-error
     async getUser(id) {

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -268,7 +268,7 @@ export interface Adapter {
    *
    * See also [User management](https://authjs.dev/guides/adapters/creating-a-database-adapter#user-management)
    */
-  createUser?(user: AdapterUser): Awaitable<AdapterUser>
+  createUser?(user: Omit<AdapterUser, "id">): Awaitable<AdapterUser>
   /**
    * Returns a user from the database via the user id.
    *


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The type of `Adapter` seems to be different for next-auth@4.24.5 and @auth/core@0.19.0.

[`next-auth@4.24.5`](https://github.com/nextauthjs/next-auth/blob/next-auth%404.24.5/packages/next-auth/src/adapters.ts#L63):

```
createUser?: (user: Omit<AdapterUser, "id">) => Awaitable<AdapterUser>
```

[`@auth/core@0.19.0`](https://github.com/nextauthjs/next-auth/blob/%40auth/core%400.19.0/packages/core/src/adapters.ts#L271):

```
createUser?(user: AdapterUser): Awaitable<AdapterUser>
```

User ID is generated in the adapter, so I think it is appropriate to omit it from the argument type.

See: https://github.com/nextauthjs/next-auth/issues/9493

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/9493

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
