### PR TITLE
Update oauth-tutorial.mdx

### DIFF
--- a/docs/docs/getting-started/providers/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/providers/oauth-tutorial.mdx
@@ -350,7 +350,7 @@ NextAuth.js will already create this API endpoint for you when we start the appl
   <TabItem value="sveltekit" label="SvelteKit">
 
 ```
-http://localhost:5173/auth/callback/github
+http://localhost:5173/api/auth/callback/github
 ```
 
   </TabItem>


### PR DESCRIPTION
Fix SvelteKit docs for the OAuth tutorial.


## ☕️ Reasoning

Looks like there was a missing path segment in the OAuth tutorial for SvelteKit.

## 🧢 Checklist

- [x] Documentation
- [ ] ~Tests~
- [x] Ready to be merged

## 🎫 Affected issues

None

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
