### PR TITLE
fix(providers): add state as default check to Okta

### DIFF
--- a/packages/core/src/providers/okta.ts
+++ b/packages/core/src/providers/okta.ts
@@ -99,6 +99,7 @@ export default function Okta<P extends OktaProfile>(
     name: "Okta",
     type: "oidc",
     style: { logo: "/okta.svg", bg: "#000", text: "#fff" },
+    checks: ['pkce', 'state'],
     options,
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
Okta [requires state](https://developer.okta.com/docs/reference/api/oidc/) to be included, and as the note for `providers/okta` states: the Okta provider is based on OIDC. So let's have `state` in the provider config's `checks` as default.


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues
Fixes #9625
<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
