### PR TITLE
fix(sveltekit): add space after provider name in SignIn btn

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/components/SignIn.svelte
+++ b/packages/frameworks-sveltekit/src/lib/components/SignIn.svelte
@@ -32,14 +32,14 @@
 >
   <input type="hidden" name="providerId" value={provider} />
   {#if callbackUrl}
-  <input type="hidden" name="callbackUrl" value={callbackUrl} />
+    <input type="hidden" name="callbackUrl" value={callbackUrl} />
   {/if}
   {#if redirect}
-  <input type="hidden" name="redirect" value={redirect} />
+    <input type="hidden" name="redirect" value={redirect} />
   {/if}
   {#if authorizationParamsInputs}
     {#each Object.entries(authorizationParamsInputs) as [key, value]}
-      <input type="hidden" name={`authorizationParams-${key}`} value={value} />
+      <input type="hidden" name={`authorizationParams-${key}`} {value} />
     {/each}
   {/if}
   {#if provider === "credentials"}
@@ -47,7 +47,10 @@
   {/if}
   {#if provider === "email" || provider === "sendgrid" || provider === "resend"}
     <slot name="email">
-      <label class="section-header" for={`input-email-for-${provider}-provider`}>
+      <label
+        class="section-header"
+        for={`input-email-for-${provider}-provider`}
+      >
         Email
       </label>
       <input
@@ -60,6 +63,6 @@
     </slot>
   {/if}
   <button type="submit">
-    <slot name="submitButton">Signin{provider ? `with ${provider}` : ""}</slot>
+    <slot name="submitButton">Signin{provider ? ` with ${provider}` : ""}</slot>
   </button>
 </form>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- Fix missing space in `SignIn` button label

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
