### PR TITLE
test: fix drizzle test by `tsx`-ing imports

### DIFF
--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -55,6 +55,7 @@
     "drizzle-kit": "^0.20.6",
     "drizzle-orm": "^0.29.1",
     "mysql2": "^3.2.0",
-    "postgres": "^3.3.4"
+    "postgres": "^3.3.4",
+    "tsx": "^4.7.0"
   }
 }

--- a/packages/adapter-drizzle/test/mysql-multi-project-schema/test.sh
+++ b/packages/adapter-drizzle/test/mysql-multi-project-schema/test.sh
@@ -16,7 +16,7 @@ mysql:8 \
 
 echo "Waiting 15 sec for db to start..." && sleep 15
 
-drizzle-kit generate:mysql --config=./test/mysql/drizzle.config.ts
-drizzle-kit push:mysql --config=./test/mysql/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit generate:mysql --config=./test/mysql/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit push:mysql --config=./test/mysql/drizzle.config.ts
 vitest -c ../utils/vitest.config.ts ./test/mysql/index.test.ts
 docker stop ${MYSQL_CONTAINER_NAME}

--- a/packages/adapter-drizzle/test/mysql/test.sh
+++ b/packages/adapter-drizzle/test/mysql/test.sh
@@ -16,7 +16,7 @@ mysql:8 \
 
 echo "Waiting 15 sec for db to start..." && sleep 15
 
-drizzle-kit generate:mysql --config=./test/mysql/drizzle.config.ts
-drizzle-kit push:mysql --config=./test/mysql/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit generate:mysql --config=./test/mysql/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit push:mysql --config=./test/mysql/drizzle.config.ts
 vitest -c ../utils/vitest.config.ts ./test/mysql/index.test.ts
 docker stop ${MYSQL_CONTAINER_NAME}

--- a/packages/adapter-drizzle/test/pg-multi-project-schema/test.sh
+++ b/packages/adapter-drizzle/test/pg-multi-project-schema/test.sh
@@ -20,6 +20,6 @@ postgres:15.3
 echo "Waiting 15 sec for db to start..." && sleep 15
 
 drizzle-kit generate:pg --config=./test/pg/drizzle.config.ts
-npx tsx ./test/pg/migrator.ts
+tsx ./test/pg/migrator.ts
 vitest -c ../utils/vitest.config.ts ./test/pg/index.test.ts
 docker stop ${PG_CONTAINER_NAME}

--- a/packages/adapter-drizzle/test/pg/test.sh
+++ b/packages/adapter-drizzle/test/pg/test.sh
@@ -19,7 +19,7 @@ postgres:15.3
 
 echo "Waiting 15 sec for db to start..." && sleep 15
 
-drizzle-kit generate:pg --config=./test/pg/drizzle.config.ts
-npx tsx ./test/pg/migrator.ts
+NODE_OPTIONS='--import tsx' drizzle-kit generate:pg --config=./test/pg/drizzle.config.ts
+tsx ./test/pg/migrator.ts
 vitest -c ../utils/vitest.config.ts ./test/pg/index.test.ts
 docker stop ${PG_CONTAINER_NAME}

--- a/packages/adapter-drizzle/test/sqlite-multi-project-schema/test.sh
+++ b/packages/adapter-drizzle/test/sqlite-multi-project-schema/test.sh
@@ -7,6 +7,6 @@ echo "Running SQLite tests."
 
 rm -f db.sqlite
 
-drizzle-kit generate:sqlite --config=./test/sqlite/drizzle.config.ts
-drizzle-kit push:sqlite --config=./test/sqlite/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit generate:sqlite --config=./test/sqlite/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit push:sqlite --config=./test/sqlite/drizzle.config.ts
 vitest -c ../utils/vitest.config.ts ./test/sqlite/index.test.ts

--- a/packages/adapter-drizzle/test/sqlite/test.sh
+++ b/packages/adapter-drizzle/test/sqlite/test.sh
@@ -7,14 +7,14 @@ echo "Running SQLite tests."
 
 rm -f db.sqlite
 
-drizzle-kit generate:sqlite --config=./test/sqlite/drizzle.config.ts
-drizzle-kit push:sqlite --config=./test/sqlite/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit generate:sqlite --config=./test/sqlite/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit push:sqlite --config=./test/sqlite/drizzle.config.ts
 vitest -c ../utils/vitest.config.ts ./test/sqlite/index.test.ts
 
 echo "Running LibSQL tests."
 
 rm -f db.sqlite
 
-drizzle-kit generate:sqlite --config=./test/sqlite/drizzle.config.ts
-drizzle-kit push:sqlite --config=./test/sqlite/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit generate:sqlite --config=./test/sqlite/drizzle.config.ts
+NODE_OPTIONS='--import tsx' drizzle-kit push:sqlite --config=./test/sqlite/drizzle.config.ts
 vitest -c ../utils/vitest.config.ts ./test/sqlite/libsql.test.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       postgres:
         specifier: ^3.3.4
         version: 3.4.3
+      tsx:
+        specifier: ^4.7.0
+        version: 4.7.0
 
   packages/adapter-dynamodb:
     dependencies:
@@ -24395,6 +24398,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.3.3
+    dev: true
+
+  /tsx@4.7.0:
+    resolution: {integrity: sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.19.12
+      get-tsconfig: 4.7.2
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /tunnel-agent@0.6.0:


### PR DESCRIPTION
There seems to be a bug in Drizzle which makes it not able to correctly handle imports with extensions: https://github.com/drizzle-team/drizzle-orm/issues/849

See failing test: https://github.com/nextauthjs/next-auth/actions/runs/7710641249/job/21014387531#step:8:70

There is a recommendation in this comment https://github.com/drizzle-team/drizzle-orm/issues/849#issuecomment-1805634538 to use `tsx`, which fixes the issue, but this should likely be resolved upstream in Drizzle.

Closes #9844