### PR TITLE
fix(docs): use `auth` over `getSession`

### DIFF
--- a/docs/docs/getting-started/providers/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/providers/oauth-tutorial.mdx
@@ -245,14 +245,14 @@ or https://generate-secret.vercel.app/32 to generate a random value for it.
 
 ### Exposing the session via page store
 
-Auth.js provides us a getSession, function to access the session data and status, to call from the `event.locals` variable. We can now just call it and add it to our `$page` store.
+Auth.js provides us a `auth`, function to access the session data and status, to call from the `event.locals` variable. We can now just call it and add it to our `$page` store.
 
 ```ts
 import type { LayoutServerLoad } from "./$types"
 
 export const load: LayoutServerLoad = async (event) => {
   return {
-    session: await event.locals.getSession(),
+    session: await event.locals.auth(),
   }
 }
 ```
@@ -279,14 +279,14 @@ You can use the `$page.data.session` variable from anywhere on your page. Learn 
 
 ### Protecting API Routes
 
-To protect your API Routes (blocking unauthorized access to resources), you can use `locals.getSessions()` just like in the layouts file to know whether a session exists or not:
+To protect your API Routes (blocking unauthorized access to resources), you can use `locals.auth()` just like in the layouts file to know whether a session exists or not:
 
 ```ts title="routes/api/movies/+server.ts"
 import { json, error } from "@sveltejs/kit"
 import type { RequestEvent } from "./$types"
 
 export async function GET({ locals }: RequestEvent) {
-  const session = await locals.getSession()
+  const session = await locals.auth()
   if (!session?.user) {
     throw error(401, "You must sign in to view movies.")
   }


### PR DESCRIPTION
Replaces `getSession` with `auth` given that `getSession` is now deprecated.

Refer to: https://github.com/sveltejs/kit/discussions/5883 for context.

The following PR also serves as context for the same milestone: https://github.com/sveltejs/kit/pull/5946

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
