### PR TITLE
docs: fix the link to Yandex provider options in yandex.md

### DIFF
--- a/docs/docs/providers/yandex.md
+++ b/docs/docs/providers/yandex.md
@@ -15,7 +15,7 @@ https://oauth.yandex.com/client/new
 
 The **Yandex Provider** comes with a set of default options:
 
-- [Yandex Provider options](https://github.com/nextauthjs/next-auth/blob/v4/packages/next-auth/src/providers/yandex.js)
+- [Yandex Provider options](https://github.com/nextauthjs/next-auth/blob/v4/packages/next-auth/src/providers/yandex.ts)
 
 You can override any of the options to suit your own use case.
 


### PR DESCRIPTION
## ☕️ Reasoning

Fix the link to Yandex provider options.

https://next-auth.js.org/providers/yandex#options

## 🧢 Checklist

+ [x] Documentation
 