### PR TITLE
refactor: update JWT enc

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Auth.js can be used with or without a database.
 - Designed to be secure by default and encourage best practices for safeguarding user data
 - Uses Cross-Site Request Forgery (CSRF) Tokens on POST routes (sign in, sign out)
 - Default cookie policy aims for the most restrictive policy appropriate for each cookie
-- When JSON Web Tokens are used, they are encrypted by default (JWE) with A256GCM
+- When JSON Web Tokens are used, they are encrypted by default (JWE) with A256CBC-HS512
 - Features tab/window syncing and session polling to support short-lived sessions
 - Attempts to implement the latest guidance published by [Open Web Application Security Project](https://owasp.org)
 

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -6,7 +6,7 @@
  * issued and used by Auth.js.
  *
  * The JWT issued by Auth.js is _encrypted by default_, using the _A256CBC-HS512_ algorithm ({@link https://www.rfc-editor.org/rfc/rfc7518.html#section-5.2.5 JWE}).
- * It uses the `AUTH_SECRET` environment variable to derive a sufficient encryption key.
+ * It uses the `AUTH_SECRET` environment variable or the passed `secret` propery to derive a suitable encryption key.
  *
  * :::info Note
  * Auth.js JWTs are meant to be used by the same app that issued them.

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -5,7 +5,7 @@
  * to encode and decode {@link https://authjs.dev/concepts/session-strategies#jwt JWT}s
  * issued and used by Auth.js.
  *
- * The JWT issued by Auth.js is _encrypted by default_, using the _ A256CBC-HS512_ algorithm ({@link https://www.rfc-editor.org/rfc/rfc7518.html#section-5.2.5 JWE}).
+ * The JWT issued by Auth.js is _encrypted by default_, using the _A256CBC-HS512_ algorithm ({@link https://www.rfc-editor.org/rfc/rfc7518.html#section-5.2.5 JWE}).
  * It uses the `AUTH_SECRET` environment variable to derive a sufficient encryption key.
  *
  * :::info Note

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -5,7 +5,7 @@
  * to encode and decode {@link https://authjs.dev/concepts/session-strategies#jwt JWT}s
  * issued and used by Auth.js.
  *
- * The JWT issued by Auth.js is _encrypted by default_, using the _A256GCM_ algorithm ({@link https://www.rfc-editor.org/rfc/rfc7516 JWE}).
+ * The JWT issued by Auth.js is _encrypted by default_, using the _ A256CBC-HS512_ algorithm ({@link https://www.rfc-editor.org/rfc/rfc7518.html#section-5.2.5 JWE}).
  * It uses the `AUTH_SECRET` environment variable to derive a sufficient encryption key.
  *
  * :::info Note


### PR DESCRIPTION
This PR updates the JWT Content Encryption Algorithm from A256GCM to A256CBC-HS512, the algorithm will be used for all new issued JWTs. During verification both are allowed to allow for a seamless transition (in due time A256GCM may be completely removed).

The reason for this is that given the used secret is static it is safer to use an algorithm with larger initialization vector (GCM uses 96 bits, CBC uses 128) to limit the possibility of iv-reuse.