### PR TITLE
fix: pages configuration

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -184,8 +184,7 @@ export async function Auth(
 
     const pageKind = (isAuthError && error.kind) || "error"
     const pagePath =
-      config.pages?.[pageKind] ??
-      `/${config.basePath}/${pageKind.toLowerCase()}`
+      config.pages?.[pageKind] ?? `${config.basePath}/${pageKind.toLowerCase()}`
     const url = `${internalRequest.url.origin}${pagePath}?${params}`
 
     if (isRedirect) return Response.json({ url })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,8 +183,10 @@ export async function Auth(
     if (error instanceof CredentialsSignin) params.set("code", error.code)
 
     const pageKind = (isAuthError && error.kind) || "error"
-    const pagePath = config.pages?.[pageKind] ?? `/${pageKind.toLowerCase()}`
-    const url = `${internalRequest.url.origin}${config.basePath}${pagePath}?${params}`
+    const pagePath =
+      config.pages?.[pageKind] ??
+      `/${config.basePath}/${pageKind.toLowerCase()}`
+    const url = `${internalRequest.url.origin}${pagePath}?${params}`
 
     if (isRedirect) return Response.json({ url })
     return Response.redirect(url)

--- a/packages/core/test/actions/callback.test.ts
+++ b/packages/core/test/actions/callback.test.ts
@@ -3,6 +3,7 @@ import * as jose from "jose"
 import * as o from "oauth4webapi"
 
 import GitHub from "../../src/providers/github.js"
+import Credentials from "../../src/providers/credentials.js"
 
 import { makeAuthRequest } from "../utils.js"
 
@@ -65,4 +66,22 @@ describe("assert GET callback action", () => {
       `https://login.example.com?state=${encodedState}`
     )
   })
+})
+
+it("should redirect to the custom error page is custom error page is defined", async () => {
+  const { response } = await makeAuthRequest({
+    action: "callback",
+    path: "/credentials",
+    config: {
+      pages: {
+        error:'/custom/error'
+      },
+      providers: [Credentials],
+    },
+  })
+
+  expect(response.status).toEqual(302)
+  expect(response.headers.get("location")).toEqual(
+    `https://authjs.test/custom/error?error=Configuration`
+  )
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Currently, in the latest next-auth v5, if you customize the error page to `/auth/error` in the `pages` config, next-auth will redirect to `http://localhost:3000/api/auth/auth/error` instead of `http://localhost:3000/auth/error`

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: #10289

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
