### PR TITLE
chore(docs): fix oauth-tutorial link

### DIFF
--- a/docs/docs/getting-started/providers/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/providers/oauth-tutorial.mdx
@@ -113,7 +113,7 @@ export default function App({
 Instances of `useSession` (more on it in the next section) will have access to the session data and status. The `<SessionProvider />` also keep the session updated and synced between browser tabs and windows. 💪🏽
 
 :::tip
-Check our [client docs](reference/nextjs/react/) to learn all the available options for handling sessions on the browser.
+Check our [client docs](/) to learn all the available options for handling sessions on the browser.
 :::
 
 ### Consuming the session via hooks

--- a/docs/docs/getting-started/providers/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/providers/oauth-tutorial.mdx
@@ -113,7 +113,7 @@ export default function App({
 Instances of `useSession` (more on it in the next section) will have access to the session data and status. The `<SessionProvider />` also keep the session updated and synced between browser tabs and windows. 💪🏽
 
 :::tip
-Check our [client docs](/) to learn all the available options for handling sessions on the browser.
+Check our [client docs](https://authjs.dev/reference/nextjs/react) to learn all the available options for handling sessions on the browser.
 :::
 
 ### Consuming the session via hooks

--- a/docs/docs/getting-started/providers/oauth-tutorial.mdx
+++ b/docs/docs/getting-started/providers/oauth-tutorial.mdx
@@ -113,7 +113,7 @@ export default function App({
 Instances of `useSession` (more on it in the next section) will have access to the session data and status. The `<SessionProvider />` also keep the session updated and synced between browser tabs and windows. 💪🏽
 
 :::tip
-Check our [client docs](https://authjs.dev/reference/nextjs/react) to learn all the available options for handling sessions on the browser.
+Check our [client docs](/reference/nextjs/react) to learn all the available options for handling sessions on the browser.
 :::
 
 ### Consuming the session via hooks


### PR DESCRIPTION
The link leads to a not-found site.
## ☕️ Reasoning

- The redirected site does not reach any point.
- I directed you to the site you want to go to.

## 🧢 Checklist

- 
He doesn't think these are necessary since it's not a big problem. I am adding the necessary picture for the result.

![not-found](https://github.com/nextauthjs/next-auth/assets/150898451/f068f77a-3a4c-4161-9976-36edbf10a17f)

