### PR TITLE
feat: expose full session in session callback

### DIFF
--- a/packages/core/src/lib/actions/session.ts
+++ b/packages/core/src/lib/actions/session.ts
@@ -123,12 +123,9 @@ export async function session(
 
       // Pass Session through to the session callback
       const sessionPayload = await callbacks.session({
-        // By default, only exposes a limited subset of information to the client
-        // as needed for presentation purposes (e.g. "you are logged in as...").
-        session: {
-          user: { name: user.name, email: user.email, image: user.image },
-          expires: session.expires.toISOString(),
-        },
+        // TODO: user already passed below,
+        // remove from session object in https://github.com/nextauthjs/next-auth/pull/9702
+        session: { ...session, user },
         user,
         newSession,
         ...(isUpdate ? { trigger: "update" } : {}),

--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -41,7 +41,17 @@ export const defaultCallbacks: CallbacksOptions = {
     return baseUrl
   },
   session({ session }) {
-    return session
+    return {
+      user: {
+        name: session.user?.name,
+        email: session.user?.email,
+        image: session.user?.image,
+      },
+      expires:
+        session.expires instanceof Date
+          ? session.expires.toISOString()
+          : session.expires,
+    }
   },
   jwt({ token }) {
     return token
@@ -142,7 +152,7 @@ export async function init({
     isOnRedirectProxy,
     experimental: {
       ...authOptions.experimental,
-    }
+    },
   }
 
   // Init cookies

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,7 +60,7 @@ import type {
   OAuth2TokenEndpointResponse,
   OpenIDTokenEndpointResponse,
 } from "oauth4webapi"
-import type { Adapter, AdapterUser } from "./adapters.js"
+import type { Adapter, AdapterSession, AdapterUser } from "./adapters.js"
 import { AuthConfig } from "./index.js"
 import type { JWT, JWTOptions } from "./jwt.js"
 import type { Cookie } from "./lib/utils/cookie.js"
@@ -250,7 +250,7 @@ export interface CallbacksOptions<P = Profile, A = Account> {
   session: (
     params: (
       | {
-          session: Session
+          session: { user: AdapterUser } & AdapterSession
           /** Available when {@link AuthConfig.session} is set to `strategy: "database"`. */
           user: AdapterUser
         }

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -180,11 +180,12 @@ describe("Session Action", () => {
         image: "https://test.com/test.png",
       }
 
+      const expectedUserId = randomString(32)
       const mockAdapter: Adapter = {
         getSessionAndUser: vi.fn().mockResolvedValue({
           session: {
             sessionToken: expectedSessionToken,
-            userId: randomString(32),
+            userId: expectedUserId,
             expires: currentExpires,
           },
           user: expectedUser,
@@ -231,7 +232,9 @@ describe("Session Action", () => {
         newSession: undefined,
         session: {
           user: expectedUser,
-          expires: currentExpires.toISOString(),
+          expires: currentExpires,
+          sessionToken: expectedSessionToken,
+          userId: expectedUserId,
         },
         user: expectedUser,
       })
@@ -268,11 +271,12 @@ describe("Session Action", () => {
         image: "https://test.com/test.png",
       }
 
+      const expectedUserId = randomString(32)
       const mockAdapter: Adapter = {
         getSessionAndUser: vi.fn().mockResolvedValue({
           session: {
             sessionToken: expectedSessionToken,
-            userId: randomString(32),
+            userId: expectedUserId,
             expires: currentExpires,
           },
           user: expectedUser,
@@ -316,7 +320,9 @@ describe("Session Action", () => {
         newSession: undefined,
         session: {
           user: expectedUser,
-          expires: currentExpires.toISOString(),
+          expires: currentExpires,
+          sessionToken: expectedSessionToken,
+          userId: expectedUserId,
         },
         user: expectedUser,
       })

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -76,7 +76,13 @@ async function getSession(headers: Headers, config: NextAuthConfig) {
       async session(...args) {
         const session =
           // If the user defined a custom session callback, use that instead
-          (await config.callbacks?.session?.(...args)) ?? args[0].session
+          (await config.callbacks?.session?.(...args)) ?? {
+            ...args[0].session,
+            expires:
+              args[0].session.expires instanceof Date
+                ? args[0].session.expires.toISOString()
+                : args[0].session.expires,
+          }
         // @ts-expect-error either user or token will be defined
         const user = args[0].user ?? args[0].token
         return { user, ...session } satisfies Session


### PR DESCRIPTION
This PR forwards the entire `AdapterSession` to the session callback.

Instead of limiting the user's callback by filtering out the default values, we can rather pass them the full object, and only filter in `defaultCallbacks`, a much more fitting place for this action.

This change made if clear that sending `user` in `session` is unnecessary, since we already pass `user` directly to the `session` callback. For backwards compat, we will keep doing so, but we can change this behavior in #9702 behind a flag.

Fixes #8115, closes #9334, closes #9419
