### PR TITLE
test: re-introduce E2E, add basic login/logout tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         name: Upload Playwright report
         with:
           name: playwright-report
-          path: packages/utils/playwright-report/
+          path: packages/core/playwright-report/
           retention-days: 30
       - uses: codecov/codecov-action@v3
         name: Coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,6 @@ jobs:
         env:
           UPSTASH_REDIS_URL: ${{ secrets.UPSTASH_REDIS_URL }}
           UPSTASH_REDIS_KEY: ${{ secrets.UPSTASH_REDIS_KEY }}
-      - uses: codecov/codecov-action@v3
-        name: Coverage
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run E2E tests
         if: github.repository == 'nextauthjs/next-auth'
         run: \
@@ -111,8 +107,10 @@ jobs:
           AUTH_KEYCLOAK_ID: ${{ secrets.AUTH_KEYCLOAK_ID }}
           AUTH_KEYCLOAK_SECRET: ${{ secrets.AUTH_KEYCLOAK_SECRET }}
           AUTH_KEYCLOAK_ISSUER: ${{ secrets.AUTH_KEYCLOAK_ISSUER }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      - uses: codecov/codecov-action@v3
+        name: Coverage
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   release-branch:
     name: Publish branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         if: github.repository == 'nextauthjs/next-auth'
         run: |
           pnpm exec playwright install --with-deps
-          cd apps/dev/nextjs && pnpm build
+          pnpm build:app
           pnpm test:e2e
         timeout-minutes: 15
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,8 @@ jobs:
       - name: Run E2E tests
         if: github.repository == 'nextauthjs/next-auth'
         run: |
-          pnpm exec playwright install --with-deps &&
-          cd apps/dev/nextjs && pnpm build &&
+          pnpm exec playwright install --with-deps
+          cd apps/dev/nextjs && pnpm build
           pnpm test:e2e
         timeout-minutes: 15
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
           AUTH_KEYCLOAK_ID: ${{ secrets.AUTH_KEYCLOAK_ID }}
           AUTH_KEYCLOAK_SECRET: ${{ secrets.AUTH_KEYCLOAK_SECRET }}
           AUTH_KEYCLOAK_ISSUER: ${{ secrets.AUTH_KEYCLOAK_ISSUER }}
+          AUTH_TRUST_HOST: 1
       - uses: actions/upload-artifact@v3
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Run E2E tests
         if: github.repository == 'nextauthjs/next-auth'
         run: |
-          pnpm exec playwright install --with-deps
+          pnpm exec playwright install --with-deps > /dev/null 2>&1
           pnpm build:app
           pnpm test:e2e
         timeout-minutes: 15
@@ -109,9 +109,10 @@ jobs:
           AUTH_KEYCLOAK_ISSUER: ${{ secrets.AUTH_KEYCLOAK_ISSUER }}
           AUTH_TRUST_HOST: 1
       - uses: actions/upload-artifact@v3
+        name: Upload Playwright report
         with:
           name: playwright-report
-          path: playwright-report/
+          path: packages/utils/playwright-report/
           retention-days: 30
       - uses: codecov/codecov-action@v3
         name: Coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,22 +98,22 @@ jobs:
         name: Coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      # - name: Run E2E tests
-      #   if: github.repository == 'nextauthjs/next-auth'
-      #   run: pnpm e2e
-      #   timeout-minutes: 15
-      #   env:
-      #     AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
-      #     AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
-      #     TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      #     TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      # - name: Upload E2E artifacts
-      #   if: github.repository == 'nextauthjs/next-auth'
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: playwright-report
-      #     path: apps/dev/nextjs/playwright-report/
-      #     retention-days: 30
+      - name: Run E2E tests
+        if: github.repository == 'nextauthjs/next-auth'
+        run: \
+          pnpm exec playwright install --with-deps && \
+          cd apps/dev/nextjs && pnpm build && \
+          pnpm test:e2e
+        timeout-minutes: 15
+        env:
+          TEST_KEYCLOAK_USERNAME: ${{ secrets.TEST_KEYCLOAK_USERNAME }}
+          TEST_KEYCLOAK_PASSWORD: ${{ secrets.TEST_KEYCLOAK_PASSWORD }}
+          AUTH_KEYCLOAK_ID: ${{ secrets.AUTH_KEYCLOAK_ID }}
+          AUTH_KEYCLOAK_SECRET: ${{ secrets.AUTH_KEYCLOAK_SECRET }}
+          AUTH_KEYCLOAK_ISSUER: ${{ secrets.AUTH_KEYCLOAK_ISSUER }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
   release-branch:
     name: Publish branch
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,9 @@ jobs:
           UPSTASH_REDIS_KEY: ${{ secrets.UPSTASH_REDIS_KEY }}
       - name: Run E2E tests
         if: github.repository == 'nextauthjs/next-auth'
-        run: \
-          pnpm exec playwright install --with-deps && \
-          cd apps/dev/nextjs && pnpm build && \
+        run: |
+          pnpm exec playwright install --with-deps &&
+          cd apps/dev/nextjs && pnpm build &&
           pnpm test:e2e
         timeout-minutes: 15
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,11 @@ jobs:
           AUTH_KEYCLOAK_ID: ${{ secrets.AUTH_KEYCLOAK_ID }}
           AUTH_KEYCLOAK_SECRET: ${{ secrets.AUTH_KEYCLOAK_SECRET }}
           AUTH_KEYCLOAK_ISSUER: ${{ secrets.AUTH_KEYCLOAK_ISSUER }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
       - uses: codecov/codecov-action@v3
         name: Coverage
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,11 @@ coverage
 dynamodblocal-bin
 firestore-debug.log
 test.schema.gql
+test-results
+playwright-report
+blob-report
+playwright/.cache
+
 
 # Turborepo
 .turbo

--- a/apps/dev/nextjs/auth.config.ts
+++ b/apps/dev/nextjs/auth.config.ts
@@ -5,6 +5,7 @@ import Google from "next-auth/providers/google"
 import Facebook from "next-auth/providers/facebook"
 import Auth0 from "next-auth/providers/auth0"
 import Twitter from "next-auth/providers/twitter"
+import Keycloak from "next-auth/providers/keycloak"
 
 declare module "next-auth" {
   /**
@@ -39,6 +40,7 @@ export default {
     }),
     GitHub,
     Google,
+    Keycloak,
     Facebook,
     Auth0,
     Twitter,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@actions/core": "^1.10.0",
     "@balazsorban/monorepo-release": "0.5.0",
+    "@playwright/test": "1.41.2",
     "@types/node": "^20.8.10",
     "@typescript-eslint/eslint-plugin": "5.47.0",
     "@typescript-eslint/parser": "5.47.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:docs": "turbo run build --filter=docs",
     "build": "turbo run build --filter=next-auth --filter=@auth/* --no-deps",
     "test": "turbo run test --concurrency=1 --filter=[HEAD^1] --filter=./packages/* --filter=!*app* --filter=!*dynamo* --filter=!*edgedb* --filter=!*hasura* --filter=!*supabase* --filter=!*upstash* --filter=!*xata*",
+    "test:e2e": "turbo run test:e2e",
     "clean": "turbo run clean --no-cache",
     "dev:example": "turbo run dev --parallel --continue --filter=nextjs-example-app... --filter=!./packages/adapter-*",
     "dev:db": "turbo run dev --parallel --continue --filter=next-auth-app...",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,7 @@
     "clean": "rm -rf *.js *.d.ts* lib providers",
     "css": "node scripts/generate-css",
     "dev": "pnpm css && pnpm providers && tsc -w",
+    "test:e2e": "playwright test -c ../utils/playwright.config.ts",
     "test": "vitest -c ../utils/vitest.config.ts",
     "providers": "node scripts/generate-providers"
   },

--- a/packages/core/test/e2e/basic-auth.spec.ts
+++ b/packages/core/test/e2e/basic-auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test"
+import { test, expect, type Page } from "@playwright/test"
 // import v8toIstanbul from "v8-to-istanbul"
 // import { writeFile } from "fs/promises"
 

--- a/packages/core/test/e2e/basic-login.spec.ts
+++ b/packages/core/test/e2e/basic-login.spec.ts
@@ -39,9 +39,9 @@ test("Basic login", async ({ page }) => {
   const session = await page.locator("pre").textContent()
   expect(JSON.parse(session ?? "{}")).toEqual({
     user: {
-      email: "info@balazsorban.com",
-      name: "Balázs Orbán",
-      image: "https://avatars.githubusercontent.com/u/18369201?v=4",
+      email: "bob@alice.com",
+      name: "Bob Alice",
+      image: "https://avatars.githubusercontent.com/u/67470890?s=200&v=4",
     },
     expires: expect.any(String),
   })

--- a/packages/core/test/e2e/basic-login.spec.ts
+++ b/packages/core/test/e2e/basic-login.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, Page } from "@playwright/test"
+// import v8toIstanbul from "v8-to-istanbul"
+// import { writeFile } from "fs/promises"
+
+// TODO
+async function withCoverage(page: Page, fn: () => Promise<void>) {
+  // await page.coverage.startJSCoverage()
+  await fn()
+  // const coverage = await page.coverage.stopJSCoverage()
+  // for (const entry of coverage) {
+  //   const converter = v8toIstanbul("", 0, { source: entry.source ?? "" })
+  //   await converter.load()
+  //   converter.applyCoverage(entry.functions)
+  //   await writeFile(
+  //     `???`,
+  //     JSON.stringify(converter.toIstanbul()),
+  //     "utf8"
+  //   )
+  // }
+}
+
+test("Basic login", async ({ page }) => {
+  if (
+    !process.env.TEST_KEYCLOAK_USERNAME ||
+    !process.env.TEST_KEYCLOAK_PASSWORD
+  )
+    throw new TypeError("Incorrect TEST_KEYCLOAK_{USERNAME,PASSWORD}")
+
+  // await withCoverage(page, async () => {
+  await page.goto("http://localhost:3000/auth/signin")
+  await page.getByText("Keycloak").click()
+  await page.getByText("Username or email").waitFor()
+  await page
+    .getByLabel("Username or email")
+    .fill(process.env.TEST_KEYCLOAK_USERNAME)
+  await page.locator("#password").fill(process.env.TEST_KEYCLOAK_PASSWORD)
+  await page.getByRole("button", { name: "Sign In" }).click()
+  await page.waitForURL("http://localhost:3000")
+  const session = await page.locator("pre").textContent()
+  expect(JSON.parse(session ?? "{}")).toEqual({
+    user: {
+      email: "info@balazsorban.com",
+      name: "Balázs Orbán",
+      image: "https://avatars.githubusercontent.com/u/18369201?v=4",
+    },
+    expires: expect.any(String),
+  })
+  // })
+})

--- a/packages/utils/playwright.config.ts
+++ b/packages/utils/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from "@playwright/test"
+
+/** See https://playwright.dev/docs/test-configuration. */
+export default defineConfig({
+  testDir: `../core/test/e2e`, // TODO: `core` should not be hardcoded here
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: { trace: "on-first-retry" },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "cd ../../apps/dev/nextjs && pnpm start",
+    url: "http://localhost:3000",
+    timeout: 10_000,
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/packages/utils/playwright.config.ts
+++ b/packages/utils/playwright.config.ts
@@ -9,7 +9,12 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: { trace: "on-first-retry" },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
+    },
+  ],
   webServer: {
     command: "cd ../../apps/dev/nextjs && pnpm start",
     url: "http://localhost:3000",

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -6,6 +6,8 @@ import swc from "unplugin-swc"
 // https://vitejs.dev/config/
 export default defineConfig({
   test: {
+    // NOTE: `.spec` is reserved for Playwright tests
+    include: ["**/*.test.?(c|m)[jt]s?(x)"],
     coverage: {
       all: true,
       enabled: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@balazsorban/monorepo-release':
         specifier: 0.5.0
         version: 0.5.0(patch_hash=cqvuvq5dn5jyeeoklla3tkfope)
+      '@playwright/test':
+        specifier: 1.41.2
+        version: 1.41.2
       '@types/node':
         specifier: ^20.8.10
         version: 20.11.7
@@ -6597,6 +6600,14 @@ packages:
     dependencies:
       '@types/node': 18.11.10
       playwright-core: 1.29.2
+    dev: true
+
+  /@playwright/test@1.41.2:
+    resolution: {integrity: sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright: 1.41.2
     dev: true
 
   /@pnpm/config.env-replace@1.1.0:
@@ -14170,6 +14181,14 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -20068,6 +20087,22 @@ packages:
     resolution: {integrity: sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
+
+  /playwright-core@1.41.2:
+    resolution: {integrity: sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.41.2:
+    resolution: {integrity: sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.41.2
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /portfinder@1.0.32:

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
+      "inputs": [
+        "src/**"
+      ],
       "dependsOn": [
         "^build"
       ],

--- a/turbo.json
+++ b/turbo.json
@@ -34,9 +34,12 @@
       ],
       "outputMode": "new-only"
     },
-    "e2e": {
+    "test:e2e": {
       "outputs": [
-        "playwright-report/**"
+        "blob-report/**",
+        "playwright-report/**",
+        "playwright/.cache/**",
+        "test-results/**"
       ]
     },
     "@auth/upstash-redis-adapter#test": {

--- a/turbo.json
+++ b/turbo.json
@@ -2,9 +2,6 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
-      "inputs": [
-        "src/**"
-      ],
       "dependsOn": [
         "^build"
       ],


### PR DESCRIPTION
This PR adds back the Playwright setup necessary to add proper E2E tests to our libraries.

We've had a setup before, but needed to disable it, since common providers cannot be tested from CI environments, as these IPs are usually blocked and will ask for captcha.

We now have our own self-hosted OIDC provider, against which we can run tests.

Hooking up coverage can be tackled in a different PR, as it seemed a bit more involved.