### PR TITLE
chore: update clerk sponsorship on website + docs

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -7,8 +7,8 @@ import { existsSync } from "fs"
 
 const clerk: PropSidebarItemLink = {
   type: "link",
-  href: "https://clerk.com?utm_source=sponsorship&utm_medium=docs&utm_campaign=authjs&utm_content=callout",
-  label: "Clerk (hosted auth)",
+  href: "https://clerk.com?utm_source=sponsorship&utm_medium=docs&utm_campaign=authjs&utm_content=nav",
+  label: "Hosted Auth (Clerk)",
 }
 
 export default {

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -168,10 +168,10 @@ export default function Home() {
               </div>
             </div>
             <span className={styles.heroClerk}>
-              sponsored by{" "}
-              <Link to="https://clerk.com?utm_source=sponsorship&utm_medium=website&utm_campaign=authjs&utm_content=09_01_2023">
-                Clerk
-              </Link>
+              Looking for a hosted alternative?
+              <a href="https://clerk.com?utm_source=sponsorship&utm_medium=website&utm_campaign=authjs&utm_content=cta" target="_blank">
+                Try Clerk →
+              </a>
             </span>
             <div className="hero-marquee">
               <ProviderMarquee />

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -121,10 +121,9 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  font-size: 1.2rem;
 
   a {
-    font-size: 1.4rem;
-    color: #6c47ff;
     position: relative;
     z-index: 1000;
   }


### PR DESCRIPTION
- Adjusted sponsorship copy in the hero callout and fixed link font size. It now reads `Looking for a hosted alternative? Try Clerk →`
- Changed copy in side navbar to `Hosted Auth (Clerk)`
- Updated UTMs

**Before**
<img width="1706" alt="Screenshot 2024-01-09 at 10 26 44 AM" src="https://github.com/nextauthjs/next-auth/assets/1328388/f7442c05-b23b-45ac-8401-7651e3a955d3">

**After**
<img width="1407" alt="Screenshot 2024-01-09 at 4 01 29 PM" src="https://github.com/nextauthjs/next-auth/assets/1328388/00b9e1f0-4624-4ffb-bbfc-f989262f79ae">