### PR TITLE
feat(env): add environment variable inference

### DIFF
--- a/apps/examples/sveltekit/src/hooks.server.ts
+++ b/apps/examples/sveltekit/src/hooks.server.ts
@@ -9,51 +9,16 @@ import Discord from "@auth/sveltekit/providers/discord"
 import Twitch from "@auth/sveltekit/providers/twitch"
 import Pinterest from "@auth/sveltekit/providers/pinterest"
 
-import {
-  AUTH_GITHUB_ID,
-  AUTH_GITHUB_SECRET,
-  AUTH_LINKEDIN_ID,
-  AUTH_LINKEDIN_SECRET,
-  AUTH_GOOGLE_ID,
-  AUTH_GOOGLE_SECRET,
-  AUTH_FACEBOOK_ID,
-  AUTH_FACEBOOK_SECRET,
-  AUTH_TWITTER_ID,
-  AUTH_TWITTER_SECRET,
-  AUTH_AUTH0_ID,
-  AUTH_AUTH0_SECRET,
-  AUTH_AUTH0_ISSUER,
-  AUTH_DISCORD_ID,
-  AUTH_DISCORD_SECRET,
-  AUTH_TWITCH_ID,
-  AUTH_TWITCH_SECRET,
-  AUTH_PINTEREST_ID,
-  AUTH_PINTEREST_SECRET,
-} from "$env/static/private"
-
 export const handle = SvelteKitAuth({
   providers: [
-    GitHub({ clientId: AUTH_GITHUB_ID, clientSecret: AUTH_GITHUB_SECRET }),
-    LinkedIn({
-      clientId: AUTH_LINKEDIN_ID,
-      clientSecret: AUTH_LINKEDIN_SECRET,
-    }),
-    Google({ clientId: AUTH_GOOGLE_ID, clientSecret: AUTH_GOOGLE_SECRET }),
-    Facebook({
-      clientId: AUTH_FACEBOOK_ID,
-      clientSecret: AUTH_FACEBOOK_SECRET,
-    }),
-    Twitter({ clientId: AUTH_TWITTER_ID, clientSecret: AUTH_TWITTER_SECRET }),
-    Auth0({
-      clientId: AUTH_AUTH0_ID,
-      clientSecret: AUTH_AUTH0_SECRET,
-      issuer: AUTH_AUTH0_ISSUER,
-    }),
-    Discord({ clientId: AUTH_DISCORD_ID, clientSecret: AUTH_DISCORD_SECRET }),
-    Twitch({ clientId: AUTH_TWITCH_ID, clientSecret: AUTH_TWITCH_SECRET }),
-    Pinterest({
-      clientId: AUTH_PINTEREST_ID,
-      clientSecret: AUTH_PINTEREST_SECRET,
-    }),
+    GitHub,
+    LinkedIn,
+    Google,
+    Facebook,
+    Twitter,
+    Auth0,
+    Discord,
+    Twitch,
+    Pinterest,
   ],
 })

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -307,7 +307,6 @@ declare module "$env/dynamic/private" {
 }
 
 export function setEnvDefaults(envObject: any, config: SvelteKitAuthConfig) {
-  if (dev) config.trustHost ??= true
   if (building) return
 
   config.redirectProxyUrl ??= env.AUTH_REDIRECT_PROXY_URL
@@ -317,7 +316,8 @@ export function setEnvDefaults(envObject: any, config: SvelteKitAuthConfig) {
     env.NEXTAUTH_URL ??
     env.AUTH_TRUST_HOST ??
     env.VERCEL ??
-    env.NODE_ENV !== "production"
+    env.NODE_ENV !== "production" ??
+    dev
   )
   config.providers = config.providers.map((p) => {
     const finalProvider = typeof p === "function" ? p({}) : p

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -200,7 +200,7 @@
 /// <reference types="@sveltejs/kit" />
 import type { Handle, RequestEvent } from "@sveltejs/kit"
 
-import { dev } from "$app/environment"
+import { dev, building } from "$app/environment"
 import { base } from "$app/paths"
 import { env } from "$env/dynamic/private"
 
@@ -219,7 +219,7 @@ export async function getSession(
   req: Request,
   config: SvelteKitAuthConfig
 ): ReturnType<App.Locals["getSession"]> {
-  config.secret ??= env.AUTH_SECRET
+  setEnvDefaults(env, config)
   config.trustHost ??= true
 
   const prefix = config.prefix ?? `${base}/auth`
@@ -258,31 +258,23 @@ const actions: AuthAction[] = [
   "error",
 ]
 
-type DynamicSvelteKitAuthConfig = (
-  event: RequestEvent
-) => PromiseLike<SvelteKitAuthConfig>
-
 /**
  * The main entry point to `@auth/sveltekit`
  * @see https://sveltekit.authjs.dev
  */
 export function SvelteKitAuth(
-  svelteKitAuthOptions: SvelteKitAuthConfig | DynamicSvelteKitAuthConfig
+  config:
+    | SvelteKitAuthConfig
+    | ((event: RequestEvent) => PromiseLike<SvelteKitAuthConfig>)
 ): Handle {
   return async function ({ event, resolve }) {
-    const authOptions =
-      typeof svelteKitAuthOptions === "object"
-        ? svelteKitAuthOptions
-        : await svelteKitAuthOptions(event)
-    const { prefix = `${base}/auth` } = authOptions
-
-    authOptions.secret ??= env.AUTH_SECRET
-    authOptions.redirectProxyUrl ??= env.AUTH_REDIRECT_PROXY_URL
-    authOptions.trustHost ??= !!(env.AUTH_TRUST_HOST ?? env.VERCEL ?? dev)
+    const _config = typeof config === "object" ? config : await config(event)
+    setEnvDefaults(env, _config)
+    const { prefix = `${base}/auth` } = _config
 
     const { url, request } = event
 
-    event.locals.getSession ??= () => getSession(request, authOptions)
+    event.locals.getSession ??= () => getSession(request, _config)
 
     const action = url.pathname
       .slice(prefix.length + 1)
@@ -292,7 +284,7 @@ export function SvelteKitAuth(
       return resolve(event)
     }
 
-    return Auth(request, authOptions)
+    return Auth(request, _config)
   }
 }
 
@@ -312,4 +304,31 @@ declare module "$env/dynamic/private" {
   export const AUTH_SECRET: string
   export const AUTH_TRUST_HOST: string
   export const VERCEL: string
+}
+
+export function setEnvDefaults(envObject: any, config: SvelteKitAuthConfig) {
+  if (dev) config.trustHost ??= true
+  if (building) return
+
+  config.redirectProxyUrl ??= env.AUTH_REDIRECT_PROXY_URL
+  config.secret ??= env.AUTH_SECRET
+  config.trustHost ??= !!(
+    env.AUTH_URL ??
+    env.NEXTAUTH_URL ??
+    env.AUTH_TRUST_HOST ??
+    env.VERCEL ??
+    env.NODE_ENV !== "production"
+  )
+  config.providers = config.providers.map((p) => {
+    const finalProvider = typeof p === "function" ? p({}) : p
+    if (finalProvider.type === "oauth" || finalProvider.type === "oidc") {
+      const ID = finalProvider.id.toUpperCase()
+      finalProvider.clientId ??= envObject[`AUTH_${ID}_ID`]
+      finalProvider.clientSecret ??= envObject[`AUTH_${ID}_SECRET`]
+      if (finalProvider.type === "oidc") {
+        finalProvider.issuer ??= envObject[`AUTH_${ID}_ISSUER`]
+      }
+    }
+    return finalProvider
+  })
 }


### PR DESCRIPTION
Similar to `next-auth`, SvelteKit Auth will now support [environment variable inference](https://authjs.dev/reference/nextjs#environment-variable-inference). Any `AUTH_` prefiexed environment variables will be picked up, to simplify the configuration setup.

This also fixes #9436, checking for the `building` value from `$app/environment` to not fail builds that are using `$env/dynamic/private`.