### PR TITLE
fix: bump z-index of clerk's homepage sponsorship

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -126,9 +126,6 @@
   justify-content: center;
   gap: 0.5rem;
   font-size: 1.2rem;
-
-  a {
-    position: relative;
-    z-index: 1000;
-  }
+  position: relative;
+  z-index: 1000;
 }


### PR DESCRIPTION
This PR fix bumps the z-index of the Clerk CTA on the homepage hero. Before, the animated background marquee blocked link clicks in certain viewports.