### PR TITLE
feat: don't override basePath if it's already been set

### DIFF
--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -6,7 +6,7 @@ export function setEnvDefaults(config: NextAuthConfig) {
   config.secret ??= process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET
   try {
     const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL
-    if (url) config.basePath = new URL(url).pathname
+    if (url && !config.basePath) config.basePath = new URL(url).pathname
   } catch {
   } finally {
     config.basePath ??= "/api/auth"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- While testing https://github.com/nextauthjs/next-auth/pull/8808/ I kept getting errors in `core/lib/utils/web.ts` - `parseActionAndProviderId()` that it couldn't "parse the action at `/session`". The last part of that error msg is the pathname and should be `/auth/session` there :thinking: 
- If yall can confirm this behaviour, we should fix it in the other client libs, I think the `getEnvDefaults` fn is more or less the same there


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
