### PR TITLE
fix: export `CredentialsSignin` class to extend in custom authorize errors

### DIFF
--- a/packages/core/src/providers/credentials.ts
+++ b/packages/core/src/providers/credentials.ts
@@ -51,7 +51,9 @@ export interface CredentialsConfig<
    * @example
    * ```ts
    * async authorize(credentials, request) { // you have access to the original request as well
-   *   if(!isValidCredentials(credentials)) return null
+   *   if(!isValidCredentials(credentials)) {
+   *      throw new CustomError()
+   *   }
    *   return await getUser(credentials) // assuming it returns a User or null
    * }
    * ```

--- a/packages/frameworks-express/src/index.ts
+++ b/packages/frameworks-express/src/index.ts
@@ -128,6 +128,7 @@ import type { AuthConfig, Session } from "@auth/core/types"
 import * as e from "express"
 import { toWebRequest, toExpressResponse } from "./lib/index.js"
 
+export { AuthError, CredentialsSignin } from "@auth/core/errors"
 export type {
   Account,
   DefaultSession,

--- a/packages/frameworks-solid-start/src/index.ts
+++ b/packages/frameworks-solid-start/src/index.ts
@@ -19,6 +19,15 @@
 import { Auth } from "@auth/core"
 import type { AuthAction, AuthConfig, Session } from "@auth/core/types"
 
+export { AuthError, CredentialsSignin } from "@auth/core/errors"
+export type {
+  Account,
+  DefaultSession,
+  Profile,
+  Session,
+  User,
+} from "@auth/core/types"
+
 export interface SolidAuthConfig extends AuthConfig {
   /**
    * Defines the base path for the auth routes.

--- a/packages/frameworks-sveltekit/src/lib/index.ts
+++ b/packages/frameworks-sveltekit/src/lib/index.ts
@@ -288,6 +288,8 @@ import { setEnvDefaults } from "./env"
 import { auth, signIn, signOut } from "./actions"
 import { Auth, isAuthAction } from "@auth/core"
 
+export { AuthError, CredentialsSignin } from "@auth/core/errors"
+
 export type {
   Account,
   DefaultSession,

--- a/packages/next-auth/src/index.tsx
+++ b/packages/next-auth/src/index.tsx
@@ -82,7 +82,7 @@ import type {
 import type { AppRouteHandlerFn } from "./lib/types.js"
 import type { NextRequest } from "next/server"
 import type { NextAuthConfig, NextAuthRequest } from "./lib/index.js"
-export { AuthError } from "@auth/core/errors"
+export { AuthError, CredentialsSignin } from "@auth/core/errors"
 
 export type {
   Session,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- Extending https://github.com/nextauthjs/next-auth/pull/9871
- Explicitly shows throwing the custom error in the Credentials provider docs
- Exports the `CredentialsSignin` class you're meant to extend from each framework package, to avoid having to install `@auth/core` just for this.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
