### PR TITLE
fix: ignore `/` for `NEXTAUTH_URL` path, infer `NEXTAUTH_SECRET`

### DIFF
--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -15,12 +15,17 @@ export function reqWithEnvURL(req: NextRequest): NextRequest {
  * For backwards compatibility, `next-auth` checks for `NEXTAUTH_URL`
  * and the `basePath` by default is `/api/auth` instead of `/auth`
  * (which is the default for all other Auth.js integrations).
+ *
+ * For the same reason, `NEXTAUTH_SECRET` is also checked.
  */
 export function setEnvDefaults(config: NextAuthConfig) {
   try {
+    config.secret ??= process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET
     const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL
     if (!url) return
-    config.basePath ||= new URL(url).pathname
+    const { pathname } = new URL(url)
+    if (pathname === "/") return
+    config.basePath ||= pathname
   } catch {
   } finally {
     config.basePath ||= "/api/auth"


### PR DESCRIPTION
If you want `basePath` to be the root (eg `/`), you can set the `basePath` config option instead.

This fixes the issue where people unnecessarily have `NEXTAUTH_URL=http://localhost:3000` or `AUTH_URL=http://localhost:3000` set, which has not been needed for a very long time. But to keep things non-breaking, we will keep supporting this format.

At some point, we could add a warning when we don't detect a `pathname` on these values to nudge people to drop it, or change it to the correct `http://localhost:3000/api/auth` format instead.