### PR TITLE
fix(sveltekit): update server-side "SignIn" and "SignOut" button components

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/components/SignIn.svelte
+++ b/packages/frameworks-sveltekit/src/lib/components/SignIn.svelte
@@ -3,7 +3,7 @@
   import type { signIn } from "$lib/actions"
 
   export let className = ""
-  export let provider: Parameters<typeof signIn>[0]
+  export let provider: Partial<Parameters<typeof signIn>[0]> = ""
   /** The path to the FormAction file in your route. @default signin */
   export let signInPage = "signin"
   export let options: Parameters<typeof signIn>[1] | undefined = undefined
@@ -59,7 +59,7 @@
       />
     </slot>
   {/if}
-  <button style="width: 100%" type="submit"
-    ><slot name="submitButton">Sign in with {provider}</slot></button
-  >
+  <button type="submit">
+    <slot name="submitButton">Signin{provider ? `with ${provider}` : ""}</slot>
+  </button>
 </form>

--- a/packages/frameworks-sveltekit/src/lib/components/SignOut.svelte
+++ b/packages/frameworks-sveltekit/src/lib/components/SignOut.svelte
@@ -23,5 +23,7 @@
       <input type="hidden" name="redirectTo" value={options.redirectTo} />
     {/if}
   {/if}
-  <button type="submit"><slot /></button>
+  <button type="submit">
+    <slot name="submitButton">Sign Out</slot>
+  </button>
 </form>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- Update `SignOut` button slot to match `SignIn` button's, named `submitButton`
- Make `SignIn` button's prop `provider` optional

**EDIT**:

Looks good in my editor now :tada: 

![image](https://github.com/nextauthjs/next-auth/assets/7415984/88e8663c-231d-4910-95fd-0af0f8fa3148)


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
