### PR TITLE
fix(sveltekit): re-export `SvelteKitAuthConfig`

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -242,6 +242,8 @@ export type {
   User,
 } from "@auth/core/types"
 
+export type { SvelteKitAuthConfig }
+
 const authorizationParamsPrefix = "authorizationParams-"
 
 /**


### PR DESCRIPTION
`SvelteKitAuthConfig` was mistakenly removed from the public export, this adds it back 