### PR TITLE
refactor(core): export `isAuthAction`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -321,8 +321,7 @@ export interface AuthConfig {
    * ```ts
    * // /pages/api/auth/[...nextauth].js
    * import log from "logging-service"
-   * import { isAuthAction } from './lib/utils/actions';
-export default NextAuth({
+   * export default NextAuth({
    *   logger: {
    *     error(code, ...message) {
    *       log.error(code, message)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,8 +55,9 @@ import type {
 } from "./types.js"
 import type { Provider } from "./providers/index.js"
 import { JWTOptions } from "./jwt.js"
+import { isAuthAction } from "./lib/utils/actions.js"
 
-export { skipCSRFCheck, raw, setEnvDefaults, createActionURL }
+export { skipCSRFCheck, raw, setEnvDefaults, createActionURL, isAuthAction }
 
 export async function Auth(
   request: Request,
@@ -320,7 +321,8 @@ export interface AuthConfig {
    * ```ts
    * // /pages/api/auth/[...nextauth].js
    * import log from "logging-service"
-   * export default NextAuth({
+   * import { isAuthAction } from './lib/utils/actions';
+export default NextAuth({
    *   logger: {
    *     error(code, ...message) {
    *       log.error(code, message)

--- a/packages/core/src/lib/utils/actions.ts
+++ b/packages/core/src/lib/utils/actions.ts
@@ -1,0 +1,16 @@
+import type { AuthAction } from "../../types.js"
+
+const actions: AuthAction[] = [
+  "providers",
+  "session",
+  "csrf",
+  "signin",
+  "signout",
+  "callback",
+  "verify-request",
+  "error",
+]
+
+export function isAuthAction(action: string): action is AuthAction {
+  return actions.includes(action as AuthAction)
+}

--- a/packages/core/src/lib/utils/web.ts
+++ b/packages/core/src/lib/utils/web.ts
@@ -7,6 +7,7 @@ import type {
   RequestInternal,
   ResponseInternal,
 } from "../../types.js"
+import { isAuthAction } from "./actions.js"
 
 async function getBody(req: Request): Promise<Record<string, any> | undefined> {
   if (!("body" in req) || !req.body || req.method !== "POST") return
@@ -19,17 +20,6 @@ async function getBody(req: Request): Promise<Record<string, any> | undefined> {
     return Object.fromEntries(params)
   }
 }
-
-const actions: AuthAction[] = [
-  "providers",
-  "session",
-  "csrf",
-  "signin",
-  "signout",
-  "callback",
-  "verify-request",
-  "error",
-]
 
 export async function toInternalRequest(
   req: Request,
@@ -119,10 +109,6 @@ export function randomString(size: number) {
   return Array.from(bytes).reduce(r, "")
 }
 
-function isAction(action: string): action is AuthAction {
-  return actions.includes(action as AuthAction)
-}
-
 /** @internal Parse the action and provider id from a URL pathname. */
 export function parseActionAndProviderId(
   pathname: string,
@@ -145,7 +131,7 @@ export function parseActionAndProviderId(
 
   const [action, providerId] = b
 
-  if (!isAction(action))
+  if (!isAuthAction(action))
     throw new UnknownAction(`Cannot parse action at ${pathname}`)
 
   if (providerId && !["signin", "callback"].includes(action))


### PR DESCRIPTION
- isAuthAction is also used in `@auth/sveltekit` so this PR exports it to reuse . see #9714 