### PR TITLE
Remove `notNull()` constraint from `email` in drizzle

### DIFF
--- a/packages/adapter-drizzle/src/index.ts
+++ b/packages/adapter-drizzle/src/index.ts
@@ -46,7 +46,7 @@ import type { Adapter } from "@auth/core/adapters"
  *   ],
  * })
  * ```
- * 
+ *
  * :::info
  * If you're using multi-project schemas, you can pass your table function as a second argument
  * :::
@@ -75,7 +75,7 @@ import type { Adapter } from "@auth/core/adapters"
  * export const users = pgTable("user", {
  *  id: text("id").notNull().primaryKey(),
  *  name: text("name"),
- *  email: text("email").notNull(),
+ *  email: text("email"),
  *  emailVerified: timestamp("emailVerified", { mode: "date" }),
  *  image: text("image"),
  * })
@@ -138,7 +138,7 @@ import type { Adapter } from "@auth/core/adapters"
  * export const users = mysqlTable("user", {
  *  id: varchar("id", { length: 255 }).notNull().primaryKey(),
  *  name: varchar("name", { length: 255 }),
- *  email: varchar("email", { length: 255 }).notNull(),
+ *  email: varchar("email", { length: 255 }),
  *   emailVerified: timestamp("emailVerified", { mode: "date", fsp: 3 }).defaultNow(),
  *  image: varchar("image", { length: 255 }),
  * })
@@ -197,7 +197,7 @@ import type { Adapter } from "@auth/core/adapters"
  * export const users = sqliteTable("user", {
  *  id: text("id").notNull().primaryKey(),
  *  name: text("name"),
- *  email: text("email").notNull(),
+ *  email: text("email"),
  *  emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),
  *  image: text("image"),
  * })

--- a/packages/adapter-drizzle/src/lib/mysql.ts
+++ b/packages/adapter-drizzle/src/lib/mysql.ts
@@ -15,7 +15,7 @@ export function createTables(mySqlTable: MySqlTableFn) {
   const users = mySqlTable("user", {
     id: varchar("id", { length: 255 }).notNull().primaryKey(),
     name: varchar("name", { length: 255 }),
-    email: varchar("email", { length: 255 }).notNull(),
+    email: varchar("email", { length: 255 }),
     emailVerified: timestamp("emailVerified", {
       mode: "date",
       fsp: 3,

--- a/packages/adapter-drizzle/src/lib/pg.ts
+++ b/packages/adapter-drizzle/src/lib/pg.ts
@@ -16,7 +16,7 @@ export function createTables(pgTable: PgTableFn) {
   const users = pgTable("user", {
     id: text("id").notNull().primaryKey(),
     name: text("name"),
-    email: text("email").notNull(),
+    email: text("email"),
     emailVerified: timestamp("emailVerified", { mode: "date" }),
     image: text("image"),
   })

--- a/packages/adapter-drizzle/src/lib/sqlite.ts
+++ b/packages/adapter-drizzle/src/lib/sqlite.ts
@@ -15,7 +15,7 @@ export function createTables(sqliteTable: SQLiteTableFn) {
   const users = sqliteTable("user", {
     id: text("id").notNull().primaryKey(),
     name: text("name"),
-    email: text("email").notNull(),
+    email: text("email"),
     emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),
     image: text("image"),
   })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Based on the docs, it is possible for email to be null: https://authjs.dev/reference/core/providers/discord#email

Additionally it is null in other adapters: https://authjs.dev/reference/adapter/prisma

This would not be a breaking change as it's dropping a constraint, not adding one. Although I believe we should also:
1. Make email `unique()`
2. Allow renaming of tables and columns like we do with other adapters
^ But we should do these in another PR

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Related to https://github.com/nextauthjs/next-auth/issues/8629 but doesn't fix the primary concern of that

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
