### PR TITLE
fix: properly extend `NodemailerConfig` by `EmailConfig`

### DIFF
--- a/packages/core/src/providers/email.ts
+++ b/packages/core/src/providers/email.ts
@@ -43,8 +43,10 @@ export interface EmailConfig extends CommonProviderOptions {
   }) => Awaitable<void>
   /** Used to hash the verification token. */
   secret?: string
-  /** Used with HTTP-based email providers  */
+  /** Used with HTTP-based email providers. */
   apiKey?: string
+  /** Used with SMTP-based email providers. */
+  server?: NodemailerConfig["server"]
   generateVerificationToken?: () => Awaitable<string>
   normalizeIdentifier?: (identifier: string) => string
   options: EmailUserConfig

--- a/packages/core/src/providers/nodemailer.ts
+++ b/packages/core/src/providers/nodemailer.ts
@@ -1,5 +1,6 @@
 import { createTransport } from "nodemailer"
-import { EmailConfig, html, text } from "./email"
+import { EmailConfig, html, text } from "./email.js"
+import { AuthError } from "../errors.js"
 
 import type { Transport, TransportOptions } from "nodemailer"
 import * as JSONTransport from "nodemailer/lib/json-transport/index.js"
@@ -8,7 +9,7 @@ import * as SESTransport from "nodemailer/lib/ses-transport/index.js"
 import * as SMTPTransport from "nodemailer/lib/smtp-transport/index.js"
 import * as SMTPPool from "nodemailer/lib/smtp-pool/index.js"
 import * as StreamTransport from "nodemailer/lib/stream-transport/index.js"
-import type { Awaitable, Theme } from "../types"
+import type { Awaitable, Theme } from "../types.js"
 
 type AllTransportOptions =
   | string
@@ -27,9 +28,8 @@ type AllTransportOptions =
   | Transport<any>
   | TransportOptions
 
-export interface NodemailerConfig
-  extends Omit<EmailConfig, "sendVerificationRequest" | "options"> {
-  server: AllTransportOptions
+export interface NodemailerConfig extends EmailConfig {
+  server?: AllTransportOptions
   sendVerificationRequest: (params: {
     identifier: string
     url: string
@@ -50,6 +50,9 @@ export type NodemailerUserConfig = Omit<
 export default function Nodemailer(
   config: NodemailerUserConfig
 ): NodemailerConfig {
+  if (!config.server)
+    throw new AuthError("Nodemailer requires a `server` configuration")
+
   return {
     id: "nodemailer",
     type: "email",


### PR DESCRIPTION
Fixes #9883 (had a wrong import at [this line](https://github.com/nextauthjs/next-auth/pull/9890/files#diff-a9cb24cb7d80099bcf42d3ee2c2accba917bf5dd259a3aa1d01ca4252c382452R2)). _Might_ be related to #9882, but hard to tell without a reproduction.

The `server` property was missing on `EmailConfig`. It's not required for _all_ email providers, so it's only made mandatory on `Nodemailer`. If it's missing, we throw an error now.