### PR TITLE
feat: Simplify ExpressAuth setup

### DIFF
--- a/packages/frameworks-express/src/index.ts
+++ b/packages/frameworks-express/src/index.ts
@@ -21,24 +21,9 @@
  *
  * const app = express()
  *
- * // Make sure to use these body parsers so Auth.js can receive data from the client
- * app.use(express.json())
- * app.use(express.urlencoded({ extended: true }))
- *
  * // If app is served through a proxy, trust the proxy to allow HTTPS protocol to be detected
  * app.use('trust proxy')
- *
- * app.use(
- *   "/api/auth/*",
- *   ExpressAuth({
- *     providers: [
- *       GitHub({
- *         clientId: process.env.GITHUB_ID,
- *         clientSecret: process.env.GITHUB_SECRET,
- *       }),
- *     ],
- *   })
- * )
+ * app.use("/auth/*", ExpressAuth({ providers: [ GitHub ] }))
  * ```
  *
  * Don't forget to set the `AUTH_SECRET` environment variable. This should be a minimum of 32 characters, random string. On UNIX systems you can use `openssl rand -hex 32` or check out `https://generate-secret.vercel.app/32`.
@@ -49,7 +34,7 @@
  * The callback URL used by the [providers](https://authjs.dev/reference/core/modules/providers) must be set to the following, unless you mount the `ExpressAuth` handler on a different path:
  *
  * ```
- * [origin]/api/auth/callback/[provider]
+ * [origin]/auth/callback/[provider]
  * ```
  *
  * ## Signing in and signing out
@@ -139,9 +124,17 @@
  */
 
 import { Auth } from "@auth/core"
-import type { AuthConfig, Session } from "@auth/core/types"
-import { Request as ExpressRequest, Response as ExpressResponse } from "express"
+import type { AuthAction, AuthConfig, Session } from "@auth/core/types"
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+  NextFunction,
+  json,
+  urlencoded,
+} from "express"
 import { toWebRequest, toExpressResponse } from "./lib/index.js"
+import type { IncomingHttpHeaders } from "http"
+import { REFUSED } from "dns"
 
 export type {
   Account,
@@ -151,46 +144,42 @@ export type {
   User,
 } from "@auth/core/types"
 
-function ExpressAuthHandler(authConfig: Omit<AuthConfig, "raw">) {
-  return async (req: ExpressRequest, res: ExpressResponse) => {
-    const request = toWebRequest(req)
-    const response = await Auth(request, authConfig)
-    await toExpressResponse(response, res)
+export function ExpressAuth(config: Omit<AuthConfig, "raw">) {
+  return async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction
+  ) => {
+    json()(req, res, async (err) => {
+      if (err) return next(err)
+      urlencoded({ extended: true })(req, res, async (err) => {
+        if (err) return next(err)
+        config.basePath = getBasePath(req)
+        setEnvDefaults(config)
+        await toExpressResponse(await Auth(toWebRequest(req), config), res)
+        next()
+      })
+    })
   }
-}
-
-export function ExpressAuth(
-  config: AuthConfig
-): ReturnType<typeof ExpressAuthHandler> {
-  const { ...authOptions } = config
-  authOptions.secret ??= process.env.AUTH_SECRET
-  authOptions.redirectProxyUrl ??= process.env.AUTH_REDIRECT_PROXY_URL
-  authOptions.trustHost ??= !!(
-    process.env.AUTH_TRUST_HOST ??
-    process.env.VERCEL ??
-    process.env.NODE_ENV !== "production"
-  )
-
-  const handler = ExpressAuthHandler(authOptions)
-
-  return handler
 }
 
 export type GetSessionResult = Promise<Session | null>
 
 export async function getSession(
   req: ExpressRequest,
-  options: Omit<AuthConfig, "raw">
+  config: Omit<AuthConfig, "raw">
 ): GetSessionResult {
-  options.secret ??= process.env.AUTH_SECRET
-  options.trustHost ??= true
-
-  const request = toWebRequest(req)
-  const url = new URL("/api/auth/session", request.url)
+  setEnvDefaults(config)
+  const url = createActionURL(
+    "session",
+    req.protocol.toString(),
+    req.headers,
+    config.basePath
+  )
 
   const response = await Auth(
-    new Request(url, { headers: request.headers }),
-    options
+    new Request(url, { headers: { cookie: req.headers.cookie ?? "" } }),
+    config
   )
 
   const { status = 200 } = response
@@ -200,4 +189,59 @@ export async function getSession(
   if (!data || !Object.keys(data).length) return null
   if (status === 200) return data
   throw new Error(data.message)
+}
+
+export function setEnvDefaults(config: AuthConfig) {
+  config.secret ??= process.env.AUTH_SECRET
+  try {
+    const url = process.env.AUTH_URL
+    if (url) config.basePath = new URL(url).pathname
+  } catch {
+  } finally {
+    config.basePath ??= "/auth"
+  }
+
+  config.trustHost ??= !!(
+    process.env.AUTH_URL ??
+    process.env.AUTH_TRUST_HOST ??
+    process.env.VERCEL ??
+    process.env.NODE_ENV !== "production"
+  )
+  config.redirectProxyUrl ??= process.env.AUTH_REDIRECT_PROXY_URL
+  config.providers = config.providers.map((p) => {
+    const finalProvider = typeof p === "function" ? p({}) : p
+    if (finalProvider.type === "oauth" || finalProvider.type === "oidc") {
+      const ID = finalProvider.id.toUpperCase()
+      finalProvider.clientId ??= process.env[`AUTH_${ID}_ID`]
+      finalProvider.clientSecret ??= process.env[`AUTH_${ID}_SECRET`]
+      if (finalProvider.type === "oidc") {
+        finalProvider.issuer ??= process.env[`AUTH_${ID}_ISSUER`]
+      }
+    }
+    return finalProvider
+  })
+}
+
+/**
+ * Extract the origin and base path from either the `AUTH_URL` environment variable,
+ * or the request's headers and the {@link AuthConfig.basePath} option.
+ */
+export function createActionURL(
+  action: AuthAction,
+  protocol: string,
+  headers: IncomingHttpHeaders,
+  basePath?: string
+): URL {
+  let url = process.env.AUTH_URL
+  if (!url) {
+    const host = headers["x-forwarded-host"] ?? headers.host
+    const proto = headers["x-forwarded-proto"] ?? protocol
+    url = `${proto === "http" ? "http" : "https"}://${host}${basePath}`
+  }
+
+  return new URL(`${url.replace(/\/$/, "")}/${action}`)
+}
+
+function getBasePath(req: ExpressRequest) {
+  return req.baseUrl.split(req.params[0])[0].replace(/\/$/, "")
 }

--- a/packages/frameworks-express/src/index.ts
+++ b/packages/frameworks-express/src/index.ts
@@ -125,16 +125,9 @@
 
 import { Auth } from "@auth/core"
 import type { AuthAction, AuthConfig, Session } from "@auth/core/types"
-import {
-  Request as ExpressRequest,
-  Response as ExpressResponse,
-  NextFunction,
-  json,
-  urlencoded,
-} from "express"
+import * as e from "express"
 import { toWebRequest, toExpressResponse } from "./lib/index.js"
 import type { IncomingHttpHeaders } from "http"
-import { REFUSED } from "dns"
 
 export type {
   Account,
@@ -145,14 +138,10 @@ export type {
 } from "@auth/core/types"
 
 export function ExpressAuth(config: Omit<AuthConfig, "raw">) {
-  return async (
-    req: ExpressRequest,
-    res: ExpressResponse,
-    next: NextFunction
-  ) => {
-    json()(req, res, async (err) => {
+  return async (req: e.Request, res: e.Response, next: e.NextFunction) => {
+    e.json()(req, res, async (err) => {
       if (err) return next(err)
-      urlencoded({ extended: true })(req, res, async (err) => {
+      e.urlencoded({ extended: true })(req, res, async (err) => {
         if (err) return next(err)
         config.basePath = getBasePath(req)
         setEnvDefaults(config)
@@ -166,7 +155,7 @@ export function ExpressAuth(config: Omit<AuthConfig, "raw">) {
 export type GetSessionResult = Promise<Session | null>
 
 export async function getSession(
-  req: ExpressRequest,
+  req: e.Request,
   config: Omit<AuthConfig, "raw">
 ): GetSessionResult {
   setEnvDefaults(config)
@@ -242,6 +231,6 @@ export function createActionURL(
   return new URL(`${url.replace(/\/$/, "")}/${action}`)
 }
 
-function getBasePath(req: ExpressRequest) {
+function getBasePath(req: e.Request) {
   return req.baseUrl.split(req.params[0])[0].replace(/\/$/, "")
 }

--- a/packages/frameworks-express/tests/index/session.test.ts
+++ b/packages/frameworks-express/tests/index/session.test.ts
@@ -39,8 +39,6 @@ describe("getSession", () => {
   it("Should return the mocked session from the Auth response", async () => {
     let expectations: Function = () => {}
 
-    app.use(express.json())
-
     app.post("/", async (req, res) => {
       const session = await getSession(req, {
         providers: [],


### PR DESCRIPTION
- The new setup becomes:

```diff
- app.use(express.json())
- app.use(express.urlencoded({ extended: true }))
- app.use(
-   "/api/auth/*",
-   ExpressAuth({
-     providers: [
-       GitHub({
-         clientId: process.env.GITHUB_ID,
-         clientSecret: process.env.GITHUB_SECRET,
-       }),
-     ],
-   })
- )
app.use('trust proxy')
+ app.use("/auth/*", ExpressAuth({ providers: [ GitHub ] }))
```

- The default base path is now `/auth` to match other integrations. You can configure this via the `basePath` option. (which is not needed for `ExpressAuth` since we can infer it, but needed for `getSession`, which might need more work in a future PR)

- I also added environment variable inference similar to SvelteKit Auth #9670.

Prefix your variables with `AUTH_` (eg.: `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET`), and we will pick them up!

- Cleaned up tests a bit as well. I think we need to iterate on the tests in a future PR, it's currently pretty hard to understand and they are relying on a lot of internals