### PR TITLE
fix: use match instead of split when parsing action

### DIFF
--- a/packages/core/src/lib/utils/web.ts
+++ b/packages/core/src/lib/utils/web.ts
@@ -131,9 +131,9 @@ export function parseActionAndProviderId(
   action: AuthAction
   providerId?: string
 } {
-  const a = pathname.split(base)
+  const a = pathname.match(new RegExp(`^${base}(.+)`))
 
-  if (a.length !== 2 || a[0] !== "")
+  if (a === null)
     throw new UnknownAction(`Cannot parse action at ${pathname}`)
 
   const [_, actionAndProviderId] = a

--- a/packages/core/test/url-parsing.test.ts
+++ b/packages/core/test/url-parsing.test.ts
@@ -46,6 +46,12 @@ describe("parse the action and provider id", () => {
       error: "Cannot parse action at /api/auth/signin/api/auth/signin/github",
       basePath: "/api/auth",
     },
+    {
+      path: "/auth/signin/auth0",
+      action: "signin",
+      providerId: "auth0",
+      basePath: "/auth",
+    },
   ])("$path", ({ path, error, basePath, action, providerId }) => {
     if (action || providerId) {
       const parsed = parseActionAndProviderId(path, basePath)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

The recent addition of the https://github.com/nextauthjs/next-auth/pull/9686 has caused providers that start with "auth" (e.g. `auth0`, `authentik`) to break when using the default base path (`/auth`).

The problem is here: https://github.com/nextauthjs/next-auth/pull/9686/files#diff-e2783aeceecac8cd1b559372f242d520b894883a0c297fa4829ef4e5a5f35e88R134

`pathname.split(base)` represents `'/auth/signin/auth0'.split('/auth')` when using the Auth0 provider. As such the result of the operation is `['', '/signin', '0']` which causes the function to throw since there's an expected length of 2.

See https://github.com/nextauthjs/next-auth/issues/9743.

**Side note:** auto-closing issues that don't have a "valid" repro URL is frustrating. I think making it an absolute requirement to include a reproduction URL is a mistake.

## 🧢 Checklist

I was unable to get the tests to work. Presumably the addition of all possible provider URLs here would have caught this:
https://github.com/nextauthjs/next-auth/blob/963086b36f4dc9203cbcf6997b5fed148f90edc8/packages/core/test/url-parsing.test.ts

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 
Fixes: https://github.com/nextauthjs/next-auth/issues/9743

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
