### PR TITLE
fix: filter client error response, error on missing host

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,13 +114,12 @@ export async function Auth(
       !htmlPages.includes(internalRequest.action) ||
       internalRequest.method !== "GET"
     ) {
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           message:
             "There was a problem with the server configuration. Check the server logs for more information.",
-          code: assertionResult.name,
-        }),
-        { status: 500, headers: { "Content-Type": "application/json" } }
+        },
+        { status: 500 }
       )
     }
 

--- a/packages/core/src/lib/utils/env.ts
+++ b/packages/core/src/lib/utils/env.ts
@@ -53,6 +53,7 @@ export function createActionURL(
   let url = envObject.AUTH_URL ?? envObject.NEXTAUTH_URL
   if (!url) {
     const host = headers.get("x-forwarded-host") ?? headers.get("host")
+    if (!host) throw new TypeError("Missing host")
     const proto = headers.get("x-forwarded-proto") ?? protocol
     url = `${proto === "http" ? "http" : "https"}://${host}${basePath}`
   }

--- a/packages/core/test/assert-config.test.ts
+++ b/packages/core/test/assert-config.test.ts
@@ -1,0 +1,183 @@
+import { vi, expect, it, describe, beforeEach } from "vitest"
+import { makeAuthRequest } from "./utils"
+import {
+  InvalidCallbackUrl,
+  InvalidEndpoints,
+  MissingAuthorize,
+  MissingSecret,
+  UnsupportedStrategy,
+  UntrustedHost,
+} from "../src/errors"
+import { Provider } from "../src/providers"
+import { AuthConfig } from "../src"
+import Credentials from "../src/providers/credentials"
+
+describe("Assert user config correctness", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it("missing secret", async () => {
+    const { response, logger } = await makeAuthRequest({
+      action: "session",
+      config: { secret: undefined },
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      message:
+        "There was a problem with the server configuration. Check the server logs for more information.",
+    })
+    expect(logger?.error).toHaveBeenCalledWith(
+      new MissingSecret("Please define a `secret`.")
+    )
+  })
+
+  it("trust host", async () => {
+    const { response, logger } = await makeAuthRequest({
+      action: "session",
+      config: { trustHost: false },
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      message:
+        "There was a problem with the server configuration. Check the server logs for more information.",
+    })
+    expect(logger?.error).toHaveBeenCalledWith(
+      new UntrustedHost(
+        "Host must be trusted. URL was: http://authjs.test/auth/session"
+      )
+    )
+  })
+
+  describe.each(["non-relative", "a"])(
+    'invalid callbackUrl (url: "%s")',
+    async (callbackUrl) => {
+      it.each(["search param", "cookie", "cookie-custom"])(
+        "from %s",
+        async (type) => {
+          const cookieName =
+            type === "cookie" ? "authjs.callback-url" : "custom-name"
+
+          const { response, logger } = await makeAuthRequest({
+            action: "session",
+            ...(type.startsWith("cookie")
+              ? { cookies: { [cookieName]: callbackUrl } }
+              : { query: { callbackUrl } }),
+            config: {
+              cookies:
+                type === "cookie-custom"
+                  ? { callbackUrl: { name: cookieName } }
+                  : undefined,
+            },
+          })
+
+          expect(response.status).toBe(500)
+          expect(await response.json()).toEqual({
+            message:
+              "There was a problem with the server configuration. Check the server logs for more information.",
+          })
+          expect(logger?.error).toHaveBeenCalledWith(
+            new InvalidCallbackUrl(
+              `Invalid callback URL. Received: ${callbackUrl}`
+            )
+          )
+        }
+      )
+    }
+  )
+
+  describe("providers", () => {
+    it.each<[Provider, string]>([
+      [
+        () => ({ type: "oidc", id: "provider-id", name: "" }),
+        'Provider "provider-id" is missing both `issuer` and `authorization` endpoint config. At least one of them is required.',
+      ],
+      [
+        { type: "oidc", id: "provider-id", name: "" },
+        'Provider "provider-id" is missing both `issuer` and `authorization` endpoint config. At least one of them is required.',
+      ],
+      [
+        {
+          authorization: { url: "http://a" },
+          type: "oauth",
+          id: "provider-id",
+          name: "",
+        },
+        'Provider "provider-id" is missing both `issuer` and `token` endpoint config. At least one of them is required.',
+      ],
+      [
+        {
+          authorization: "http://a",
+          token: { url: "http://a" },
+          type: "oauth",
+          id: "provider-id",
+          name: "",
+        },
+        'Provider "provider-id" is missing both `issuer` and `userinfo` endpoint config. At least one of them is required.',
+      ],
+      [
+        {
+          authorization: "http://a",
+          token: "http://a",
+          // @ts-expect-error Purposefully testing invalid config
+          userinfo: { foo: "http://a" },
+          type: "oauth",
+          id: "oauth-provider",
+          name: "",
+        },
+        'Provider "oauth-provider" is missing both `issuer` and `userinfo` endpoint config. At least one of them is required.',
+      ],
+    ])("OAuth/OIDC: invalid endpoints %j", async (provider, error) => {
+      const { response, logger } = await makeAuthRequest({
+        action: "providers",
+        config: { providers: [provider] },
+      })
+
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({
+        message:
+          "There was a problem with the server configuration. Check the server logs for more information.",
+      })
+      expect(logger?.error).toHaveBeenCalledWith(new InvalidEndpoints(error))
+    })
+
+    it.each<[string, Provider, Error, Partial<AuthConfig>]>([
+      [
+        "missing authorize() (function)",
+        () => ({ type: "credentials", id: "provider-id", name: "" }),
+        new MissingAuthorize(
+          "Must define an authorize() handler to use credentials authentication provider"
+        ),
+      ],
+      [
+        "missing authorize() (object)",
+        { type: "credentials", id: "provider-id", name: "" },
+        new MissingAuthorize(
+          "Must define an authorize() handler to use credentials authentication provider"
+        ),
+      ],
+      [
+        "trying to use database strategy",
+        Credentials({}),
+        new UnsupportedStrategy(
+          "Signing in with credentials only supported if JWT strategy is enabled"
+        ),
+        { session: { strategy: "database" } },
+      ],
+    ] as any)("credentials: %s", async (_, provider, error, config) => {
+      const { response, logger } = await makeAuthRequest({
+        action: "providers",
+        config: { ...config, providers: [provider] },
+      })
+
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({
+        message:
+          "There was a problem with the server configuration. Check the server logs for more information.",
+      })
+      expect(logger?.error).toHaveBeenCalledWith(error)
+    })
+  })
+})

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -1,0 +1,74 @@
+import { vi } from "vitest"
+import { Auth, createActionURL } from "../src"
+
+import type { Adapter } from "../src/adapters"
+import type { AuthAction, AuthConfig, LoggerInstance } from "../src/types"
+
+export function TestAdapter(): Adapter {
+  return {
+    createUser: vi.fn(),
+    getUser: vi.fn(),
+    getUserByEmail: vi.fn(),
+    getUserByAccount: vi.fn(),
+    updateUser: vi.fn(),
+    deleteUser: vi.fn(),
+    linkAccount: vi.fn(),
+    unlinkAccount: vi.fn(),
+    createSession: vi.fn(),
+    getSessionAndUser: vi.fn(),
+    updateSession: vi.fn(),
+    deleteSession: vi.fn(),
+    createVerificationToken: vi.fn(),
+    useVerificationToken: vi.fn(),
+  }
+}
+
+export const logger: LoggerInstance = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}
+
+export function testConfig(overrides?: Partial<AuthConfig>): AuthConfig {
+  return {
+    secret: "secret",
+    trustHost: true,
+    logger,
+    basePath: "/auth",
+    providers: [],
+    ...overrides,
+  }
+}
+
+export async function makeAuthRequest(params: {
+  action: AuthAction
+  cookies?: Record<string, string>
+  query?: Record<string, string>
+  body?: any
+  config?: Partial<AuthConfig>
+}) {
+  const { action, body, cookies = {} } = params
+  const config = testConfig(params.config)
+  const headers = new Headers({ host: "authjs.test" })
+  for (const [name, value] of Object.entries(cookies))
+    headers.append("cookie", `${name}=${value}`)
+
+  let url: string | URL = createActionURL(
+    action,
+    "http",
+    headers,
+    {},
+    config.basePath
+  )
+  if (params.query) url = `${url}?${new URLSearchParams(params.query)}`
+  const request = new Request(url, {
+    method: body ? "POST" : "GET",
+    headers,
+    body,
+  })
+  const response = (await Auth(request, config)) as Response
+  return {
+    response,
+    logger: config.logger,
+  }
+}


### PR DESCRIPTION
The error response sent to the client (browser) should be as minimal as possible, dropped the `code` property.

During testing, I also discovered that technically we did not care if both `host` and `x-forwarded-host` were `null` and just continued. This would likely cause issues later in the flow, so we should throw an error early.

I also added some testing utilities to core. See https://github.com/nextauthjs/next-auth/blob/e87070490ba61156af5b22d0d0bcb7cdc313a3ea/packages/core/test/utils.ts

It's a nice balance between unit vs. e2e tests IMO. For higher-level testing, we might want to set up Playwright again.