### PR TITLE
fix(docs): update example secret generation cmd for more entropy

### DIFF
--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -77,7 +77,7 @@ Not providing any `secret` or `NEXTAUTH_SECRET` will throw [an error](/errors#no
 You can quickly create a good value on the command line via this `openssl` command.
 
 ```bash
-$ openssl rand -base64 32
+$ openssl rand -base64 33
 ```
 
 :::tip


### PR DESCRIPTION
This is a documentation-only change that adjusts the recommended command for generating a secret to increase entropy and avoid the needless padding at the end of the output.

Due to the way base64 works, it produces 4 output characters for every 3 input bytes, but input lengths that are not evenly divisible by 3 wind up producing an output with padding characters (`=`) at the end of the output string. Asking for 32 bytes from `openssl rand` thus will always produce a base64 encoded value with a single `=` as padding at the end.

Asking `openssl rand` instead for 33 bytes of output increases the entropy and produces a base64 encoded length of 44 characters evenly without padding characters at the end of the string. This is a better recommendation, and it is quite common for this purpose.

For example: 

```
$ openssl rand 32 | btoa
# 6mahCn+mX6SchA3ZGfFCbrwf+BC+HHze0AGF9/5xZqE=
$ openssl rand 33 | btoa
# JFkmrfp8lANp44bbvCIyHPkCfv/V8cfeIBjiyXOjG8tS
```