### PR TITLE
fix(providers): Handle Azure AD tenants correctly

### DIFF
--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -24,8 +24,13 @@ export async function getAuthorizationUrl(
     // We check this in assert.ts
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const issuer = new URL(provider.issuer!)
-    const discoveryResponse = await o.discoveryRequest(issuer)
-    const as = await o.processDiscoveryResponse(issuer, discoveryResponse)
+    let discoveryResponse: Response | undefined = await o.discoveryRequest(issuer)
+
+    if (provider.authorization?.conform) {
+      discoveryResponse = await provider.authorization?.conform(discoveryResponse);
+    }
+
+    const as = await o.processDiscoveryResponse(issuer, discoveryResponse!)
 
     if (!as.authorization_endpoint) {
       throw new TypeError(

--- a/packages/core/src/lib/utils/providers.ts
+++ b/packages/core/src/lib/utils/providers.ts
@@ -151,5 +151,5 @@ function normalizeEndpoint(
       url.searchParams.set(key, String(value))
     }
   }
-  return { url, request: e?.request, conform: e?.conform }
+  return { url, request: e?.request, conform: e?.conform, serverConform: e?.serverConform }
 }

--- a/packages/core/src/providers/microsoft-entra-id.ts
+++ b/packages/core/src/providers/microsoft-entra-id.ts
@@ -9,6 +9,7 @@
  * @module providers/microsoft-entra-id
  */
 import type { OAuthConfig, OAuthUserConfig } from "./index.js"
+import * as jose from "jose"
 
 export interface MicrosoftEntraIDProfile extends Record<string, any> {
   sub: string
@@ -145,6 +146,31 @@ export default function MicrosoftEntraID<P extends MicrosoftEntraIDProfile>(
       params: {
         scope: "openid profile email User.Read",
       },
+      async conform(response) {
+        // Microsoft being special and non-compliant #9635
+        //
+        // MS doesn't follow the spec for some common tenant
+        // ID's ("common", "organizations", "customers"), returning
+        // a different issuer URL than used to make the request.
+        if (response.status !== 200) return response
+
+        let json = await response.json()
+        json.issuer = rest.issuer;
+        return new Response(JSON.stringify(json), response)
+      },
+      async serverConform(authServer, codeGrantResponse) {
+        if (codeGrantResponse.status !== 200) return authServer
+
+        const { id_token } = await codeGrantResponse.clone().json()
+        const jwt: jose.JWTPayload & { tid?: string } = jose.decodeJwt(id_token)
+
+        return {
+          ...authServer,
+          issuer: jwt.tid
+            ? authServer.issuer.replace(tenantId, jwt.tid)
+            : authServer.issuer,
+        }
+      }
     },
     async profile(profile, tokens) {
       // https://learn.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0&tabs=http#examples


### PR DESCRIPTION
## ☕️ Reasoning

Endpoints returned by Azure AD want us to edit the path so that each request gets routed to their proper tenant IDs.
The old implementation didn't handle this properly when using the "common" tenant ID, which basically lets us use it normally like any other provider. We would receive the template endpoint paths and use those in error checking and stuff rather than the ones we actually use.

I've just thrown something up and I've done some quick testing. It seems to work normally. I'll test custom tenants at some point and I suspect it won't work until I test and fix it.

## 🧢 Checklist

- [X] Documentation
- [X] Tests
- [X] Ready to be merged

## 🎫 Affected issues

Fixes: #9635

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
