### PR TITLE
feat: nodemailer (prev Email), Resend, SendGrid

### DIFF
--- a/apps/dev/nextjs/auth.ts
+++ b/apps/dev/nextjs/auth.ts
@@ -1,6 +1,6 @@
 import NextAuth from "next-auth"
-// import Email from "next-auth/providers/email"
 import authConfig from "auth.config"
+// import Email from "next-auth/providers/email"
 // import { PrismaClient } from "@prisma/client"
 // import { PrismaAdapter } from "@auth/prisma-adapter"
 
@@ -8,7 +8,6 @@ import authConfig from "auth.config"
 
 // authConfig.providers.push(
 //   // Start server with `pnpm email`
-//   // @ts-expect-error
 //   Email({ server: "smtp://127.0.0.1:1025?tls.rejectUnauthorized=false" })
 // )
 

--- a/apps/dev/nextjs/auth.ts
+++ b/apps/dev/nextjs/auth.ts
@@ -1,36 +1,40 @@
 import NextAuth from "next-auth"
 import authConfig from "auth.config"
-// import Email from "next-auth/providers/email"
 // import { PrismaClient } from "@prisma/client"
 // import { PrismaAdapter } from "@auth/prisma-adapter"
+// import SendGrid from "next-auth/providers/sendgrid"
+// import Resend from "next-auth/providers/resend"
+// import Email from "next-auth/providers/email"
 
 // globalThis.prisma ??= new PrismaClient()
 
 // authConfig.providers.push(
 //   // Start server with `pnpm email`
-//   Email({ server: "smtp://127.0.0.1:1025?tls.rejectUnauthorized=false" })
+//   Email({ server: "smtp://127.0.0.1:1025?tls.rejectUnauthorized=false" }),
+//   SendGrid,
+//   Resend
 // )
 
-export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth(
-  (request) => {
-    if (request?.nextUrl.searchParams.get("test")) {
-      return {
-        // adapter: PrismaAdapter(globalThis.prisma),
-        session: { strategy: "jwt" },
-        ...authConfig,
-        providers: [],
-      }
-    }
-    return {
-      // adapter: PrismaAdapter(globalThis.prisma),
-      session: { strategy: "jwt" },
-      ...authConfig,
-    }
-  }
-)
+// export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth(
+//   (request) => {
+//     if (request?.nextUrl.searchParams.get("test")) {
+//       return {
+//         // adapter: PrismaAdapter(globalThis.prisma),
+//         session: { strategy: "jwt" },
+//         ...authConfig,
+//         providers: [],
+//       }
+//     }
+//     return {
+//       // adapter: PrismaAdapter(globalThis.prisma),
+//       session: { strategy: "jwt" },
+//       ...authConfig,
+//     }
+//   }
+// )
 
-// export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
-//   // adapter: PrismaAdapter(globalThis.prisma),
-//   session: { strategy: "jwt" },
-//   ...authConfig,
-// })
+export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
+  // adapter: PrismaAdapter(globalThis.prisma),
+  session: { strategy: "jwt" },
+  ...authConfig,
+})

--- a/package.json
+++ b/package.json
@@ -260,6 +260,9 @@
   "pnpm": {
     "patchedDependencies": {
       "@balazsorban/monorepo-release@0.3.1": "patches/@balazsorban__monorepo-release@0.3.1.patch"
+    },
+    "overrides": {
+      "mailparser": "3.6.6"
     }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,6 +168,7 @@ export async function Auth(
 
     const type = isAuthError ? error.type : "Configuration"
     const page = (isAuthError && error.kind) || "error"
+    // TODO: Filter out some error types from being sent to the client
     const params = new URLSearchParams({ error: type })
     const path =
       config.pages?.[page] ?? `${config.basePath}/${page.toLowerCase()}`

--- a/packages/core/src/lib/actions/signin/send-token.ts
+++ b/packages/core/src/lib/actions/signin/send-token.ts
@@ -51,11 +51,13 @@ export async function sendToken(
 
   const secret = provider.secret ?? options.secret
 
+  const baseUrl = new URL(options.basePath, options.url.origin)
+
   const sendRequest = provider.sendVerificationRequest({
     identifier: email,
     token,
     expires,
-    url: `${url}/callback/${provider.id}?${new URLSearchParams({
+    url: `${baseUrl}/callback/${provider.id}?${new URLSearchParams({
       callbackUrl,
       token,
       email,
@@ -74,7 +76,7 @@ export async function sendToken(
   await Promise.all([sendRequest, createToken])
 
   return {
-    redirect: `${url}/verify-request?${new URLSearchParams({
+    redirect: `${baseUrl}/verify-request?${new URLSearchParams({
       provider: provider.id,
       type: provider.type,
     })}`,

--- a/packages/core/src/providers/email.ts
+++ b/packages/core/src/providers/email.ts
@@ -1,392 +1,53 @@
 import type { CommonProviderOptions } from "./index.js"
 import type { Awaitable, Theme } from "../types.js"
 
-import { Transport, TransportOptions, createTransport } from "nodemailer"
-import * as JSONTransport from "nodemailer/lib/json-transport/index.js"
-import * as SendmailTransport from "nodemailer/lib/sendmail-transport/index.js"
-import * as SESTransport from "nodemailer/lib/ses-transport/index.js"
-import * as SMTPTransport from "nodemailer/lib/smtp-transport/index.js"
-import * as SMTPPool from "nodemailer/lib/smtp-pool/index.js"
-import * as StreamTransport from "nodemailer/lib/stream-transport/index.js"
-
-// TODO: Make use of https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html for the string
-type AllTransportOptions =
-  | string
-  | SMTPTransport
-  | SMTPTransport.Options
-  | SMTPPool
-  | SMTPPool.Options
-  | SendmailTransport
-  | SendmailTransport.Options
-  | StreamTransport
-  | StreamTransport.Options
-  | JSONTransport
-  | JSONTransport.Options
-  | SESTransport
-  | SESTransport.Options
-  | Transport<any>
-  | TransportOptions
-
-export interface SendVerificationRequestParams {
-  identifier: string
-  url: string
-  expires: Date
-  provider: EmailConfig
-  token: string
-  theme: Theme
-  request: Request
-}
+// TODO: Kepts for backwards compatibility
+// Remove this import and encourage users
+// to import it from @auth/core/providers/nodemailer directly
+import Nodemailer from "./nodemailer.js"
+import type { NodemailerConfig, NodemailerUserConfig } from "./nodemailer.js"
 
 /**
- * The Email Provider needs to be configured with an e-mail client.
- * By default, it uses `nodemailer`, which you have to install if this
- * provider is present.
+ * @deprecated
  *
- * You can use a other services as well, like:
- * - [Postmark](https://postmarkapp.com)
- * - [Mailgun](https://www.mailgun.com)
- * - [SendGrid](https://sendgrid.com)
- * - etc.
+ * Import this provider from the `providers/nodemailer` submodule instead of `providers/email`.
  *
- * [Custom email service with Auth.js](https://authjs.dev/guides/providers/email#custom-email-service)
+ * To log in with nodemailer, change `signIn("email")` to `signIn("nodemailer")`
  */
-export interface EmailUserConfig extends Record<string, unknown> {
-  server?: AllTransportOptions
-  type?: "email"
-  /** @default `"Auth.js <no-reply@authjs.dev>"` */
-  from?: string
-  /**
-   * How long until the e-mail can be used to log the user in,
-   * in seconds. Defaults to 1 day
-   *
-   * @default 86400
-   */
-  maxAge?: number
-  /** [Documentation](https://authjs.dev/guides/providers/email#customizing-emails) */
-  sendVerificationRequest?: (
-    params: SendVerificationRequestParams
-  ) => Awaitable<void>
-  /**
-   * By default, we are generating a random verification token.
-   * You can make it predictable or modify it as you like with this method.
-   *
-   * @example
-   * ```ts
-   *  Providers.Email({
-   *    async generateVerificationToken() {
-   *      return "ABC123"
-   *    }
-   *  })
-   * ```
-   * [Documentation](https://authjs.dev/guides/providers/email#customizing-the-verification-token)
-   */
-  generateVerificationToken?: () => Awaitable<string>
-  /** If defined, it is used to hash the verification token when saving to the database . */
-  secret?: string
-  /**
-   * Normalizes the user input before sending the verification request.
-   *
-   * ⚠️ Always make sure this method returns a single email address.
-   *
-   * @note Technically, the part of the email address local mailbox element
-   * (everything before the `@` symbol) should be treated as 'case sensitive'
-   * according to RFC 2821, but in practice this causes more problems than
-   * it solves, e.g.: when looking up users by e-mail from databases.
-   * By default, we treat email addresses as all lower case,
-   * but you can override this function to change this behavior.
-   *
-   * [Normalizing the email address](https://authjs.dev/reference/core/providers/email#normalizing-the-email-address) | [RFC 2821](https://tools.ietf.org/html/rfc2821) | [Email syntax](https://en.wikipedia.org/wiki/Email_address#Syntax)
-   */
-  normalizeIdentifier?: (identifier: string) => string
-}
-
-export interface EmailConfig extends CommonProviderOptions {
-  // defaults
-  id: "email"
-  type: "email"
-  name: "Email"
-  server: AllTransportOptions
-  from: string
-  maxAge: number
-  sendVerificationRequest: (
-    params: SendVerificationRequestParams
-  ) => Awaitable<void>
-
-  /**
-   * This is copied into EmailConfig in parseProviders() don't use elsewhere
-   */
-  options: EmailUserConfig
-
-  // user options
-  // TODO figure out a better way than copying from EmailUserConfig
-  secret?: string
-  generateVerificationToken?: () => Awaitable<string>
-  normalizeIdentifier?: (identifier: string) => string
+export default function Email(config: NodemailerUserConfig): NodemailerConfig {
+  return {
+    ...Nodemailer(config),
+    id: "email",
+    name: "Email",
+  }
 }
 
 // TODO: Rename to Token provider
 // when started working on https://github.com/nextauthjs/next-auth/discussions/1465
 export type EmailProviderType = "email"
 
-/**
- * ## Overview
- * The Email provider uses email to send "magic links" that can be used to sign in, you will likely have seen these if you have used services like Slack before.
- *
- * Adding support for signing in via email in addition to one or more OAuth services provides a way for users to sign in if they lose access to their OAuth account (e.g. if it is locked or deleted).
- *
- * The Email provider can be used in conjunction with (or instead of) one or more OAuth providers.
- * ### How it works
- *
- * On initial sign in, a **Verification Token** is sent to the email address provided. By default this token is valid for 24 hours. If the Verification Token is used within that time (i.e. by clicking on the link in the email) an account is created for the user and they are signed in.
- *
- *
- * If someone provides the email address of an _existing account_ when signing in, an email is sent and they are signed into the account associated with that email address when they follow the link in the email.
- *
- * :::tip
- * The Email Provider can be used with both JSON Web Tokens and database sessions, but you **must** configure a database to use it. It is not possible to enable email sign in without using a database.
- * :::
- * ## Configuration
-
- * 1. NextAuth.js does not include `nodemailer` as a dependency, so you'll need to install it yourself if you want to use the Email Provider. Run `npm install nodemailer` or `yarn add nodemailer`.
- * 2. You will need an SMTP account; ideally for one of the [services known to work with `nodemailer`](https://community.nodemailer.com/2-0-0-beta/setup-smtp/well-known-services/).
- * 3. There are two ways to configure the SMTP server connection.
- *
- * You can either use a connection string or a `nodemailer` configuration object.
- *
- * 3.1 **Using a connection string**
- *
- * Create an `.env` file to the root of your project and add the connection string and email address.
- *
- * ```js title=".env" {1}
- * 	EMAIL_SERVER=smtp://username:password@smtp.example.com:587
- * 	EMAIL_FROM=noreply@example.com
- * ```
- *
- * Now you can add the email provider like this:
- *
- * ```js {3} title="pages/api/auth/[...nextauth].js"
- * import EmailProvider from "next-auth/providers/email";
- * ...
- * providers: [
- *   EmailProvider({
- *     server: process.env.EMAIL_SERVER,
- *     from: process.env.EMAIL_FROM
- *   }),
- * ],
- * ```
- *
- * 3.2 **Using a configuration object**
- *
- * In your `.env` file in the root of your project simply add the configuration object options individually:
- *
- * ```js title=".env"
- * EMAIL_SERVER_USER=username
- * EMAIL_SERVER_PASSWORD=password
- * EMAIL_SERVER_HOST=smtp.example.com
- * EMAIL_SERVER_PORT=587
- * EMAIL_FROM=noreply@example.com
- * ```
- *
- * Now you can add the provider settings to the NextAuth.js options object in the Email Provider.
- *
- * ```js title="pages/api/auth/[...nextauth].js"
- * import EmailProvider from "next-auth/providers/email";
- * ...
- * providers: [
- *   EmailProvider({
- *     server: {
- *       host: process.env.EMAIL_SERVER_HOST,
- *       port: process.env.EMAIL_SERVER_PORT,
- *       auth: {
- *         user: process.env.EMAIL_SERVER_USER,
- *         pass: process.env.EMAIL_SERVER_PASSWORD
- *       }
- *     },
- *     from: process.env.EMAIL_FROM
- *   }),
- * ],
- * ```
- *
- * 4. Do not forget to setup one of the database [adapters](https://authjs.dev/reference/core/adapters) for storing the Email verification token.
- *
- * 5. You can now sign in with an email address at `/api/auth/signin`.
- *
- * A user account (i.e. an entry in the Users table) will not be created for the user until the first time they verify their email address. If an email address is already associated with an account, the user will be signed in to that account when they use the link in the email.
- *
- * ## Customizing emails
- *
- * You can fully customize the sign in email that is sent by passing a custom function as the `sendVerificationRequest` option to `EmailProvider()`.
- *
- * e.g.
- *
- * ```js {3} title="pages/api/auth/[...nextauth].js"
- * import EmailProvider from "next-auth/providers/email";
- * ...
- * providers: [
- *   EmailProvider({
- *     server: process.env.EMAIL_SERVER,
- *     from: process.env.EMAIL_FROM,
- *     sendVerificationRequest({
- *       identifier: email,
- *       url,
- *       provider: { server, from },
- *     }) {
- *       // your function
- *     },
- *   }),
- * ]
- * ```
- *
- * The following code shows the complete source for the built-in `sendVerificationRequest()` method:
- *
- * ```js
- * import { createTransport } from "nodemailer"
- *
- * async function sendVerificationRequest(params) {
- *   const { identifier, url, provider, theme } = params
- *   const { host } = new URL(url)
- *   // NOTE: You are not required to use `nodemailer`, use whatever you want.
- *   const transport = createTransport(provider.server)
- *   const result = await transport.sendMail({
- *     to: identifier,
- *     from: provider.from,
- *     subject: `Sign in to ${host}`,
- *     text: text({ url, host }),
- *     html: html({ url, host, theme }),
- *   })
- *   const failed = result.rejected.concat(result.pending).filter(Boolean)
- *   if (failed.length) {
- *     throw new Error(`Email(s) (${failed.join(", ")}) could not be sent`)
- *   }
- * }
- *
- * function html(params: { url: string; host: string; theme: Theme }) {
- *   const { url, host, theme } = params
- *
- *   const escapedHost = host.replace(/\./g, "&#8203;.")
- *
- *   const brandColor = theme.brandColor || "#346df1"
- *   const color = {
- *     background: "#f9f9f9",
- *     text: "#444",
- *     mainBackground: "#fff",
- *     buttonBackground: brandColor,
- *     buttonBorder: brandColor,
- *     buttonText: theme.buttonText || "#fff",
- *   }
- *
- *   return `
- * <body style="background: ${color.background};">
- *   <table width="100%" border="0" cellspacing="20" cellpadding="0"
- *     style="background: ${color.mainBackground}; max-width: 600px; margin: auto; border-radius: 10px;">
- *     <tr>
- *       <td align="center"
- *         style="padding: 10px 0px; font-size: 22px; font-family: Helvetica, Arial, sans-serif; color: ${color.text};">
- *         Sign in to <strong>${escapedHost}</strong>
- *       </td>
- *     </tr>
- *     <tr>
- *       <td align="center" style="padding: 20px 0;">
- *         <table border="0" cellspacing="0" cellpadding="0">
- *           <tr>
- *             <td align="center" style="border-radius: 5px;" bgcolor="${color.buttonBackground}"><a href="${url}"
- *                 target="_blank"
- *                 style="font-size: 18px; font-family: Helvetica, Arial, sans-serif; color: ${color.buttonText}; text-decoration: none; border-radius: 5px; padding: 10px 20px; border: 1px solid ${color.buttonBorder}; display: inline-block; font-weight: bold;">Sign
- *                 in</a></td>
- *           </tr>
- *         </table>
- *       </td>
- *     </tr>
- *     <tr>
- *       <td align="center"
- *         style="padding: 0px 0px 10px 0px; font-size: 16px; line-height: 22px; font-family: Helvetica, Arial, sans-serif; color: ${color.text};">
- *         If you did not request this email you can safely ignore it.
- *       </td>
- *     </tr>
- *   </table>
- * </body>
- * `
- * }
- *
- * // Email Text body (fallback for email clients that don't render HTML, e.g. feature phones)
- * function text({ url, host }: { url: string; host: string }) {
- *   return `Sign in to ${host}\n${url}\n\n`
- * }
- * ```
- *
- * :::tip
- * If you want to generate great looking email client compatible HTML with React, check out https://mjml.io
- * :::
- *
- * ## Customizing the Verification Token
- *
- * By default, we are generating a random verification token. You can define a `generateVerificationToken` method in your provider options if you want to override it:
- *
- * ```js title="pages/api/auth/[...nextauth].js"
- * providers: [
- *   EmailProvider({
- *     async generateVerificationToken() {
- *       return "ABC123"
- *     }
- *   })
- * ],
- * ```
- *
- * ## Normalizing the email address
- *
- * By default, Auth.js will normalize the email address. It treats values as case-insensitive (which is technically not compliant to the [RFC 2821 spec](https://datatracker.ietf.org/doc/html/rfc2821), but in practice this causes more problems than it solves, eg. when looking up users by e-mail from databases.) and also removes any secondary email address that was passed in as a comma-separated list. You can apply your own normalization via the `normalizeIdentifier` method on the `EmailProvider`. The following example shows the default behavior:
- * ```ts
- *   EmailProvider({
- *     // ...
- *     normalizeIdentifier(identifier: string): string {
- *       // Get the first two elements only,
- *       // separated by `@` from user input.
- *       let [local, domain] = identifier.toLowerCase().trim().split("@")
- *       // The part before "@" can contain a ","
- *       // but we remove it on the domain part
- *       domain = domain.split(",")[0]
- *       return `${local}@${domain}`
- *
- *       // You can also throw an error, which will redirect the user
- *       // to the sign-in page with error=EmailSignin in the URL
- *       // if (identifier.split("@").length > 2) {
- *       //   throw new Error("Only one email allowed")
- *       // }
- *     },
- *   })
- * ```
- *
- * :::warning
- * Always make sure this returns a single e-mail address, even if multiple ones were passed in.
- * :::
- */
-export default function Email(config: EmailUserConfig): EmailConfig {
-  return {
-    id: "email",
-    type: "email",
-    name: "Email",
-    server: { host: "localhost", port: 25, auth: { user: "", pass: "" } },
-    from: "Auth.js <no-reply@authjs.dev>",
-    maxAge: 24 * 60 * 60,
-    async sendVerificationRequest(params) {
-      const { identifier, url, provider, theme } = params
-      const { host } = new URL(url)
-      const transport = createTransport(provider.server)
-      const result = await transport.sendMail({
-        to: identifier,
-        from: provider.from,
-        subject: `Sign in to ${host}`,
-        text: text({ url, host }),
-        html: html({ url, host, theme }),
-      })
-      const failed = result.rejected.concat(result.pending).filter(Boolean)
-      if (failed.length) {
-        throw new Error(`Email (${failed.join(", ")}) could not be sent`)
-      }
-    },
-    options: config,
-  }
+export interface EmailConfig extends CommonProviderOptions {
+  id: string
+  type: EmailProviderType
+  name: string
+  from: string
+  maxAge: number
+  sendVerificationRequest: (params: {
+    identifier: string
+    url: string
+    expires: Date
+    provider: EmailConfig
+    token: string
+    theme: Theme
+    request: Request
+  }) => Awaitable<void>
+  secret?: string
+  generateVerificationToken?: () => Awaitable<string>
+  normalizeIdentifier?: (identifier: string) => string
+  options: EmailUserConfig
 }
+
+export type EmailUserConfig = Omit<Partial<EmailConfig>, "options" | "type">
 
 /**
  * Email HTML body
@@ -396,7 +57,7 @@ export default function Email(config: EmailUserConfig): EmailConfig {
  *
  * @note We don't add the email address to avoid needing to escape it, if you do, remember to sanitize it!
  */
-function html(params: { url: string; host: string; theme: Theme }) {
+export function html(params: { url: string; host: string; theme: Theme }) {
   const { url, host, theme } = params
 
   const escapedHost = host.replace(/\./g, "&#8203;.")
@@ -449,6 +110,6 @@ function html(params: { url: string; host: string; theme: Theme }) {
 }
 
 /** Email Text body (fallback for email clients that don't render HTML, e.g. feature phones) */
-function text({ url, host }: { url: string; host: string }) {
+export function text({ url, host }: { url: string; host: string }) {
   return `Sign in to ${host}\n${url}\n\n`
 }

--- a/packages/core/src/providers/email.ts
+++ b/packages/core/src/providers/email.ts
@@ -41,7 +41,10 @@ export interface EmailConfig extends CommonProviderOptions {
     theme: Theme
     request: Request
   }) => Awaitable<void>
+  /** Used to hash the verification token. */
   secret?: string
+  /** Used with HTTP-based email providers  */
+  apiKey?: string
   generateVerificationToken?: () => Awaitable<string>
   normalizeIdentifier?: (identifier: string) => string
   options: EmailUserConfig

--- a/packages/core/src/providers/nodemailer.ts
+++ b/packages/core/src/providers/nodemailer.ts
@@ -1,0 +1,78 @@
+import { createTransport } from "nodemailer"
+import { EmailConfig, html, text } from "./email"
+
+import type { Transport, TransportOptions } from "nodemailer"
+import * as JSONTransport from "nodemailer/lib/json-transport/index.js"
+import * as SendmailTransport from "nodemailer/lib/sendmail-transport/index.js"
+import * as SESTransport from "nodemailer/lib/ses-transport/index.js"
+import * as SMTPTransport from "nodemailer/lib/smtp-transport/index.js"
+import * as SMTPPool from "nodemailer/lib/smtp-pool/index.js"
+import * as StreamTransport from "nodemailer/lib/stream-transport/index.js"
+import type { Awaitable, Theme } from "../types"
+
+type AllTransportOptions =
+  | string
+  | SMTPTransport
+  | SMTPTransport.Options
+  | SMTPPool
+  | SMTPPool.Options
+  | SendmailTransport
+  | SendmailTransport.Options
+  | StreamTransport
+  | StreamTransport.Options
+  | JSONTransport
+  | JSONTransport.Options
+  | SESTransport
+  | SESTransport.Options
+  | Transport<any>
+  | TransportOptions
+
+export interface NodemailerConfig
+  extends Omit<EmailConfig, "sendVerificationRequest" | "options"> {
+  server: AllTransportOptions
+  sendVerificationRequest: (params: {
+    identifier: string
+    url: string
+    expires: Date
+    provider: NodemailerConfig
+    token: string
+    theme: Theme
+    request: Request
+  }) => Awaitable<void>
+  options: NodemailerUserConfig
+}
+
+export type NodemailerUserConfig = Omit<
+  Partial<NodemailerConfig>,
+  "options" | "type"
+>
+
+export default function Nodemailer(
+  config: NodemailerUserConfig
+): NodemailerConfig {
+  return {
+    id: "nodemailer",
+    type: "email",
+    name: "Nodemailer",
+    server: { host: "localhost", port: 25, auth: { user: "", pass: "" } },
+    from: "Auth.js <no-reply@authjs.dev>",
+    maxAge: 24 * 60 * 60,
+    async sendVerificationRequest(params) {
+      const { identifier, url, provider, theme } = params
+      const { host } = new URL(url)
+      const transport = createTransport(provider.server)
+      const result = await transport.sendMail({
+        to: identifier,
+        from: provider.from,
+        subject: `Sign in to ${host}`,
+        text: text({ url, host }),
+        html: html({ url, host, theme }),
+      })
+      const failed = result.rejected.concat(result.pending).filter(Boolean)
+      if (failed.length) {
+        throw new Error(`Email (${failed.join(", ")}) could not be sent`)
+      }
+    },
+    options: config,
+  }
+}

--- a/packages/core/src/providers/sendgrid.ts
+++ b/packages/core/src/providers/sendgrid.ts
@@ -1,0 +1,16 @@
+import type { EmailConfig, EmailUserConfig } from "./index.js"
+
+/** @todo Document this */
+export default function Sendgrid(config: EmailUserConfig): EmailConfig {
+  return {
+    id: "sendgrid",
+    type: "email",
+    name: "Sendgrid",
+    from: "Auth.js <no-reply@authjs.dev>",
+    maxAge: 24 * 60 * 60,
+    async sendVerificationRequest(params) {
+      throw new Error("Not yet implemented")
+    },
+    options: config,
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -587,4 +587,5 @@ export interface InternalOptions<TProviderType = ProviderType> {
    */
   isOnRedirectProxy: boolean
   experimental: Record<string, boolean>
+  basePath: string
 }

--- a/packages/frameworks-express/src/index.ts
+++ b/packages/frameworks-express/src/index.ts
@@ -199,13 +199,15 @@ export function setEnvDefaults(config: AuthConfig) {
   config.redirectProxyUrl ??= process.env.AUTH_REDIRECT_PROXY_URL
   config.providers = config.providers.map((p) => {
     const finalProvider = typeof p === "function" ? p({}) : p
+    const ID = finalProvider.id.toUpperCase()
     if (finalProvider.type === "oauth" || finalProvider.type === "oidc") {
-      const ID = finalProvider.id.toUpperCase()
       finalProvider.clientId ??= process.env[`AUTH_${ID}_ID`]
       finalProvider.clientSecret ??= process.env[`AUTH_${ID}_SECRET`]
       if (finalProvider.type === "oidc") {
         finalProvider.issuer ??= process.env[`AUTH_${ID}_ISSUER`]
       }
+    } else if (finalProvider.type === "email") {
+      finalProvider.apiKey ??= process.env[`AUTH_${ID}_KEY`]
     }
     return finalProvider
   })

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -339,13 +339,15 @@ export function setEnvDefaults(envObject: any, config: SvelteKitAuthConfig) {
   )
   config.providers = config.providers.map((p) => {
     const finalProvider = typeof p === "function" ? p({}) : p
+    const ID = finalProvider.id.toUpperCase()
     if (finalProvider.type === "oauth" || finalProvider.type === "oidc") {
-      const ID = finalProvider.id.toUpperCase()
       finalProvider.clientId ??= envObject[`AUTH_${ID}_ID`]
       finalProvider.clientSecret ??= envObject[`AUTH_${ID}_SECRET`]
       if (finalProvider.type === "oidc") {
         finalProvider.issuer ??= envObject[`AUTH_${ID}_ISSUER`]
       }
+    } else if (finalProvider.type === "email") {
+      finalProvider.apiKey ??= envObject[`AUTH_${ID}_KEY`]
     }
     return finalProvider
   })

--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -22,13 +22,15 @@ export function setEnvDefaults(config: NextAuthConfig) {
   config.redirectProxyUrl ??= process.env.AUTH_REDIRECT_PROXY_URL
   config.providers = config.providers.map((p) => {
     const finalProvider = typeof p === "function" ? p({}) : p
+    const ID = finalProvider.id.toUpperCase()
     if (finalProvider.type === "oauth" || finalProvider.type === "oidc") {
-      const ID = finalProvider.id.toUpperCase()
       finalProvider.clientId ??= process.env[`AUTH_${ID}_ID`]
       finalProvider.clientSecret ??= process.env[`AUTH_${ID}_SECRET`]
       if (finalProvider.type === "oidc") {
         finalProvider.issuer ??= process.env[`AUTH_${ID}_ISSUER`]
       }
+    } else if (finalProvider.type === "email") {
+      finalProvider.apiKey ??= process.env[`AUTH_${ID}_KEY`]
     }
     return finalProvider
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  mailparser: 3.6.6
+
 patchedDependencies:
   '@balazsorban/monorepo-release@0.3.1':
     hash: jwqbwknpdjbuidjz24xxlo7tdm
@@ -7569,6 +7572,13 @@ packages:
     dev: true
     optional: true
 
+  /@selderee/plugin-htmlparser2@0.11.0:
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
+    dev: true
+
   /@shelf/jest-dynamodb@3.4.4:
     resolution: {integrity: sha512-Ge0kqEtLftFVFB40eUnjv9W3UrxxPQNdP1GpALkp/59TRKFIcwAGVZgzVXUlaZJsL1ANcwJVYlRVuJuIQbbDJQ==}
     engines: {node: '>=16'}
@@ -13006,13 +13016,6 @@ packages:
       utila: 0.4.0
     dev: true
 
-  /dom-serializer@0.2.2:
-    resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
-    dependencies:
-      domelementtype: 2.3.0
-      entities: 2.2.0
-    dev: true
-
   /dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
     dependencies:
@@ -13029,18 +13032,8 @@ packages:
       entities: 4.5.0
     dev: true
 
-  /domelementtype@1.3.1:
-    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
-    dev: true
-
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-    dev: true
-
-  /domhandler@2.4.2:
-    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
-    dependencies:
-      domelementtype: 1.3.1
     dev: true
 
   /domhandler@4.3.1:
@@ -13059,13 +13052,6 @@ packages:
 
   /dompurify@3.0.8:
     resolution: {integrity: sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ==}
-
-  /domutils@1.7.0:
-    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
-    dependencies:
-      dom-serializer: 0.2.2
-      domelementtype: 1.3.1
-    dev: true
 
   /domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -13359,8 +13345,9 @@ packages:
       level-errors: 2.0.1
     dev: true
 
-  /encoding-japanese@1.0.30:
-    resolution: {integrity: sha512-bd/DFLAoJetvv7ar/KIpE3CNO8wEuyrt9Xuw6nSMiZ+Vrz/Q21BPsMHvARL2Wz6IKHKXgb+DWZqtRg1vql9cBg==}
+  /encoding-japanese@2.0.0:
+    resolution: {integrity: sha512-++P0RhebUC8MJAwJOsT93dT+5oc5oPImp1HubZpAuCZ5kTLnhuuBhKHj2jJeO/Gj93idPBWmIuQ9QWMe5rX3pQ==}
+    engines: {node: '>=8.10.0'}
     dev: true
 
   /encoding@0.1.13:
@@ -13395,10 +13382,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /entities@1.1.2:
-    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
-    dev: true
 
   /entities@2.1.0:
     resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
@@ -14502,7 +14485,7 @@ packages:
       express: 4.18.2
       express-basic-auth: 1.2.1
       lodash: 4.17.21
-      mailparser: 2.8.1
+      mailparser: 3.6.6
       moment: 2.30.1
       smtp-server: 3.13.0
     transitivePeerDependencies:
@@ -16169,15 +16152,15 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /html-to-text@5.1.1:
-    resolution: {integrity: sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==}
-    engines: {node: '>= 4.0.0'}
-    hasBin: true
+  /html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
     dependencies:
-      he: 1.2.0
-      htmlparser2: 3.10.1
-      lodash: 4.17.21
-      minimist: 1.2.8
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
     dev: true
 
   /html-void-elements@3.0.0:
@@ -16202,17 +16185,6 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.89.0
-    dev: true
-
-  /htmlparser2@3.10.1:
-    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
-    dependencies:
-      domelementtype: 1.3.1
-      domhandler: 2.4.2
-      domutils: 1.7.0
-      entities: 1.1.2
-      inherits: 2.0.4
-      readable-stream: 3.6.2
     dev: true
 
   /htmlparser2@6.1.0:
@@ -16401,20 +16373,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-
-  /iconv-lite@0.5.0:
-    resolution: {integrity: sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: true
-
-  /iconv-lite@0.6.2:
-    resolution: {integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: true
 
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -18140,6 +18098,10 @@ packages:
       readable-stream: 2.3.8
     dev: true
 
+  /leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
+    dev: true
+
   /level-codec@9.0.2:
     resolution: {integrity: sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==}
     engines: {node: '>=6'}
@@ -18254,26 +18216,26 @@ packages:
     resolution: {integrity: sha512-l+nePcPbIG1fNlqMzrh68MLkX/gTxk/+vdvAb388Ssi7UuUN31MI44w4Yf33mM3Cm4xDfw48mdf3rkdHszLNew==}
     dev: true
 
-  /libmime@4.2.1:
-    resolution: {integrity: sha512-09y7zjSc5im1aNsq815zgo4/G3DnIzym3aDOHsGq4Ee5vrX4PdgQRybAsztz9Rv0NhO+J5C0llEUloa3sUmjmA==}
+  /libmime@5.2.0:
+    resolution: {integrity: sha512-X2U5Wx0YmK0rXFbk67ASMeqYIkZ6E5vY7pNWRKtnNzqjvdYYG8xtPDpCnuUEnPU9vlgNev+JoSrcaKSUaNvfsw==}
     dependencies:
-      encoding-japanese: 1.0.30
-      iconv-lite: 0.5.0
+      encoding-japanese: 2.0.0
+      iconv-lite: 0.6.3
       libbase64: 1.2.1
-      libqp: 1.1.0
+      libqp: 2.0.1
     dev: true
 
-  /libmime@5.0.0:
-    resolution: {integrity: sha512-2Bm96d5ktnE217Ib1FldvUaPAaOst6GtZrsxJCwnJgi9lnsoAKIHyU0sae8rNx6DNYbjdqqh8lv5/b9poD8qOg==}
+  /libmime@5.2.1:
+    resolution: {integrity: sha512-A0z9O4+5q+ZTj7QwNe/Juy1KARNb4WaviO4mYeFC4b8dBT2EEqK2pkM+GC8MVnkOjqhl5nYQxRgnPYRRTNmuSQ==}
     dependencies:
-      encoding-japanese: 1.0.30
-      iconv-lite: 0.6.2
+      encoding-japanese: 2.0.0
+      iconv-lite: 0.6.3
       libbase64: 1.2.1
-      libqp: 1.1.0
+      libqp: 2.0.1
     dev: true
 
-  /libqp@1.1.0:
-    resolution: {integrity: sha512-4Rgfa0hZpG++t1Vi2IiqXG9Ad1ig4QTmtuZF946QJP4bPqOYC78ixUXgz5TW/wE7lNaNKlplSYTxQ+fR2KZ0EA==}
+  /libqp@2.0.1:
+    resolution: {integrity: sha512-Ka0eC5LkF3IPNQHJmYBWljJsw0UvM6j+QdKRbWyCdTmYwvIDE6a7bCm0UkTAL/K+3KXK5qXT/ClcInU01OpdLg==}
     dev: true
 
   /libsodium-wrappers@0.7.13:
@@ -18316,17 +18278,17 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
-  /linkify-it@3.0.2:
-    resolution: {integrity: sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==}
-    dependencies:
-      uc.micro: 1.0.6
-    dev: true
-
   /linkify-it@3.0.3:
     resolution: {integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==}
     requiresBuild: true
     dependencies:
       uc.micro: 1.0.6
+    dev: true
+
+  /linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+    dependencies:
+      uc.micro: 2.0.0
     dev: true
 
   /listhen@1.5.6:
@@ -18671,26 +18633,26 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /mailparser@2.8.1:
-    resolution: {integrity: sha512-H/CYAO9dsw6SFNbEGGpZsejVSWDcFlyHjb1OkHUWg0wggUekva1tNc28trB155nSqM8rhtbwTKt//orX0AmJxQ==}
+  /mailparser@3.6.6:
+    resolution: {integrity: sha512-noCjBl3FToxmqTP2fp7z17hQsiCroWNntfTd8O+UejOAF59xeN5WGZK27ilexXV2e2X/cbUhG3L8sfEKaz0/sw==}
     dependencies:
-      encoding-japanese: 1.0.30
+      encoding-japanese: 2.0.0
       he: 1.2.0
-      html-to-text: 5.1.1
-      iconv-lite: 0.6.2
-      libmime: 5.0.0
-      linkify-it: 3.0.2
-      mailsplit: 5.0.0
-      nodemailer: 6.4.11
-      tlds: 1.208.0
+      html-to-text: 9.0.5
+      iconv-lite: 0.6.3
+      libmime: 5.2.1
+      linkify-it: 5.0.0
+      mailsplit: 5.4.0
+      nodemailer: 6.9.8
+      tlds: 1.248.0
     dev: true
 
-  /mailsplit@5.0.0:
-    resolution: {integrity: sha512-HeXA0eyCKBtZqbr7uoeb3Nn2L7VV8Vm27x6/YBb0ZiNzRzLoNS2PqRgGYADwh0cBzLYtqddq40bSSirqLO2LGw==}
+  /mailsplit@5.4.0:
+    resolution: {integrity: sha512-wnYxX5D5qymGIPYLwnp6h8n1+6P6vz/MJn5AzGjZ8pwICWssL+CCQjWBIToOVHASmATot4ktvlLo6CyLfOXWYA==}
     dependencies:
       libbase64: 1.2.1
-      libmime: 4.2.1
-      libqp: 1.1.0
+      libmime: 5.2.0
+      libqp: 2.0.1
     dev: true
 
   /make-dir@3.1.0:
@@ -20724,12 +20686,6 @@ packages:
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
 
-  /nodemailer@6.4.11:
-    resolution: {integrity: sha512-BVZBDi+aJV4O38rxsUh164Dk1NCqgh6Cm0rQSb9SK/DHGll/DrCMnycVDD7msJgZCnmVa8ASo8EZzR7jsgTukQ==}
-    engines: {node: '>=6.0.0'}
-    requiresBuild: true
-    dev: true
-
   /nodemailer@6.9.4:
     resolution: {integrity: sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==}
     engines: {node: '>=6.0.0'}
@@ -21322,6 +21278,13 @@ packages:
     dependencies:
       entities: 4.5.0
 
+  /parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+    dev: true
+
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -21426,6 +21389,10 @@ packages:
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
+  /peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
     dev: true
 
   /pend@1.2.0:
@@ -24026,6 +23993,12 @@ packages:
       kind-of: 6.0.3
     dev: true
 
+  /selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+    dependencies:
+      parseley: 0.12.1
+    dev: true
+
   /select-hose@2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
     dev: true
@@ -25788,8 +25761,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /tlds@1.208.0:
-    resolution: {integrity: sha512-6kbY7GJpRQXwBddSOAbVUZXjObbCGFXliWWN+kOSEoRWIOyRWLB6zdeKC/Tguwwenl/KsUx016XR50EdHYsxZw==}
+  /tlds@1.248.0:
+    resolution: {integrity: sha512-noj0KdpWTBhwsKxMOXk0rN9otg4kTgLm4WohERRHbJ9IY+kSDKr3RmjitaQ3JFzny+DyvBOQKlFZhp0G0qNSfg==}
     hasBin: true
     dev: true
 
@@ -26337,6 +26310,10 @@ packages:
 
   /uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
+    dev: true
+
+  /uc.micro@2.0.0:
+    resolution: {integrity: sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==}
     dev: true
 
   /ufo@1.3.2:


### PR DESCRIPTION
**NOTE**: This PR does not introduce breaking changes.

In this PR:

- Move the currently default Email provider to `@auth/core/providers/nodemailer`
- re-export it from `@auth/core/providers/email` and mark it deprecated, to nudge people to move to the new import
- Introduce built-in Resend and SendGrid providers (More is planned)

Example usage:

```diff
import NextAuth from "next-auth"
+ import Resend from "next-auth/providers/resend

export const {} = NextAuth({
  providers: [
+    Resend // Relies on `AUTH_RESEND_KEY` from .env.local
  ]
})
```

- fixed some types (fixes #8871, #8601, fixes #8125)