### PR TITLE
Update github.ts

### DIFF
--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -43,6 +43,7 @@ export interface GitHubProfile {
   blog: string | null
   location: string | null
   email: string | null
+  email_verified?: boolean
   hireable: boolean | null
   bio: string | null
   twitter_username?: string | null
@@ -163,8 +164,10 @@ export default function GitHub(
           })
 
           if (res.ok) {
-            const emails: GitHubEmail[] = await res.json()
-            profile.email = (emails.find((e) => e.primary) ?? emails[0]).email
+            const emails: GithubEmail[] = await res.json();
+            const githubEmail = emails.find((e) => e.primary) ?? emails[0];
+            profile.email = githubEmail!.email;
+            profile.email_verified = githubEmail!.verified;
           }
         }
 


### PR DESCRIPTION
## ☕️ Reasoning

This PR addresses an inconsistency in the GitHub provider within NextAuth.js. Currently, the GitHub provider fails to expose the email_verified status provided by GitHub, even though this information is readily available in the API response. This change will add the email_verified field to the GitHubProfile interface and expose it in the provider's user information.

## 🧢 Checklist
[ ] Documentation (No significant documentation changes were required)
[ ] Tests (Existing tests should cover the changed behavior, potential for adding more if needed)
[x] Ready to be merged

## 🎫 Affected issues

https://github.com/nextauthjs/next-auth/issues/10013