### PR TITLE
Updated line 12 npm outdated command - npm install @prisma/client @ne…

### DIFF
--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -9,7 +9,7 @@
  * ## Installation
  *
  * ```bash npm2yarn
- * npm install @prisma/client @auth/prisma-adapter
+ * npm install @prisma/client @next-auth/prisma-adapter
  * npm install prisma --save-dev
  * ```
  *


### PR DESCRIPTION
…xt-auth/prisma-adapter

i installed wrong version of next-auth multiple times before knowing that npm command use outdated as of my knowledge

outdated version - 
npm install @prisma/client @auth/prisma-adapter

corrected version -
npm install @prisma/client @next-auth/prisma-adapter

please accept my changes if its correct or if my version is not correct please make the required changes it annoying to download wrong version cause of the outdated documentation thanks





i have just fixed npm command in line 12 of file so i am not writing big detailed description i am new sorry for that please guide me if you want anything else thanks