### PR TITLE
fix: clerk sponsorship cta in dark mode

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -167,12 +167,15 @@ export default function Home() {
                 </Link>
               </div>
             </div>
-            <span className={styles.heroClerk}>
+            <div className={styles.heroClerk}>
               Looking for a hosted alternative?
-              <a href="https://clerk.com?utm_source=sponsorship&utm_medium=website&utm_campaign=authjs&utm_content=cta" target="_blank">
+              <a
+                href="https://clerk.com?utm_source=sponsorship&utm_medium=website&utm_campaign=authjs&utm_content=cta"
+                target="_blank"
+              >
                 Try Clerk →
               </a>
-            </span>
+            </div>
             <div className="hero-marquee">
               <ProviderMarquee />
             </div>

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -116,6 +116,10 @@
   text-align: center;
 }
 
+[data-theme="dark"] .heroClerk {
+  color: #fff;
+}
+
 .heroClerk {
   display: flex;
   align-items: center;
@@ -127,8 +131,4 @@
     position: relative;
     z-index: 1000;
   }
-}
-
-[data-theme="dark"] .heroClerk {
-  color: #fff;
 }


### PR DESCRIPTION
This PR fixes the color of the Clerk sponsorship text in dark mode.

**Before**
<img width="1435" alt="Screenshot 2024-01-12 at 9 58 33 PM" src="https://github.com/nextauthjs/next-auth/assets/1328388/40b8082c-67b4-404e-88ee-b7efb2938654">

**After**
<img width="1435" alt="Screenshot 2024-01-12 at 9 58 36 PM" src="https://github.com/nextauthjs/next-auth/assets/1328388/9f4bbc28-8f4b-46ee-9d34-84c09a8e6df6">
