### PR TITLE
fix: throw `MissingSecret` when secret missing

### DIFF
--- a/packages/core/src/lib/utils/env.ts
+++ b/packages/core/src/lib/utils/env.ts
@@ -1,4 +1,5 @@
 import type { AuthAction, AuthConfig } from "../../types.js"
+import { MissingSecret } from "../../errors.js"
 
 /** Set default env variables on the config object */
 export function setEnvDefaults(envObject: any, config: AuthConfig) {
@@ -18,6 +19,12 @@ export function setEnvDefaults(envObject: any, config: AuthConfig) {
       const secret = envObject[`AUTH_SECRET_${i}`]
       if (secret) config.secret.unshift(secret)
     }
+  }
+
+  if (!config.secret?.length) {
+    throw new MissingSecret(
+      "Missing secret, please set AUTH_SECRET or config.secret"
+    )
   }
 
   config.redirectProxyUrl ??= envObject.AUTH_REDIRECT_PROXY_URL

--- a/packages/core/test/env.test.ts
+++ b/packages/core/test/env.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 describe("config is inferred from environment variables", () => {
   it("providers (client id, client secret, issuer, api key)", () => {
     const env = {
+      AUTH_SECRET: "asdf",
       AUTH_AUTH0_ID: "asdf",
       AUTH_AUTH0_SECRET: "fdsa",
       AUTH_AUTH0_ISSUER: "https://example.com",
@@ -55,19 +56,22 @@ describe("config is inferred from environment variables", () => {
   })
 
   it("AUTH_REDIRECT_PROXY_URL", () => {
-    const env = { AUTH_REDIRECT_PROXY_URL: "http://example.com" }
+    const env = {
+      AUTH_REDIRECT_PROXY_URL: "http://example.com",
+      AUTH_SECRET: "asdf",
+    }
     setEnvDefaults(env, authConfig)
     expect(authConfig.redirectProxyUrl).toBe(env.AUTH_REDIRECT_PROXY_URL)
   })
 
   it("AUTH_URL", () => {
-    const env = { AUTH_URL: "http://n/api/auth" }
+    const env = { AUTH_URL: "http://n/api/auth", AUTH_SECRET: "asdf" }
     setEnvDefaults(env, authConfig)
     expect(authConfig.basePath).toBe("/api/auth")
   })
 
   it("AUTH_URL + prefer config", () => {
-    const env = { AUTH_URL: "http://n/api/auth" }
+    const env = { AUTH_URL: "http://n/api/auth", AUTH_SECRET: "asdf" }
     const fromConfig = "/basepath-from-config"
     authConfig.basePath = fromConfig
     setEnvDefaults(env, authConfig)
@@ -75,17 +79,20 @@ describe("config is inferred from environment variables", () => {
   })
 
   it("AUTH_URL, but invalid value", () => {
-    const env = { AUTH_URL: "secret" }
+    const env = { AUTH_URL: "secret", AUTH_SECRET: "asdf" }
     setEnvDefaults(env, authConfig)
     expect(authConfig.basePath).toBe("/auth")
   })
 
   it.each([
-    [{ AUTH_TRUST_HOST: "1" }, { trustHost: true }],
-    [{ VERCEL: "1" }, { trustHost: true }],
-    [{ NODE_ENV: "development" }, { trustHost: true }],
-    [{ NODE_ENV: "test" }, { trustHost: true }],
-    [{ AUTH_URL: "http://example.com" }, { trustHost: true }],
+    [{ AUTH_TRUST_HOST: "1", AUTH_SECRET: "asdf" }, { trustHost: true }],
+    [{ VERCEL: "1" }, { trustHost: true, secret: "asdf" }],
+    [{ NODE_ENV: "development", AUTH_SECRET: "asdf" }, { trustHost: true }],
+    [{ NODE_ENV: "test" }, { trustHost: true, secret: "asdf" }],
+    [
+      { AUTH_URL: "http://example.com", AUTH_SECRET: "asdf" },
+      { trustHost: true },
+    ],
   ])(`%j`, (env, expected) => {
     setEnvDefaults(env, authConfig)
     expect(authConfig).toMatchObject(expected)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.
- See also Tim's msg in the slack

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- We had thrown `MissingSecret` if `config.secret` wasn't set, but not early enough in the flow, so a missing `AUTH_SECRET` got through in early signin and threw a mysterious error when passed to hkdf
- Added another throw of this error if `AUTH_SECRET` isn't set in our core `setEnvDefaults` fn, since that's the only core place where one of `config.secret` or `AUTH_SECRET` should definitely have been set already. If you know a better place for it I'm all ears though 👍 

Previous error msg on missing `AUTH_SECRET`:

![image](https://github.com/nextauthjs/next-auth/assets/7415984/719605c4-8443-4bfa-91fb-923f49901e90)

New error msg:

![image](https://github.com/nextauthjs/next-auth/assets/7415984/e3065d19-d505-42c8-a9b8-75f81e5ae1db)



## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
