### PR TITLE
fix: allow Facebook authorization config to be merged

### DIFF
--- a/packages/core/src/providers/facebook.ts
+++ b/packages/core/src/providers/facebook.ts
@@ -84,7 +84,12 @@ export default function Facebook<P extends FacebookProfile>(
     id: "facebook",
     name: "Facebook",
     type: "oauth",
-    authorization: "https://www.facebook.com/v15.0/dialog/oauth?scope=email",
+    authorization: {
+      url: "https://www.facebook.com/v15.0/dialog/oauth",
+      params: {
+        scope: 'email',
+      },
+    },
     token: "https://graph.facebook.com/oauth/access_token",
     userinfo: {
       // https://developers.facebook.com/docs/graph-api/reference/user/#fields


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Docs suggest that it's possible to easily extend Facebook provider options, due to deep merging of the provided properties with the defaults.
https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/facebook.ts#L63-66
https://github.com/nextauthjs/next-auth/blob/f33a0ace66dab3523d9cd0883d65558b29837b7b/docs/docs/guides/providers/custom-provider.md?plain=1#L41-60

However, `authorization` property cannot be extended this way due to it being a hardcoded string. 
https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/facebook.ts#L87

My PR includes a fix, converting the string into an object (satisfying `AdvancedEndpointHandler` interface), which is mergable in current implementation. Facebook authorization config can then be easily extended, as per the docs example.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
None

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
