### PR TITLE
feat: add experimental `AuthData` type

### DIFF
--- a/apps/dev/nextjs/app/client.tsx
+++ b/apps/dev/nextjs/app/client.tsx
@@ -6,12 +6,16 @@ export default function Client() {
   const { data: session, update, status } = useSession()
   return (
     <div>
-      <pre>
-        {status === "loading" ? "Loading..." : JSON.stringify(session, null, 2)}
-      </pre>
+      <div>
+        <b>Client component</b>
+      </div>
       <button onClick={() => signIn("github")}>Sign in</button>
       <button onClick={() => signIn("credentials", {})}>Sign in cred</button>
       <button onClick={() => update(`New Name`)}>Update session</button>
+      <pre>
+        <b>useSession() </b>
+        {status === "loading" ? "Loading..." : JSON.stringify(session, null, 2)}
+      </pre>
     </div>
   )
 }

--- a/apps/dev/nextjs/app/layout.tsx
+++ b/apps/dev/nextjs/app/layout.tsx
@@ -1,4 +1,4 @@
-import { auth, signIn, signOut, unstable_update as update } from "auth"
+import { auth, signIn, signOut, update } from "auth"
 import Footer from "components/footer"
 import { Header } from "components/header"
 import styles from "components/header.module.css"

--- a/apps/dev/nextjs/app/page.tsx
+++ b/apps/dev/nextjs/app/page.tsx
@@ -1,18 +1,24 @@
 import { SessionProvider } from "next-auth/react"
-import { auth } from "auth"
+import { auth, unstable_auth } from "auth"
 import Client from "./client"
 
 export default async function Page() {
   const session = await auth()
+  const futureAuth = await unstable_auth()
   return (
     <>
-      {/* 
-       NOTE: The `auth()` result is not run through the `session` callback, be careful passing down data
-       to a client component, this will be exposed via the /api/auth/session endpoint
-      */}
       <SessionProvider session={session} basePath="/auth">
         <Client />
       </SessionProvider>
+      <b>Server component</b>
+      <pre>
+        <b>auth() </b>
+        {JSON.stringify(session, null, 2)}
+      </pre>
+      <pre>
+        <b>unstable_auth() </b>
+        {JSON.stringify(futureAuth, null, 2)}
+      </pre>
       <h1>NextAuth.js Example</h1>
       <p>
         This is an example site to demonstrate how to use{" "}

--- a/apps/dev/nextjs/auth.config.ts
+++ b/apps/dev/nextjs/auth.config.ts
@@ -49,5 +49,8 @@ export default {
       return token
     },
   },
+  experimental: {
+    structuredAuth: true,
+  },
   basePath: "/auth",
 } satisfies NextAuthConfig

--- a/apps/dev/nextjs/auth.ts
+++ b/apps/dev/nextjs/auth.ts
@@ -12,8 +12,8 @@ import authConfig from "auth.config"
 //   Email({ server: "smtp://127.0.0.1:1025?tls.rejectUnauthorized=false" })
 // )
 
-export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth(
-  (request) => {
+export const { handlers, auth, signIn, signOut, update, unstable_auth } =
+  NextAuth((request) => {
     if (request?.nextUrl.searchParams.get("test")) {
       return {
         // adapter: PrismaAdapter(globalThis.prisma),
@@ -27,8 +27,7 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth(
       session: { strategy: "jwt" },
       ...authConfig,
     }
-  }
-)
+  })
 
 // export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
 //   // adapter: PrismaAdapter(globalThis.prisma),

--- a/packages/adapter-supabase/src/index.ts
+++ b/packages/adapter-supabase/src/index.ts
@@ -270,7 +270,7 @@ export interface SupabaseAdapterOptions {
  *   constraint "users_id_fkey" foreign key ("id")
  *         references  next_auth.users (id) match simple
  *         on update no action
- *         on delete cascade -- if user is deleted in NextAuth they will also be deleted in our public table.
+ *         on delete cascade -- if a user is deleted in NextAuth they will also be deleted in our public table.
  * );
  * alter table users enable row level security;
  * create policy "Can view own user data." on users for select using (next_auth.uid() = id);
@@ -314,7 +314,7 @@ export interface SupabaseAdapterOptions {
  * ```
  *  ### Usage with TypeScript
  *
- * You can pass types that were generated with the Supabase CLI to the Supabase Client to get enhanced type safety and auto completion.
+ * You can pass types that were generated with the Supabase CLI to the Supabase Client to get enhanced type safety and auto-completion.
  *
  * Creating a new supabase client object:
  *
@@ -338,7 +338,7 @@ export interface SupabaseAdapterOptions {
  *     // A JWT which can be used as Authorization header with supabase-js for RLS.
  *     supabaseAccessToken?: string
  *     user: {
- *       // he user's postal address
+ *       // The user's postal address
  *       address: string
  *     } & DefaultSession["user"]
  *   }

--- a/packages/next-auth/src/lib/future/index.ts
+++ b/packages/next-auth/src/lib/future/index.ts
@@ -1,0 +1,84 @@
+import type { Session, User } from "@auth/core/types"
+
+import type { NextAuthConfig } from ".."
+import { headers } from "next/headers"
+import { Auth } from "@auth/core"
+import { createActionURL } from "../actions"
+import { AuthError } from "@auth/core/errors"
+import { NextRequest } from "next/server"
+
+export interface AuthData {
+  session: Session
+  user: User
+}
+
+class ExperimentalAuthError extends AuthError {
+  static type = "ExperimentalAuthError"
+}
+
+async function getAuthData(
+  headers: Headers,
+  config: NextAuthConfig
+): Promise<Session | null> {
+  return Auth(
+    new Request(createActionURL("session", headers, config.basePath), {
+      headers: { cookie: headers.get("cookie") ?? "" },
+    }),
+    {
+      ...config,
+      callbacks: {
+        ...config.callbacks,
+        // TODO: Taint the session data to prevent accidental leakage to the client
+        // https://react.dev/reference/react/experimental_taintObjectReference
+        async session(...args) {
+          // Use the user defined session callback if it exists
+          let session = await config.callbacks?.session?.(...args)
+          // User wants to terminate the session, exit early
+          if (session === null) return null
+          // User did not define a custom session callback, use the default session value
+          if (!session) session = args[0].session
+          // @ts-expect-error either user or token will be defined
+          const user = session.user ?? args[0].user ?? args[0].token
+          // Structured auth data always requires a user object
+          if (!user) throw new TypeError("Missing user in structured auth data")
+          return { user, ...session } satisfies Session
+        },
+      },
+    } as NextAuthConfig
+    // REVIEW: This won't forward headers (eg.: Set-Cookie that terminates the session by returning null in the session callback)
+  ).then((r) => r.json())
+}
+
+async function handleAuth(config: NextAuthConfig): Promise<AuthData | null> {
+  const data = await getAuthData(headers(), config)
+  if (!data) return null
+  const { user, ...session } = data
+  if (!user) throw new TypeError("Missing user in structured auth data")
+  return { session, user }
+}
+
+function experimentalStructuredAuthEnabled(config: NextAuthConfig) {
+  if (config.experimental?.structuredAuth === true) return
+  throw new ExperimentalAuthError(
+    "`experimental.structuredAuth` must be enabled to use `unstable_auth`"
+  )
+}
+
+export function initFutureAuth(
+  configOrFunction:
+    | NextAuthConfig
+    | ((request: NextRequest | undefined) => NextAuthConfig),
+  onLazyInit?: (config: NextAuthConfig) => void
+) {
+  if (typeof configOrFunction === "function") {
+    return async () => {
+      const config = configOrFunction(undefined) // Review: Should we pass headers()?
+      experimentalStructuredAuthEnabled(config)
+      onLazyInit?.(config)
+      return await handleAuth(config)
+    }
+  }
+
+  experimentalStructuredAuthEnabled(configOrFunction)
+  return async () => await handleAuth(configOrFunction)
+}

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -12,6 +12,7 @@ import type {
 } from "next"
 import type { AppRouteHandlerFn } from "next/dist/server/future/route-modules/app-route/module"
 import type { NextFetchEvent, NextMiddleware, NextRequest } from "next/server"
+import type { AuthData } from "./future/index.js"
 
 /** Configure NextAuth.js. */
 export interface NextAuthConfig extends Omit<AuthConfig, "raw"> {
@@ -57,6 +58,10 @@ export interface NextAuthConfig extends Omit<AuthConfig, "raw"> {
       auth: Session | null
     }) => Awaitable<boolean | NextResponse | Response | undefined>
   }
+  experimental?: AuthConfig["experimental"] & {
+    /** Enable `unstable_auth` and `unstable_update` that return/modify {@link AuthData} instead of {@link Session}. */
+    structuredAuth: boolean
+  }
 }
 
 async function getSession(headers: Headers, config: NextAuthConfig) {
@@ -93,17 +98,15 @@ export function initAuth(
   config:
     | NextAuthConfig
     | ((request: NextRequest | undefined) => NextAuthConfig),
-  onLazyLoad?: (config: NextAuthConfig) => void // To set the default env vars
+  onLazyInit?: (config: NextAuthConfig) => void // To set the default env vars
 ) {
   if (typeof config === "function") {
     return (...args: WithAuthArgs) => {
       if (!args.length) {
         // React Server Components
-        const _headers = headers()
         const _config = config(undefined) // Review: Should we pass headers() here instead?
-        onLazyLoad?.(_config)
-
-        return getSession(_headers, _config).then((r) => r.json())
+        onLazyInit?.(_config)
+        return getSession(headers(), _config).then((r) => r.json())
       }
 
       if (args[0] instanceof Request) {
@@ -112,7 +115,7 @@ export function initAuth(
         const req = args[0]
         const ev = args[1]
         const _config = config(req)
-        onLazyLoad?.(_config)
+        onLazyInit?.(_config)
 
         // args[0] is supposed to be NextRequest but the instanceof check is failing.
         return handleAuth([req, ev], _config)
@@ -134,7 +137,7 @@ export function initAuth(
       const response: any = "res" in args[0] ? args[0].res : args[1]
       // @ts-expect-error -- request is NextRequest
       const _config = config(request)
-      onLazyLoad?.(_config)
+      onLazyInit?.(_config)
 
       // @ts-expect-error -- request is NextRequest
       return getSession(new Headers(request.headers), _config).then(

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -60,29 +60,12 @@ export interface NextAuthConfig extends Omit<AuthConfig, "raw"> {
 }
 
 async function getSession(headers: Headers, config: NextAuthConfig) {
-  const url = createActionURL("session", headers, config.basePath)
-  const request = new Request(url, {
-    headers: { cookie: headers.get("cookie") ?? "" },
-  })
-
-  return Auth(request, {
-    ...config,
-    callbacks: {
-      ...config.callbacks,
-      // Since we are server-side, we don't need to filter out the session data
-      // See https://authjs.dev/guides/upgrade-to-v5/v5#authenticating-server-side
-      // TODO: Taint the session data to prevent accidental leakage to the client
-      // https://react.devreference/nextjs/react/experimental_taintObjectReference
-      async session(...args) {
-        const session =
-          // If the user defined a custom session callback, use that instead
-          (await config.callbacks?.session?.(...args)) ?? args[0].session
-        // @ts-expect-error either user or token will be defined
-        const user = args[0].user ?? args[0].token
-        return { user, ...session } satisfies Session
-      },
-    },
-  }) as Promise<Response>
+  return await Auth(
+    new Request(createActionURL("session", headers, config.basePath), {
+      headers: { cookie: headers.get("cookie") ?? "" },
+    }),
+    config
+  )
 }
 
 export interface NextAuthRequest extends NextRequest {

--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server"
+
+/**
+ * AppRouteHandlerFnContext is the context that is passed to the handler as the
+ * second argument.
+ */
+type AppRouteHandlerFnContext = {
+  params?: Record<string, string | string[]>
+}
+/**
+ * Handler function for app routes. If a non-Response value is returned, an error
+ * will be thrown.
+ */
+export type AppRouteHandlerFn = (
+  /**
+   * Incoming request object.
+   */
+  req: NextRequest,
+  /**
+   * Context properties on the request (including the parameters if this was a
+   * dynamic route).
+   */
+  ctx: AppRouteHandlerFnContext
+) => unknown
+
+export type AppRouteHandlers = Record<
+  "GET" | "POST",
+  (req: NextRequest) => Promise<Response>
+>


### PR DESCRIPTION
- The `auth()` method will return the `Session` object, as defined via `session` callback, consistent with `useSession()`
- `experimental.structuredAuth` flag
- `unstable_auth()` and `unstable_update()` that always require an `AuthData` type. This so that we can reliably work with these data structures (eg.: update data in DB)