### PR TITLE
chore(sveltekit): update more current docs to latest SvelteKitAuth API and finish example app migration to latest API

### DIFF
--- a/apps/dev/sveltekit/src/routes/+page.svelte
+++ b/apps/dev/sveltekit/src/routes/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { page } from "$app/stores"
-  import { SignIn, SignOut } from "@auth/sveltekit/components"
-  import { signIn, signOut } from "@auth/sveltekit/client"
+  import { SignIn } from "@auth/sveltekit/components"
+  import { signIn } from "@auth/sveltekit/client"
 
   let password = ""
 </script>

--- a/apps/examples/sveltekit/src/components/header.svelte
+++ b/apps/examples/sveltekit/src/components/header.svelte
@@ -17,7 +17,7 @@
           {$page.data.session.user?.email ?? $page.data.session.user?.name}
         </span>
         <SignOut>
-          <div class="buttonPrimary">Sign out</div>
+          <div slot="submitButton" class="buttonPrimary">Sign out</div>
         </SignOut>
       {:else}
         <span class="notSignedInText">You are not signed in</span>

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -60,8 +60,6 @@
  *
  * ### Server-side
  *
- * The data for the current session in this example was made available through the `$page` store. The `handle` function returned from `SvelteKitAuth()` and used in your `hooks.server.ts` will add an `auth()` method on your `events.locals` object, which is available in any `page.server.ts` or `layout.server.ts`. You should call `event.locals.auth()` to get the session data and return it from your `load` function to make it available in the `$page` store.
- *
  * `<SignIn />` and `<SignOut />` are components that `@auth/sveltekit` provides out of the box - they handle the sign-in/signout flow, and can be used as-is as a starting point or customized for your own components. This is an example of how to use the `SignIn` and `SignOut` components to login and logout using SvelteKit's server-side form actions. You will need two things to make this work:
  *
  * 1. Using the components in your SvelteKit app's frontend
@@ -224,8 +222,8 @@
  * import GitHub from '@auth/sveltekit/providers/github';
  *
  * export const { handle, signIn, signOut } = SvelteKitAuth({
- * 		providers: [GitHub]
- * 	}),
+ *   providers: [GitHub]
+ * }),
  * ```
  *
  * ```ts title="src/hooks.server.ts"
@@ -234,16 +232,16 @@
  * import { sequence } from '@sveltejs/kit/hooks';
  *
  * async function authorizationHandle({ event, resolve }) {
- * 	// Protect any routes under /authenticated
- * 	if (event.url.pathname.startsWith('/authenticated')) {
- *    const session = await event.locals.getSession();
- * 		if (!session) {
- * 			throw redirect(303, '/auth');
- * 		}
- * 	}
+ *   // Protect any routes under /authenticated
+ *   if (event.url.pathname.startsWith('/authenticated')) {
+ *     const session = await event.locals.getSession();
+ *     if (!session) {
+ *       throw redirect(303, '/auth');
+ *     }
+ *   }
  *
- * 	// If the request is still here, just proceed as normally
- * 	return resolve(event);
+ *   // If the request is still here, just proceed as normally
+ *   return resolve(event);
  * }
  *
  * // First handle authentication, then authorization

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -78,6 +78,7 @@
  *       <img
  *         src={$page.data.session.user.image}
  *         class="avatar"
+ *         alt="User Avatar"
  *       />
  *     {/if}
  *     <span class="signedInText">

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -237,7 +237,8 @@
  *   if (event.url.pathname.startsWith('/authenticated')) {
  *     const session = await event.locals.getSession();
  *     if (!session) {
- *       throw redirect(303, '/auth');
+ *       // Redirect to the signin page
+ *       throw redirect(303, '/auth/signin');
  *     }
  *   }
  *


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

1. Updates `sveltekit` example app to use the new `SignOut` button `submitButton` slot now that its shipped
2. Cleanup `@auth/sveltekit` jsdoc doc regarding "per-path" authentication + authorization using the new sveltekit API
3. Update current SvelteKitAuth docs regarding new SignIn / SignOut comopnents for server-side and the `@auth/sveltekit/client` exports `signIn` / `signOut` methods for cleint-side actions

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

Fixes: [10187](https://github.com/nextauthjs/next-auth/issues/10187)

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
