### PR TITLE
chore: improve Zitadel Provider

### DIFF
--- a/packages/core/src/providers/zitadel.ts
+++ b/packages/core/src/providers/zitadel.ts
@@ -111,7 +111,7 @@ export interface ZitadelProfile extends Record<string, any> {
  *
  * :::
  */
-export default function ZITADEL<P extends ZitadelProfile>(
+export default function Zitadel<P extends ZitadelProfile>(
   options: OAuthUserConfig<P>
 ): OIDCConfig<P> {
   return {


### PR DESCRIPTION
## ☕️ Reasoning

All the other Providers are using `PascalCase` while this one is all uppercase, causing some IDEs to import the default export as `ZITADEL` instead of `Zitadel`

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged