### PR TITLE
fix: delegate user id generation to Prisma

### DIFF
--- a/packages/adapter-mongodb/tests/test.sh
+++ b/packages/adapter-mongodb/tests/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME=next-auth-mongodb-test
+CONTAINER_NAME=authjs-mongodb-test
 
 JEST_WATCH=false
 

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -220,7 +220,10 @@ import type { Adapter, AdapterAccount } from "@auth/core/adapters"
  **/
 export function PrismaAdapter(p: PrismaClient): Adapter {
   return {
-    createUser: (data) => p.user.create({ data }),
+    // We need to let Prisma generate the ID because our default UUID is incompatible with MongoDB
+    createUser: ({ id: _id, ...data }) => {
+      return p.user.create({ data })
+    },
     getUser: (id) => p.user.findUnique({ where: { id } }),
     getUserByEmail: (email) => p.user.findUnique({ where: { email } }),
     async getUserByAccount(provider_providerAccountId) {

--- a/packages/adapter-prisma/tests/index.test.ts
+++ b/packages/adapter-prisma/tests/index.test.ts
@@ -8,10 +8,8 @@ runBasicTests({
   adapter: PrismaAdapter(prisma),
   db: {
     id() {
-      if (process.env.CONTAINER_NAME === "next-auth-mongodb-test") {
-        return new ObjectId().toHexString()
-      }
-      return randomUUID()
+      if (process.env.CONTAINER_NAME !== "authjs-mongodb-test") return
+      return new ObjectId().toHexString()
     },
     connect: async () => {
       await Promise.all([

--- a/packages/adapter-prisma/tests/mongodb.test.sh
+++ b/packages/adapter-prisma/tests/mongodb.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME=next-auth-mongodb-test
+CONTAINER_NAME=authjs-mongodb-test
 
 JEST_WATCH=false
 

--- a/packages/utils/adapter/index.ts
+++ b/packages/utils/adapter/index.ts
@@ -24,7 +24,7 @@ export interface TestOptions {
   }
   db: {
     /** Generates UUID v4 by default. Use it to override how the test suite should generate IDs, like user id. */
-    id?: () => string
+    id?: () => string | undefined
     /**
      * Manually disconnect database after all tests have been run,
      * if your adapter doesn't do it automatically
@@ -59,7 +59,7 @@ const testIf = (condition: boolean) => (condition ? test : test.skip)
  * You can add additional tests below, if you wish.
  */
 export async function runBasicTests(options: TestOptions) {
-  const id = options.db.id ?? randomUUID
+  const id = () => options.db.id?.() ?? randomUUID()
   // Init
   beforeAll(async () => {
     await options.db.connect?.()
@@ -75,7 +75,7 @@ export async function runBasicTests(options: TestOptions) {
   })
 
   let user = options.fixtures?.user ?? {
-    id: id(),
+    id: randomUUID(),
     email: "fill@murray.com",
     image: "https://www.fillmurray.com/460/300",
     name: "Fill Murray",


### PR DESCRIPTION
## ☕️ Reasoning

Our default user id generation clashes with MongoDB id's in the Prisma Adapter.

Ideally, the PrismaClient could just suppress this by generating it's own ID if the provided one is malformed. But we drop the id from being passed to PrismaClient instead.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues


Fixes #9685. Ref #9380

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
