### PR TITLE
fix: always use a generated `id` for `User.id`

### DIFF
--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -197,7 +197,7 @@ async function getUserAndAccount(
     const userFromProfile = await provider.profile(OAuthProfile, tokens)
     const user = {
       ...userFromProfile,
-      id: userFromProfile.id?.toString() ?? crypto.randomUUID(),
+      id: crypto.randomUUID(),
       email: userFromProfile.email?.toLowerCase(),
     } satisfies User
 

--- a/packages/core/src/lib/utils/providers.ts
+++ b/packages/core/src/lib/utils/providers.ts
@@ -1,4 +1,3 @@
-import { OAuthProfileParseError } from "../../errors.js"
 import { merge } from "./merge.js"
 
 import type {
@@ -87,15 +86,14 @@ function normalizeOAuth(
 
 /**
  * Returns basic user profile from the userinfo response/`id_token` claims.
+ * An `id` is generated internally (using `crypto.randomUUID()`) and will override `id` if provided.
+ * The result if this function is user to create the `User` in the database.
  * @see https://authjs.dev/reference/core/adapters#user
  * @see https://openid.net/specs/openid-connect-core-1_0.html#IDToken
- * @see https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#
  */
 const defaultProfile: ProfileCallback<Profile> = (profile) => {
-  const id = profile.sub ?? profile.id
-  if (!id) throw new OAuthProfileParseError("Missing user id")
   return stripUndefined({
-    id: id.toString(),
     name: profile.name ?? profile.nickname ?? profile.preferred_username,
     email: profile.email,
     image: profile.picture,


### PR DESCRIPTION
Fixes #9699

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
