### PR TITLE
chore: add custom error messages

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -68,7 +68,7 @@ export class AuthError extends Error {
 
     Error.captureStackTrace?.(this, this.constructor)
     const url = `https://errors.authjs.dev#${this.type.toLowerCase()}`
-    this.message += `${this.message ? " ." : ""}Read more at ${url}`
+    this.message += `${this.message ? "" : this.type}`
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,9 +167,10 @@ export async function Auth(
       return Response.json(null, { status: 400 })
 
     const type = isAuthError ? error.type : "Configuration"
+    const message = isAuthError ? error.message : type
     const page = (isAuthError && error.kind) || "error"
     // TODO: Filter out some error types from being sent to the client
-    const params = new URLSearchParams({ error: type })
+    const params = new URLSearchParams({ error: message })
     const path =
       config.pages?.[page] ?? `${config.basePath}/${page.toLowerCase()}`
 

--- a/packages/core/src/lib/utils/logger.ts
+++ b/packages/core/src/lib/utils/logger.ts
@@ -21,7 +21,9 @@ const reset = "\x1b[0m"
 export const logger: LoggerInstance = {
   error(error) {
     const name = error instanceof AuthError ? error.type : error.name
-    console.error(`${red}[auth][error]${reset} ${name}: ${error.message}`)
+    console.error(
+      `${red}[auth][error]${reset} ${name}: ${error.message} Read more at https://errors.authjs.dev#${name}`
+    )
     if (
       error.cause &&
       typeof error.cause === "object" &&


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

NextAuth (Auth.JS) is missing behavior from v4 that enables users to pass custom error messages to display to the client. People have expressed similar concerns trying to return custom auth errors in v5 and this PR aims to fix those concerns. It's a necessary feature to most that was lost in v5.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

See #8999, #9249.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
