### PR TITLE
fix(types): Session callback params does not include `user` and `token`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -248,18 +248,13 @@ export interface CallbacksOptions<P = Profile, A = Account> {
    * @see [`jwt` callback](https://authjs.dev/reference/core/types#jwt)
    */
   session: (
-    params: (
-      | {
-          session: Session
-          /** Available when {@link AuthConfig.session} is set to `strategy: "database"`. */
-          user: AdapterUser
-        }
-      | {
-          session: Session
-          /** Available when {@link AuthConfig.session} is set to `strategy: "jwt"` */
-          token: JWT
-        }
-    ) & {
+    params: {
+      session: Session
+      /** Available when {@link AuthConfig.session} is set to `strategy: "database"`. */
+      user?: AdapterUser
+      /** Available when {@link AuthConfig.session} is set to `strategy: "jwt"` */
+      token?: JWT
+    } & {
       /**
        * Available when using {@link AuthConfig.session} `strategy: "database"` and an update is triggered for the session.
        *

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -76,7 +76,6 @@ async function getSession(headers: Headers, config: NextAuthConfig) {
         const session =
           // If the user defined a custom session callback, use that instead
           (await config.callbacks?.session?.(...args)) ?? args[0].session
-        // @ts-expect-error either user or token will be defined
         const user = args[0].user ?? args[0].token
         return { user, ...session } satisfies Session
       },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

In session callback, argument type does not contain user and token

```typescript
callbacks: {
  session: async ({ session, user }) => {
    if(session.user){
      session.user.id = user.id;
    }
    return session;
  }
},
```

```
Property 'user' does not exist on type '({ session: Session; user: AdapterUser; } | { session: Session; token: JWT; }) & { newSession: any; trigger?: "update" | undefined; }'.
```

This seems to be related to https://github.com/Microsoft/TypeScript/issues/14094. Look at this [TS Playground example](https://www.typescriptlang.org/play?#code/C4TwDgpgBA8gRgKwIxQLxQN5QIYC4oDOwATgJYB2A5gDRRz5FlVQC+AUKJLIgExqY4GJCjSgBjIU0qs2bMQHtyRKADMAruTH8AFNmKUC+eMigAfbgh4BKNAD5MbKE5z6CAOjj8ARF7bsgA).

```typescript
type Obj1 = { a: string, b: string }
type Obj2 = { a: string, c: string }

const func = (args: Obj1 | Obj2) => {
    args.b = ""
         ^
         Property 'b' does not exist on type 'Obj1 | Obj2'.
           Property 'b' does not exist on type 'Obj2'.
}
```

Using `{ session, user?, token? }` instead of `{ session, user } | { session, token }` seems to fix this.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

Fixes: https://github.com/nextauthjs/next-auth/issues/9633

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
