### PR TITLE
fix(express): copy providers over from core during build

### DIFF
--- a/packages/frameworks-express/package.json
+++ b/packages/frameworks-express/package.json
@@ -7,12 +7,20 @@
     "*.js",
     "*.d.ts*",
     "lib",
+    "providers",
     "src"
   ],
   "exports": {
     ".": {
       "types": "./index.d.ts",
       "import": "./index.js"
+    },
+    "./providers": {
+      "types": "./providers/index.d.ts"
+    },
+    "./providers/*": {
+      "types": "./providers/*.d.ts",
+      "import": "./providers/*.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/frameworks-express/package.json
+++ b/packages/frameworks-express/package.json
@@ -17,8 +17,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf lib index.*",
+    "build": "pnpm clean && pnpm providers && tsc",
+    "clean": "rm -rf lib index.* src/lib/providers",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.cjs",
     "providers": "node ../utils/scripts/providers.js --out src/lib"
   },

--- a/packages/frameworks-express/package.json
+++ b/packages/frameworks-express/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf lib index.*",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.cjs"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.cjs",
+    "providers": "node ../utils/scripts/providers.js --out src/lib"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/frameworks-express/src/index.ts
+++ b/packages/frameworks-express/src/index.ts
@@ -9,14 +9,14 @@
  *
  * ## Installation
  * ```bash npm2yarn2pnpm
- * npm install @auth/core @auth/express
+ * npm install @auth/express
  * ```
  *
  * ## Usage
  *
  * ```ts title="src/routes/auth.route.ts"
  * import { ExpressAuth } from "@auth/express"
- * import GitHub from "@auth/core/providers/github"
+ * import GitHub from "@auth/express/providers/github"
  * import express from "express"
  *
  * const app = express()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- Avoid installing `@auth/core` with the express client
- Copy providers over to `@auth/express` on build

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
