### PR TITLE
fix(ts): show `user` and `token` in `session` callback

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -254,7 +254,7 @@ export interface CallbacksOptions<P = Profile, A = Account> {
           /** Available when {@link AuthConfig.session} is set to `strategy: "database"`. */
           user: AdapterUser
         }
-      | {
+      & {
           session: Session
           /** Available when {@link AuthConfig.session} is set to `strategy: "jwt"` */
           token: JWT


### PR DESCRIPTION

## ☕️ Reasoning

In session callback, argument type does not contain user and token
> ### **Before code updation 👇**
<img width="370" alt="Screenshot 2024-01-24 at 8 34 52 PM" src="https://github.com/nextauthjs/next-auth/assets/53529358/3bfd8cb7-d8e7-44e5-8ef2-702e0bdcb973">


> **TypeError:** Property 'token' does not exist on type '({ session: Session; user: AdapterUser; } | { session: Session; token: JWT; }) & { newSession: any; trigger?: "update" | undefined; }'

**Type Intersection:** The original code incorrectly used a union type (`|`), potentially leading to type mismatches. The updated code employs an intersection type (`&`) to guarantee that both `user` and `token` properties are always available within the session callback, regardless of the authentication strategy.

> ### **After code updation 👇**
<img width="646" alt="Screenshot 2024-01-24 at 8 53 38 PM" src="https://github.com/nextauthjs/next-auth/assets/53529358/e1ab8b6a-b8d9-48a2-a907-0a5a740c81d3">

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
Fixed: #9633 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
