### PR TITLE
fix: correctly create `NextRequest` instance instead of `Request`

### DIFF
--- a/packages/next-auth/src/index.tsx
+++ b/packages/next-auth/src/index.tsx
@@ -68,7 +68,7 @@
  */
 
 import { Auth } from "@auth/core"
-import { reqWithEnvUrl, setEnvDefaults } from "./lib/env.js"
+import { reqWithEnvURL, setEnvDefaults } from "./lib/env.js"
 import { initAuth } from "./lib/index.js"
 import { signIn, signOut, update } from "./lib/actions.js"
 
@@ -366,7 +366,7 @@ export default function NextAuth(
     const httpHandler = (req: NextRequest) => {
       const _config = config(req)
       setEnvDefaults(_config)
-      return Auth(reqWithEnvUrl(req), _config)
+      return Auth(reqWithEnvURL(req), _config)
     }
 
     return {
@@ -392,7 +392,7 @@ export default function NextAuth(
     }
   }
   setEnvDefaults(config)
-  const httpHandler = (req: NextRequest) => Auth(reqWithEnvUrl(req), config)
+  const httpHandler = (req: NextRequest) => Auth(reqWithEnvURL(req), config)
   return {
     handlers: { GET: httpHandler, POST: httpHandler } as const,
     // @ts-expect-error

--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -37,15 +37,10 @@ export function setEnvDefaults(config: NextAuthConfig) {
 }
 
 /** If `NEXTAUTH_URL` or `AUTH_URL` is defined, override the request's URL. */
-export function reqWithEnvUrl(req: NextRequest): NextRequest {
+export function reqWithEnvURL(req: NextRequest): NextRequest {
   const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL
   if (!url) return req
-  const base = new URL(url).origin
-  // REVIEW: Bug in Next.js?: TypeError: next_dist_server_web_exports_next_request__WEBPACK_IMPORTED_MODULE_0__ is not a constructor
-  // return new NextRequest(new URL(nonBase, base), req)
-  const _url = req.nextUrl.clone()
-  _url.href = req.nextUrl.href.replace(req.nextUrl.origin, base)
-  const _req = new Request(_url, req) as any
-  _req.nextUrl = _url
-  return _req
+  const { origin: envOrigin } = new URL(url)
+  const { href, origin } = req.nextUrl
+  return new NextRequest(href.replace(origin, envOrigin), req)
 }

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -1,7 +1,7 @@
 import { Auth, type AuthConfig } from "@auth/core"
 import { headers } from "next/headers"
 import { NextResponse } from "next/server"
-import { reqWithEnvUrl } from "./env.js"
+import { reqWithEnvURL } from "./env.js"
 import { createActionURL } from "./actions.js"
 
 import type { AuthAction, Awaitable, Session } from "@auth/core/types"
@@ -219,7 +219,7 @@ async function handleAuth(
   config: NextAuthConfig,
   userMiddlewareOrRoute?: NextAuthMiddleware | AppRouteHandlerFn
 ) {
-  const request = reqWithEnvUrl(args[0])
+  const request = reqWithEnvURL(args[0])
   const sessionResponse = await getSession(request.headers, config)
   const auth = await sessionResponse.json()
 


### PR DESCRIPTION
Fixes #9045

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
