### PR TITLE
fix(ts): update `AppRouteHandlerFn` type to handle `null` response from middleware handler

### DIFF
--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -21,7 +21,7 @@ export type AppRouteHandlerFn = (
    * dynamic route).
    */
   ctx: AppRouteHandlerFnContext
-) => void | Response | Promise<void | Response>
+) => void | null | Response | Promise<void | Response>
 
 export type AppRouteHandlers = Record<
   "GET" | "POST",


### PR DESCRIPTION
## ☕️ Reasoning
In NextAuth Function in Middleware type null does not contain in overload
>  ### Before code updation 👇
<img width="385" alt="Screenshot 2024-02-17 at 4 52 19 AM" src="https://github.com/nextauthjs/next-auth/assets/53529358/c197becf-a725-4697-b6f4-e044ae6dfdd7">

> **Type Error:** No overload matches this call.

**Allow Null Return Value:** The AppRouteHandlerFnContext type now includes null as a valid return value. This addresses the error:  No overload matches this call : " Type 'null' is not assignable to type 'void | Response | Promise<void | Response>'"

>  ### After code updation 👇
<img width="499" alt="Screenshot 2024-02-17 at 5 13 00 AM" src="https://github.com/nextauthjs/next-auth/assets/53529358/2ce29ce7-75d7-43be-ae1b-b17327abe852">


## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
Fixed: #10047 

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
