### PR TITLE
Correct Cognito callback url typo

### DIFF
--- a/packages/core/src/providers/cognito.ts
+++ b/packages/core/src/providers/cognito.ts
@@ -24,7 +24,7 @@ export interface CognitoProfile extends Record<string, any> {
  *
  * #### Callback URL
  * ```
- * https://example.com/api/auth/callback/cognito
+ * https://example.com/auth/callback/cognito
  * ```
  *
  * #### Configuration


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
I believe there's a typo in the Cognito providers documentation.

The docs say the callback URL is `https://example.com/api/auth/callback/cognito`, but the actual URL that is being passed as the `redirect_uri` does not have the `api/` portion of that URL.

Here's a screenshot of the debugging in my terminal:
<img width="1725" alt="Screenshot 2024-01-16 at 10 51 01 PM" src="https://github.com/nextauthjs/next-auth/assets/1650292/34fc5d36-7a9a-4500-af15-854d18d6feb8">

Either the callback is incorrect, or the docs are incorrect.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
