### PR TITLE
Support empty string VERCEL_URL

### DIFF
--- a/packages/next-auth/src/lib/client.ts
+++ b/packages/next-auth/src/lib/client.ts
@@ -218,7 +218,7 @@ export function parseUrl(url?: string): {
     url = `https://${url}`
   }
 
-  const _url = new URL(url ?? defaultUrl)
+  const _url = new URL(url || defaultUrl)
   const path = (_url.pathname === "/" ? defaultUrl.pathname : _url.pathname)
     // Remove trailing slash
     .replace(/\/$/, "")

--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -54,12 +54,12 @@ export { SessionProviderProps }
 // 2. When invoked server side the value is picked up from an environment
 //    variable and defaults to 'http://localhost:3000'.
 const __NEXTAUTH: AuthClientConfig = {
-  baseUrl: parseUrl(process.env.NEXTAUTH_URL ?? (process.env.VERCEL_URL || undefined)).origin,
+  baseUrl: parseUrl(process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL).origin,
   basePath: parseUrl(process.env.NEXTAUTH_URL).path,
   baseUrlServer: parseUrl(
     process.env.NEXTAUTH_URL_INTERNAL ??
       process.env.NEXTAUTH_URL ??
-      (process.env.VERCEL_URL || undefined)
+      process.env.VERCEL_URL
   ).origin,
   basePathServer: parseUrl(
     process.env.NEXTAUTH_URL_INTERNAL ?? process.env.NEXTAUTH_URL

--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -54,12 +54,12 @@ export { SessionProviderProps }
 // 2. When invoked server side the value is picked up from an environment
 //    variable and defaults to 'http://localhost:3000'.
 const __NEXTAUTH: AuthClientConfig = {
-  baseUrl: parseUrl(process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL).origin,
+  baseUrl: parseUrl(process.env.NEXTAUTH_URL ?? (process.env.VERCEL_URL || undefined)).origin,
   basePath: parseUrl(process.env.NEXTAUTH_URL).path,
   baseUrlServer: parseUrl(
     process.env.NEXTAUTH_URL_INTERNAL ??
       process.env.NEXTAUTH_URL ??
-      process.env.VERCEL_URL
+      (process.env.VERCEL_URL || undefined)
   ).origin,
   basePathServer: parseUrl(
     process.env.NEXTAUTH_URL_INTERNAL ?? process.env.NEXTAUTH_URL


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Using `vercel env pull` results in `TypeError [ERR_INVALID_URL]: Invalid URL` in development. 

Vercel CLI creates a VERCEL_URL environment variable with an empty string as value. This trips next-auth in development, causing the above error.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #4363 

