### PR TITLE
feat(sveltekit): Refresh session cookie expiry & introduce `auth` method

### DIFF
--- a/apps/dev/sveltekit/package.json
+++ b/apps/dev/sveltekit/package.json
@@ -12,11 +12,12 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "next",
-    "@sveltejs/kit": "next",
-    "svelte": "3.55.0",
+    "@sveltejs/kit": "2.4.1",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "svelte": "^4",
     "svelte-check": "2.10.2",
     "typescript": "5.2.2",
-    "vite": "4.0.5"
+    "vite": "^5"
   },
   "dependencies": {
     "@auth/sveltekit": "workspace:*"

--- a/apps/dev/sveltekit/src/routes/+layout.server.ts
+++ b/apps/dev/sveltekit/src/routes/+layout.server.ts
@@ -2,6 +2,6 @@ import type { LayoutServerLoad } from "./$types"
 
 export const load: LayoutServerLoad = async (event) => {
   return {
-    session: await event.locals.getSession(),
+    session: await event.locals.auth(),
   }
 }

--- a/apps/dev/sveltekit/svelte.config.js
+++ b/apps/dev/sveltekit/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from "@sveltejs/adapter-auto"
-import { vitePreprocess } from "@sveltejs/kit/vite"
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte"
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/packages/core/src/lib/utils/web.ts
+++ b/packages/core/src/lib/utils/web.ts
@@ -119,7 +119,7 @@ export function randomString(size: number) {
   return Array.from(bytes).reduce(r, "")
 }
 
-export function isAction(action: string): action is AuthAction {
+function isAction(action: string): action is AuthAction {
   return actions.includes(action as AuthAction)
 }
 

--- a/packages/core/src/lib/utils/web.ts
+++ b/packages/core/src/lib/utils/web.ts
@@ -119,7 +119,7 @@ export function randomString(size: number) {
   return Array.from(bytes).reduce(r, "")
 }
 
-function isAction(action: string): action is AuthAction {
+export function isAction(action: string): action is AuthAction {
   return actions.includes(action as AuthAction)
 }
 

--- a/packages/frameworks-sveltekit/package.json
+++ b/packages/frameworks-sveltekit/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "@sveltejs/kit": "^1.0.0 || ^2.0.0",
-    "svelte": "^3.54.0 || ^4.0.0" || "^5"
+    "svelte": "^3.54.0 || ^4.0.0 || ^5"
   },
   "type": "module",
   "types": "./index.d.ts",

--- a/packages/frameworks-sveltekit/package.json
+++ b/packages/frameworks-sveltekit/package.json
@@ -38,6 +38,7 @@
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/package": "^1.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "@types/set-cookie-parser": "^2.4.7",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.3",
     "tslib": "^2.4.1",
@@ -45,11 +46,12 @@
     "vitest": "^1.0.0"
   },
   "dependencies": {
-    "@auth/core": "workspace:*"
+    "@auth/core": "workspace:*",
+    "set-cookie-parser": "^2.6.0"
   },
   "peerDependencies": {
-    "svelte": "^3.54.0 || ^4.0.0",
-    "@sveltejs/kit": "^1.0.0 || ^2.0.0"
+    "@sveltejs/kit": "^1.0.0 || ^2.0.0",
+    "svelte": "^3.54.0 || ^4.0.0"
   },
   "type": "module",
   "types": "./index.d.ts",
@@ -57,6 +59,7 @@
     "client.*",
     "index.*",
     "providers",
+    "vendored",
     "src"
   ],
   "exports": {

--- a/packages/frameworks-sveltekit/package.json
+++ b/packages/frameworks-sveltekit/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "@sveltejs/kit": "^1.0.0 || ^2.0.0",
-    "svelte": "^3.54.0 || ^4.0.0"
+    "svelte": "^3.54.0 || ^4.0.0" || "^5"
   },
   "type": "module",
   "types": "./index.d.ts",
@@ -59,7 +59,6 @@
     "client.*",
     "index.*",
     "providers",
-    "vendored",
     "src"
   ],
   "exports": {

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -227,7 +227,7 @@ async function auth(
   const basePath = config.basePath ?? `${base}/auth`
   const url = new URL(basePath + "/session", req.url)
   const request = new Request(url, {
-    headers: { cookie: headers.get("cookie") ?? "" },
+    headers: { cookie: req.headers.get("cookie") ?? "" },
   })
   const response = await Auth(request, config)
 

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -226,7 +226,9 @@ async function auth(
 
   const basePath = config.basePath ?? `${base}/auth`
   const url = new URL(basePath + "/session", req.url)
-  const request = new Request(url, { headers: req.headers })
+  const request = new Request(url, {
+    headers: { cookie: headers.get("cookie") ?? "" },
+  })
   const response = await Auth(request, config)
 
   const authCookies = parse(response.headers.getSetCookie())

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -270,7 +270,6 @@ export function SvelteKitAuth(
   return async function ({ event, resolve }) {
     const _config = typeof config === "object" ? config : await config(event)
     setEnvDefaults(env, _config)
-    _config.basePath ??= `${base}/auth`
 
     const { url, request } = event
 
@@ -278,11 +277,14 @@ export function SvelteKitAuth(
     event.locals.getSession ??= event.locals.auth
 
     const action = url.pathname
-      .slice(_config.basePath.length + 1)
+      .slice(
+        // @ts-expect-error - basePath is defined in setEnvDefaults
+        _config.basePath.length + 1
+      )
       .split("/")[0]
 
     if (isAction(action) && url.pathname.startsWith(_config.basePath + "/")) {
-        return Auth(request, _config)
+      return Auth(request, _config)
     }
     return resolve(event)
   }
@@ -317,11 +319,11 @@ export function setEnvDefaults(envObject: any, config: SvelteKitAuthConfig) {
   if (building) return
 
   try {
-    const url = env.AUTH_URL ?? base
+    const url = env.AUTH_URL
     if (url) config.basePath = new URL(url).pathname
   } catch {
   } finally {
-    config.basePath ??= "/auth"
+    config.basePath ??= `${base}/auth`
   }
 
   config.redirectProxyUrl ??= env.AUTH_REDIRECT_PROXY_URL

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -279,13 +279,12 @@ export function SvelteKitAuth(
 
     const action = url.pathname
       .slice(_config.basePath.length + 1)
-      .split("/")[0] as AuthAction
+      .split("/")[0]
 
-    if (!isAction(action) || !url.pathname.startsWith(_config.basePath + "/")) {
-      return resolve(event)
+    if (isAction(action) && url.pathname.startsWith(_config.basePath + "/")) {
+        return Auth(request, _config)
     }
-
-    return Auth(request, _config)
+    return resolve(event)
   }
 }
 
@@ -299,9 +298,7 @@ declare global {
   namespace App {
     interface Locals {
       auth(): Promise<Session | null>
-      /**
-       * @deprecated Use `auth` instead.
-       */
+      /** @deprecated Use `auth` instead. */
       getSession(): Promise<Session | null>
     }
     interface PageData {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,22 +167,25 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: next
-        version: 1.0.0-next.91(@sveltejs/kit@1.0.0-next.589)
+        version: 1.0.0-next.91(@sveltejs/kit@2.4.1)
       '@sveltejs/kit':
-        specifier: next
-        version: 1.0.0-next.589(svelte@3.55.0)(vite@4.0.5)
+        specifier: 2.4.1
+        version: 2.4.1(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^3.0.0
+        version: 3.0.1(svelte@4.2.8)(vite@5.0.10)
       svelte:
-        specifier: 3.55.0
-        version: 3.55.0
+        specifier: ^4
+        version: 4.2.8
       svelte-check:
         specifier: 2.10.2
-        version: 2.10.2(@babel/core@7.23.3)(svelte@3.55.0)
+        version: 2.10.2(@babel/core@7.23.3)(svelte@4.2.8)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: 4.0.5
-        version: 4.0.5(@types/node@20.9.0)
+        specifier: ^5
+        version: 5.0.10(@types/node@20.9.0)
 
   docs:
     dependencies:
@@ -704,6 +707,9 @@ importers:
       '@auth/core':
         specifier: workspace:*
         version: link:../core
+      set-cookie-parser:
+        specifier: ^2.6.0
+        version: 2.6.0
     devDependencies:
       '@playwright/test':
         specifier: 1.29.2
@@ -720,6 +726,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
         version: 3.0.1(svelte@4.2.8)(vite@5.0.10)
+      '@types/set-cookie-parser':
+        specifier: ^2.4.7
+        version: 2.4.7
       svelte:
         specifier: ^4.0.0
         version: 4.2.8
@@ -9108,7 +9117,7 @@ packages:
       busboy: 1.6.0
       dotenv: 10.0.0
       kleur: 4.1.5
-      set-cookie-parser: 2.5.1
+      set-cookie-parser: 2.6.0
       undici: 5.20.0
       urlpattern-polyfill: 4.0.3
     dev: true
@@ -9766,7 +9775,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.15.0
@@ -10655,12 +10664,12 @@ packages:
       - encoding
       - supports-color
 
-  /@sveltejs/adapter-auto@1.0.0-next.91(@sveltejs/kit@1.0.0-next.589):
+  /@sveltejs/adapter-auto@1.0.0-next.91(@sveltejs/kit@2.4.1):
     resolution: {integrity: sha512-U57tQdzTfFINim8tzZSARC9ztWPzwOoHwNOpGdb2o6XrD0mEQwU9DsII7dBblvzg+xCnmd0pw7PDtXz5c5t96w==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0-next.587
     dependencies:
-      '@sveltejs/kit': 1.0.0-next.589(svelte@3.55.0)(vite@4.0.5)
+      '@sveltejs/kit': 2.4.1(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10)
       import-meta-resolve: 2.2.0
     dev: true
 
@@ -10671,34 +10680,6 @@ packages:
     dependencies:
       '@sveltejs/kit': 2.0.6(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10)
       import-meta-resolve: 4.0.0
-    dev: true
-
-  /@sveltejs/kit@1.0.0-next.589(svelte@3.55.0)(vite@4.0.5):
-    resolution: {integrity: sha512-5ABRw46z9B+cCe/YWhcx+I/azNZg1NCDEkVJifZn8ToFoJ3a1eP0OexNIrvMEWpllMbNMPcJm2TC9tnz9oPfWQ==}
-    engines: {node: '>=16.14'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      svelte: ^3.54.0
-      vite: ^4.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.0.0(svelte@3.55.0)(vite@4.0.5)
-      '@types/cookie': 0.5.1
-      cookie: 0.5.0
-      devalue: 4.3.2
-      esm-env: 1.0.0
-      kleur: 4.1.5
-      magic-string: 0.27.0
-      mime: 3.0.0
-      sade: 1.8.1
-      set-cookie-parser: 2.5.1
-      sirv: 2.0.2
-      svelte: 3.55.0
-      tiny-glob: 0.2.9
-      undici: 5.14.0
-      vite: 4.0.5(@types/node@20.9.0)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@sveltejs/kit@2.0.6(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10):
@@ -10716,6 +10697,33 @@ packages:
       cookie: 0.6.0
       devalue: 4.3.2
       esm-env: 1.0.0
+      kleur: 4.1.5
+      magic-string: 0.30.5
+      mrmime: 2.0.0
+      sade: 1.8.1
+      set-cookie-parser: 2.6.0
+      sirv: 2.0.4
+      svelte: 4.2.8
+      tiny-glob: 0.2.9
+      vite: 5.0.10(@types/node@20.9.0)
+    dev: true
+
+  /@sveltejs/kit@2.4.1(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10):
+    resolution: {integrity: sha512-NnDrPOmTjzhgWkwJNPcth3vBMWQmI/QhwbMRXow1p/RkM+17HxP2yQR3GYwIK83rkYSKwQiweyBVWGOjJY4gsg==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.3
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.0.10)
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      devalue: 4.3.2
+      esm-env: 1.0.0
+      import-meta-resolve: 4.0.0
       kleur: 4.1.5
       magic-string: 0.30.5
       mrmime: 2.0.0
@@ -10755,25 +10763,6 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
       svelte: 4.2.8
       vite: 5.0.10(@types/node@20.9.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@sveltejs/vite-plugin-svelte@2.0.0(svelte@3.55.0)(vite@4.0.5):
-    resolution: {integrity: sha512-oUFrYQarRv4fppmxdrv00qw3wX8Ycdj0uv33MfpRZyR8K67dyxiOcHnqkB0zSy5sDJA8RC/2aNtYhXJ8NINVHQ==}
-    engines: {node: ^14.18.0 || >= 16}
-    peerDependencies:
-      svelte: ^3.54.0
-      vite: ^4.0.0
-    dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
-      deepmerge: 4.3.0
-      kleur: 4.1.5
-      magic-string: 0.27.0
-      svelte: 3.55.0
-      svelte-hmr: 0.15.1(svelte@3.55.0)
-      vite: 4.0.5(@types/node@20.9.0)
-      vitefu: 0.2.4(vite@4.0.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11128,7 +11117,7 @@ packages:
   /@types/acorn@4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
 
   /@types/babel__core@7.20.4:
     resolution: {integrity: sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==}
@@ -11198,7 +11187,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 14.18.53
+      '@types/node': 18.11.10
     dev: true
 
   /@types/cookie@0.5.1:
@@ -11248,21 +11237,20 @@ packages:
   /@types/eslint@8.4.3:
     resolution: {integrity: sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@types/json-schema': 7.0.11
     dev: true
 
   /@types/estree-jsx@1.0.3:
     resolution: {integrity: sha512-pvQ+TKeRHeiUGRhvYwRrQ/ISnohKkSJR14fT2yqyZ4e9K5vqc7hrtY2Y1Dw0ZwAzQ6DQsxsaCUuSIIi8v0Cq6w==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
 
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
@@ -11777,7 +11765,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.53
+      '@types/node': 18.11.10
     dev: true
 
   /@types/serve-index@1.9.1:
@@ -11791,6 +11779,12 @@ packages:
     dependencies:
       '@types/mime': 1.3.2
       '@types/node': 14.18.53
+    dev: true
+
+  /@types/set-cookie-parser@2.4.7:
+    resolution: {integrity: sha512-+ge/loa0oTozxip6zmhRIk8Z/boU51wl9Q6QdLZcokIGMzY5lFXYy/x7Htj2HTC6/KZP1hUbZ1ekx8DYXICvWg==}
+    dependencies:
+      '@types/node': 18.11.10
     dev: true
 
   /@types/shelljs@0.8.11:
@@ -15454,11 +15448,6 @@ packages:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
 
-  /deepmerge@4.3.0:
-    resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -17261,14 +17250,14 @@ packages:
     resolution: {integrity: sha512-+5Ba/xGGS6mnwFbXIuQiDPTbuTxuMCooq3arVv7gPZtYpjp+VXH/NkHAP35OOefPhNG/UGqU3vt/LTABwcHX0w==}
     requiresBuild: true
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
     dev: false
     optional: true
 
   /estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
     dev: true
 
   /estree-util-build-jsx@3.0.1:
@@ -19260,7 +19249,7 @@ packages:
   /hast-util-to-estree@3.1.0:
     resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@types/estree-jsx': 1.0.3
       '@types/hast': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -22098,13 +22087,6 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string@0.27.0:
-    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
-
   /magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
@@ -22921,7 +22903,7 @@ packages:
     resolution: {integrity: sha512-zZpeQtc5wfWKdzDsHRBY003H2Smg+PUi2REhqgIhdzAa5xonhP03FcXxqFSerFiNUr5AWmHpaNPQTBVOS4lrXw==}
     requiresBuild: true
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
@@ -22935,7 +22917,7 @@ packages:
   /micromark-extension-mdx-expression@3.0.0:
     resolution: {integrity: sha512-sI0nwhUDz97xyzqJAbHQhp5TfaxEvZZZ2JDqUo+7NvyIYG6BZ5CPPqj2ogUoPJlmXHBnyZUzISg9+oUmU6tUjQ==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.1
       micromark-factory-space: 2.0.0
@@ -22950,7 +22932,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       estree-util-is-identifier-name: 2.1.0
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
@@ -22966,7 +22948,7 @@ packages:
     resolution: {integrity: sha512-uvhhss8OGuzR4/N17L1JwvmJIpPhAd8oByMawEKx6NVdBCbesjH4t+vjEp3ZXft9DwvlKSD07fCeI44/N0Vf2w==}
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.1
@@ -22995,7 +22977,7 @@ packages:
     resolution: {integrity: sha512-xNRBw4aoURcyz/S69B19WnZAkWJMxHMT5hE36GtDAyhoyn/8TuAeqjFJQlwk+MKQsUD7b3l7kFX+vlfVWgcX1w==}
     requiresBuild: true
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       micromark-core-commonmark: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
@@ -23010,7 +22992,7 @@ packages:
   /micromark-extension-mdxjs-esm@3.0.0:
     resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
       micromark-util-character: 2.0.1
@@ -23087,7 +23069,7 @@ packages:
     resolution: {integrity: sha512-jGIWzSmNfdnkJq05c7b0+Wv0Kfz3NJ3N4cBjnbO4zjXIlxJr+f8lk+5ZmwFvqdAbUy2q6B5rCY//g0QAAaXDWA==}
     requiresBuild: true
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
       micromark-util-symbol: 1.1.0
@@ -23101,7 +23083,7 @@ packages:
   /micromark-factory-mdx-expression@2.0.1:
     resolution: {integrity: sha512-F0ccWIUHRLRrYp5TC9ZYXmZo+p2AM13ggbsW4T0b5CRKP8KHVRB8t4pwtBgTxtjRmwrK0Irwm7vs2JOZabHZfg==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       devlop: 1.1.0
       micromark-util-character: 2.0.1
       micromark-util-events-to-acorn: 2.0.2
@@ -23258,7 +23240,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@types/unist': 2.0.6
       estree-util-visit: 1.2.1
       micromark-util-symbol: 1.1.0
@@ -23272,7 +23254,7 @@ packages:
     resolution: {integrity: sha512-Fk+xmBrOv9QZnEDguL9OI9/NQQp6Hz4FuQ4YmCb/5V7+9eAh1s6AYSvL20kHkD67YIg7EpE54TiSlcsf3vyZgA==}
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@types/unist': 3.0.2
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -27541,13 +27523,8 @@ packages:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: true
 
-  /set-cookie-parser@2.5.1:
-    resolution: {integrity: sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==}
-    dev: true
-
   /set-cookie-parser@2.6.0:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
-    dev: true
 
   /setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -27681,15 +27658,6 @@ packages:
 
   /sirv@2.0.2:
     resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
-    engines: {node: '>= 10'}
-    dependencies:
-      '@polka/url': 1.0.0-next.21
-      mrmime: 1.0.1
-      totalist: 3.0.0
-    dev: true
-
-  /sirv@2.0.3:
-    resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}
     engines: {node: '>= 10'}
     dependencies:
       '@polka/url': 1.0.0-next.21
@@ -27907,7 +27875,7 @@ packages:
       rollup-plugin-visualizer: 5.9.0(rollup@3.15.0)
       rollup-route-manifest: 1.0.0(rollup@3.15.0)
       sade: 1.8.1
-      set-cookie-parser: 2.5.1
+      set-cookie-parser: 2.6.0
       sirv: 2.0.2
       solid-js: 1.6.6
       terser: 5.16.1
@@ -28623,7 +28591,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /svelte-check@2.10.2(@babel/core@7.23.3)(svelte@3.55.0):
+  /svelte-check@2.10.2(@babel/core@7.23.3)(svelte@4.2.8):
     resolution: {integrity: sha512-h1Tuiir0m8J5yqN+Vx6qgKKk1L871e6a9o7rMwVWfu8Qs6Wg7x2R+wcxS3SO3VpW5JCxCat90rxPsZMYgz+HaQ==}
     hasBin: true
     peerDependencies:
@@ -28635,8 +28603,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 3.55.0
-      svelte-preprocess: 4.10.7(@babel/core@7.23.3)(svelte@3.55.0)(typescript@5.2.2)
+      svelte: 4.2.8
+      svelte-preprocess: 4.10.7(@babel/core@7.23.3)(svelte@4.2.8)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -28678,15 +28646,6 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr@0.15.1(svelte@3.55.0):
-    resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
-    engines: {node: ^12.20 || ^14.13.1 || >= 16}
-    peerDependencies:
-      svelte: '>=3.19.0'
-    dependencies:
-      svelte: 3.55.0
-    dev: true
-
   /svelte-hmr@0.15.3(svelte@4.2.8):
     resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
@@ -28696,7 +28655,7 @@ packages:
       svelte: 4.2.8
     dev: true
 
-  /svelte-preprocess@4.10.7(@babel/core@7.23.3)(svelte@3.55.0)(typescript@5.2.2):
+  /svelte-preprocess@4.10.7(@babel/core@7.23.3)(svelte@4.2.8)(typescript@5.2.2):
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -28744,7 +28703,7 @@ packages:
       magic-string: 0.25.9
       sorcery: 0.10.0
       strip-indent: 3.0.0
-      svelte: 3.55.0
+      svelte: 4.2.8
       typescript: 5.2.2
     dev: true
 
@@ -29738,13 +29697,6 @@ packages:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
-  /undici@5.14.0:
-    resolution: {integrity: sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==}
-    engines: {node: '>=12.18'}
-    dependencies:
-      busboy: 1.6.0
-    dev: true
-
   /undici@5.20.0:
     resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
     engines: {node: '>=12.18'}
@@ -30457,7 +30409,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
       fs-extra: 11.1.1
       kolorist: 1.6.0
-      sirv: 2.0.3
+      sirv: 2.0.4
       ufo: 1.1.2
       vite: 3.2.7(@types/node@18.11.10)
     transitivePeerDependencies:
@@ -30551,40 +30503,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@4.0.5(@types/node@20.9.0):
-    resolution: {integrity: sha512-7m87RC+caiAxG+8j3jObveRLqaWA/neAdCat6JAZwMkSWqFHOvg8MYe5fAQxVBRAuKAQ1S6XDh3CBQuLNbY33w==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.9.0
-      esbuild: 0.16.4
-      postcss: 8.4.31
-      resolve: 1.22.1
-      rollup: 3.15.0
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite@5.0.10(@types/node@18.11.10):
     resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -30666,17 +30584,6 @@ packages:
         optional: true
     dependencies:
       vite: 3.2.7(@types/node@18.11.10)
-    dev: true
-
-  /vitefu@0.2.4(vite@4.0.5):
-    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      vite: 4.0.5(@types/node@20.9.0)
     dev: true
 
   /vitefu@0.2.5(vite@5.0.10):
@@ -30919,7 +30826,7 @@ packages:
       lodash.uniqby: 4.7.0
       opener: 1.5.2
       picocolors: 1.0.0
-      sirv: 2.0.3
+      sirv: 2.0.4
       ws: 7.5.8
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
Closes #9497

- Rename `getSession` to `auth` to match `next-auth` return value
- Set the cookies from the Auth response before returning the session body
- Set a default value for `basePath` for SvelteKit - See #9686
- Upgrade the dev app to SvelteKit v2  

Fixes: #8034