### PR TITLE
fix: allow string return `signIn` callback

### DIFF
--- a/packages/core/src/lib/actions/callback/index.ts
+++ b/packages/core/src/lib/actions/callback/index.ts
@@ -390,5 +390,6 @@ async function handleAuthorized(
     throw new AuthorizedCallbackError(e as Error)
   }
   if (!authorized) throw new AuthorizedCallbackError("AccessDenied")
-  if (typeof authorized === "string") return await redirect({ url: authorized, baseUrl: config.url.origin })
+  if (typeof authorized !== "string") return
+  return await redirect({ url: authorized, baseUrl: config.url.origin })
 }

--- a/packages/core/src/lib/actions/callback/index.ts
+++ b/packages/core/src/lib/actions/callback/index.ts
@@ -390,6 +390,5 @@ async function handleAuthorized(
     throw new AuthorizedCallbackError(e as Error)
   }
   if (!authorized) throw new AuthorizedCallbackError("AccessDenied")
-  if (typeof authorized !== "string") return
-  return await redirect({ url: authorized, baseUrl: config.url.origin })
+  if (typeof authorized === "string") return await redirect({ url: authorized, baseUrl: config.url.origin })
 }

--- a/packages/core/src/lib/actions/signin/index.ts
+++ b/packages/core/src/lib/actions/signin/index.ts
@@ -28,7 +28,8 @@ export async function signIn(
       return { redirect, cookies }
     }
     case "email": {
-      return await sendToken(request, options)
+      const response = await sendToken(request, options)
+      return { ...response, cookies }
     }
     default:
       return { redirect: signInUrl, cookies }

--- a/packages/core/src/lib/actions/signin/index.ts
+++ b/packages/core/src/lib/actions/signin/index.ts
@@ -13,7 +13,7 @@ export async function signIn(
   cookies: Cookie[],
   options: InternalOptions
 ): Promise<ResponseInternal> {
-  const signInUrl = `${options.url}/signin`
+  const signInUrl = `${options.url.origin}${options.basePath}/signin`
 
   if (!options.provider) return { redirect: signInUrl, cookies }
 

--- a/packages/core/src/lib/actions/signin/send-token.ts
+++ b/packages/core/src/lib/actions/signin/send-token.ts
@@ -14,7 +14,7 @@ export async function sendToken(
   options: InternalOptions<"email">
 ) {
   const { body } = request
-  const { provider, url, callbacks, adapter } = options
+  const { provider, callbacks, adapter } = options
   const normalizer = provider.normalizeIdentifier ?? defaultNormalizer
   const email = normalizer(body?.email)
 
@@ -39,6 +39,14 @@ export async function sendToken(
     throw new AuthorizedCallbackError(e as Error)
   }
   if (!authorized) throw new AuthorizedCallbackError("AccessDenied")
+  if (typeof authorized === "string") {
+    return {
+      redirect: await callbacks.redirect({
+        url: authorized,
+        baseUrl: options.url.origin,
+      }),
+    }
+  }
 
   const { callbackUrl, theme } = options
   const token =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -184,8 +184,9 @@ export interface Profile {
 export interface CallbacksOptions<P = Profile, A = Account> {
   /**
    * Controls whether a user is allowed to sign in or not.
-   * Returning `true` continues the sign-in flow, while
-   * returning `false` throws an `AuthorizedCallbackError` with the message `"AccessDenied"`.
+   * Returning `true` continues the sign-in flow.
+   * Returning `false` or throwing an error will stop the sign-in flow and redirect the user to the error page.
+   * Returning a string will redirect the user to the specified URL.
    *
    * Unhandled errors will throw an `AuthorizedCallbackError` with the message set to the original error.
    *
@@ -221,7 +222,7 @@ export interface CallbacksOptions<P = Profile, A = Account> {
     }
     /** If Credentials provider is used, it contains the user credentials */
     credentials?: Record<string, CredentialInput>
-  }) => Awaitable<boolean>
+  }) => Awaitable<boolean | string>
   /**
    * This callback is called anytime the user is redirected to a callback URL (e.g. on signin or signout).
    * By default only URLs on the same URL as the site are allowed,

--- a/packages/core/test/authorize.test.ts
+++ b/packages/core/test/authorize.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { Auth, AuthConfig, skipCSRFCheck } from "../src"
+import { Adapter } from "../src/adapters"
+import SendGrid from "../src/providers/sendgrid"
+
+const mockAdapter: Adapter = {
+  createVerificationToken: vi.fn(),
+  useVerificationToken: vi.fn(),
+  getUserByEmail: vi.fn(),
+}
+const logger = { error: vi.fn() }
+
+async function signIn(config: Partial<AuthConfig> = {}) {
+  return (await Auth(
+    new Request("http://a/auth/signin/sendgrid", {
+      method: "POST",
+      body: new URLSearchParams({ email: "a@b.c" }),
+    }),
+    {
+      secret: "secret",
+      trustHost: true,
+      logger,
+      adapter: mockAdapter,
+      skipCSRFCheck,
+      providers: [SendGrid],
+      ...config,
+    }
+  )) as Response
+}
+
+describe("auth via callbacks.signIn", () => {
+  beforeEach(() => {
+    logger.error.mockReset()
+  })
+  describe("redirect before sending an email", () => {
+    it("return false", async () => {
+      const res = await signIn({ callbacks: { signIn: () => false } })
+      expect(res.headers.get("Location")).toBe(
+        "http://a/auth/error?error=AuthorizedCallbackError"
+      )
+    })
+    it("return redirect relative URL", async () => {
+      const res = await signIn({ callbacks: { signIn: () => "/wrong" } })
+      expect(res.headers.get("Location")).toBe("http://a/wrong")
+    })
+
+    it("return redirect absolute URL, different domain", async () => {
+      const res = await signIn({ callbacks: { signIn: () => "/wrong" } })
+      const redirect = res.headers.get("Location")
+      // Not allowed by our default redirect callback
+      expect(redirect).not.toBe("http://b/wrong")
+      expect(redirect).toBe("http://a/wrong")
+    })
+
+    it("throw error", async () => {
+      const e = new Error("my error")
+      const res = await signIn({
+        callbacks: {
+          signIn() {
+            throw e
+          },
+        },
+      })
+      expect(res.headers.get("Location")).toBe(
+        "http://a/auth/error?error=AuthorizedCallbackError"
+      )
+    })
+  })
+
+  // TODO: We need an OAuth provider to test against
+  describe.todo("redirect in oauth", () => {})
+})


### PR DESCRIPTION
## ☕️ Reasoning

This is still a supported feature in `next-auth` v4 which was removed without a good reason and therefore should not break it. Re-adding for backwards compatibility

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes #9827