### PR TITLE
fix: append `.js` to import

### DIFF
--- a/packages/adapter-drizzle/src/lib/pg.ts
+++ b/packages/adapter-drizzle/src/lib/pg.ts
@@ -10,7 +10,7 @@ import {
 } from "drizzle-orm/pg-core"
 
 import type { Adapter, AdapterAccount } from "@auth/core/adapters"
-import { stripUndefined } from "./utils"
+import { stripUndefined } from "./utils.js"
 
 export function createTables(pgTable: PgTableFn) {
   const users = pgTable("user", {

--- a/packages/adapter-drizzle/src/lib/sqlite.ts
+++ b/packages/adapter-drizzle/src/lib/sqlite.ts
@@ -7,7 +7,7 @@ import {
   BaseSQLiteDatabase,
   SQLiteTableFn,
 } from "drizzle-orm/sqlite-core"
-import { stripUndefined } from "./utils"
+import { stripUndefined } from "./utils.js"
 
 import type { Adapter, AdapterAccount } from "@auth/core/adapters"
 


### PR DESCRIPTION
Fixes #9844 
