### PR TITLE
chore(svelte): rm paragraph tag with many different children in docs example code

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -68,7 +68,7 @@
  * </script>
  *
  * <h1>SvelteKit Auth Example</h1>
- * <p>
+ * <div>
  *   {#if $page.data.session}
  *     {#if $page.data.session.user?.image}
  *       <span
@@ -87,7 +87,7 @@
  *     <SignIn provider="google"/>
  *     <SignIn provider="facebook"/>
  *   {/if}
- * </p>
+ * </div>
  * ```
  *
  * `<SignIn />` and `<SignOut />` are components that `@auth/sveltekit` provides out of the box - they handle the sign-in/signout flow, and can be used as-is as a starting point or customized for your own components.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- In this SvelteKit docs example code, we're using a `<p>` with a bunch of children, which will likely lead to hydration mismatches or errors regarding "tag X can't be a child of a paragraph tag..", etc. 
- Got here from: https://github.com/sveltejs/svelte/issues/10630

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
