### PR TITLE
fix(build): generate providers under `@auth/express/providers/*`

### DIFF
--- a/packages/frameworks-express/package.json
+++ b/packages/frameworks-express/package.json
@@ -28,7 +28,7 @@
     "build": "pnpm clean && pnpm providers && tsc",
     "clean": "rm -rf lib index.* src/lib/providers",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.cjs",
-    "providers": "node ../utils/scripts/providers.js --out src/lib"
+    "providers": "node ../utils/scripts/providers"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Closes #9560

Should be same as https://github.com/nextauthjs/next-auth/blob/50a0b64ffb4a83e83d26aaf50ddf63d3d0419347/packages/next-auth/package.json#L64

The issue was that the script was copied from https://github.com/nextauthjs/next-auth/blob/50a0b64ffb4a83e83d26aaf50ddf63d3d0419347/packages/frameworks-sveltekit/package.json#L32, but `@auth/sveltekit` has a different file structure (because it uses [`svelte-package`/Svelte practices for packaging](https://github.com/nextauthjs/next-auth/blob/50a0b64ffb4a83e83d26aaf50ddf63d3d0419347/packages/frameworks-sveltekit/package.json#L26), instead of just `tsc` as other framework packages)