### PR TITLE
fix(fauna): support custom collection names

### DIFF
--- a/packages/adapter-fauna/fauna/account.fsl
+++ b/packages/adapter-fauna/fauna/account.fsl
@@ -6,3 +6,13 @@ collection Account {
         terms [.provider, .providerAccountId]
     }
 }
+
+collection CustomAccount {
+    index byUserId {
+        terms [.userId]
+    }
+    index byProviderAndProviderAccountId {
+        terms [.provider, .providerAccountId]
+    }
+}
+

--- a/packages/adapter-fauna/fauna/session.fsl
+++ b/packages/adapter-fauna/fauna/session.fsl
@@ -7,3 +7,14 @@ collection Session {
         terms [.userId]
     }
 }
+
+collection CustomSession {
+    unique [.sessionToken]
+    index bySessionToken {
+        terms [.sessionToken]
+    }
+    index byUserId {
+        terms [.userId]
+    }
+}
+

--- a/packages/adapter-fauna/fauna/user.fsl
+++ b/packages/adapter-fauna/fauna/user.fsl
@@ -4,3 +4,10 @@ collection User {
         terms [.email]
     }
 }
+
+collection CustomUser {
+    unique [.email]
+    index byEmail {
+        terms [.email]
+    }
+}

--- a/packages/adapter-fauna/fauna/verificationToken.fsl
+++ b/packages/adapter-fauna/fauna/verificationToken.fsl
@@ -3,3 +3,10 @@ collection VerificationToken {
         terms [.identifier, .token]
     }
 }
+
+collection CustomVerificationToken {
+    index byIdentifierAndToken {
+        terms [.identifier, .token]
+    }
+}
+

--- a/packages/adapter-fauna/package.json
+++ b/packages/adapter-fauna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/fauna-adapter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Fauna Adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-fauna/src/index.ts
+++ b/packages/adapter-fauna/src/index.ts
@@ -225,37 +225,33 @@ const defaultCollectionNames = {
  **/
 export function FaunaAdapter(client: Client, config?: AdapterConfig): Adapter {
   const { collectionNames = defaultCollectionNames } = config || {}
-  const User = new Module(collectionNames.user)
-  const Session = new Module(collectionNames.session)
-  const Account = new Module(collectionNames.account)
-  const VerificationToken = new Module(collectionNames.verificationToken)
 
   return {
     async createUser(user) {
       const response = await client.query<FaunaUser>(
-        fql`${User}.create(${format.to(user)})`,
+        fql`Collection(${collectionNames.user}).create(${format.to(user)})`,
       )
       return format.from(response.data)
     },
     async getUser(id) {
       const response = await client.query<FaunaUser | NullDocument>(
-        fql`${User}.byId(${id})`,
+        fql`Collection(${collectionNames.user}).byId(${id})`,
       )
       if (response.data instanceof NullDocument) return null
       return format.from(response.data)
     },
     async getUserByEmail(email) {
       const response = await client.query<FaunaUser>(
-        fql`${User}.byEmail(${email}).first()`,
+        fql`Collection(${collectionNames.user}).byEmail(${email}).first()`,
       )
       if (response.data === null) return null
       return format.from(response.data)
     },
     async getUserByAccount({ provider, providerAccountId }) {
       const response = await client.query<FaunaUser>(fql`
-        let account = ${Account}.byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first()
+        let account = Collection(${collectionNames.account}).byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first()
         if (account != null) {
-          ${User}.byId(account.userId)
+          Collection(${collectionNames.user}).byId(account.userId)
         } else {
           null
         }
@@ -266,39 +262,39 @@ export function FaunaAdapter(client: Client, config?: AdapterConfig): Adapter {
       const _user: Partial<AdapterUser> = { ...user }
       delete _user.id
       const response = await client.query<FaunaUser>(
-        fql`${User}.byId(${user.id}).update(${format.to(_user)})`,
+        fql`Collection(${collectionNames.user}).byId(${user.id}).update(${format.to(_user)})`,
       )
       return format.from(response.data)
     },
     async deleteUser(userId) {
       await client.query(fql`
         // Delete the user's sessions
-        ${Session}.byUserId(${userId}).forEach(session => session.delete())
+        Collection(${collectionNames.session}).byUserId(${userId}).forEach(session => session.delete())
         
         // Delete the user's accounts
-        ${Account}.byUserId(${userId}).forEach(account => account.delete())
+        Collection(${collectionNames.account}).byUserId(${userId}).forEach(account => account.delete())
         
         // Delete the user
-        ${User}.byId(${userId}).delete()
+        Collection(${collectionNames.user}).byId(${userId}).delete()
       `)
     },
     async linkAccount(account) {
       await client.query<FaunaAccount>(
-        fql`${Account}.create(${format.to(account)})`,
+        fql`Collection(${collectionNames.account}).create(${format.to(account)})`,
       )
       return account
     },
     async unlinkAccount({ provider, providerAccountId }) {
       const response = await client.query<FaunaAccount>(
-        fql`${Account}.byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first().delete()`,
+        fql`Collection(${collectionNames.account}).byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first().delete()`,
       )
       return format.from<AdapterAccount>(response.data)
     },
     async getSessionAndUser(sessionToken) {
       const response = await client.query<[FaunaUser, FaunaSession]>(fql`
-        let session = ${Session}.bySessionToken(${sessionToken}).first()
+        let session = Collection(${collectionNames.session}).bySessionToken(${sessionToken}).first()
         if (session != null) {
-          let user = ${User}.byId(session.userId)
+          let user = Collection(${collectionNames.user}).byId(session.userId)
           if (user != null) {
             [user, session]
           } else {
@@ -314,13 +310,13 @@ export function FaunaAdapter(client: Client, config?: AdapterConfig): Adapter {
     },
     async createSession(session) {
       await client.query<FaunaSession>(
-        fql`${Session}.create(${format.to(session)})`,
+        fql`Collection(${collectionNames.session}).create(${format.to(session)})`,
       )
       return session
     },
     async updateSession(session) {
       const response = await client.query<FaunaSession>(
-        fql`${Session}.bySessionToken(${
+        fql`Collection(${collectionNames.session}).bySessionToken(${
           session.sessionToken
         }).first().update(${format.to(session)})`,
       )
@@ -328,12 +324,12 @@ export function FaunaAdapter(client: Client, config?: AdapterConfig): Adapter {
     },
     async deleteSession(sessionToken) {
       await client.query(
-        fql`${Session}.bySessionToken(${sessionToken}).first().delete()`,
+        fql`Collection(${collectionNames.session}).bySessionToken(${sessionToken}).first().delete()`,
       )
     },
     async createVerificationToken(verificationToken) {
       await client.query<FaunaVerificationToken>(
-        fql`${VerificationToken}.create(${format.to(
+        fql`Collection(${collectionNames.verificationToken}).create(${format.to(
           verificationToken,
         )})`,
       )
@@ -341,12 +337,12 @@ export function FaunaAdapter(client: Client, config?: AdapterConfig): Adapter {
     },
     async useVerificationToken({ identifier, token }) {
       const response = await client.query<FaunaVerificationToken>(
-        fql`${VerificationToken}.byIdentifierAndToken(${identifier}, ${token}).first()`,
+        fql`Collection(${collectionNames.verificationToken}).byIdentifierAndToken(${identifier}, ${token}).first()`,
       )
       if (response.data === null) return null
       // Delete the verification token so it can only be used once
       await client.query(
-        fql`${VerificationToken}.byId(${response.data.id}).delete()`,
+        fql`Collection(${collectionNames.verificationToken}).byId(${response.data.id}).delete()`,
       )
       const _verificationToken: Partial<FaunaVerificationToken> = { ...response.data }
       delete _verificationToken.id

--- a/packages/adapter-fauna/src/index.ts
+++ b/packages/adapter-fauna/src/index.ts
@@ -14,7 +14,7 @@
  *
  * @module @auth/fauna-adapter
  */
-import { Client, TimeStub, fql, NullDocument, QueryValue, QueryValueObject } from "fauna"
+import { Client, TimeStub, fql, NullDocument, QueryValue, QueryValueObject, Module } from "fauna"
 
 import type {
   Adapter,
@@ -32,6 +32,22 @@ export type FaunaUser = ToFauna<AdapterUser>
 export type FaunaSession = ToFauna<AdapterSession>
 export type FaunaVerificationToken = ToFauna<VerificationToken> & { id: string }
 export type FaunaAccount = ToFauna<AdapterAccount>
+
+type AdapterConfig = {
+  collectionNames: {
+    user: string
+    session: string
+    account: string
+    verificationToken: string
+  }
+}
+
+const defaultCollectionNames = {
+  user: "User",
+  session: "Session",
+  account: "Account",
+  verificationToken: "VerificationToken",
+}
 
 /**
  *
@@ -136,6 +152,22 @@ export type FaunaAccount = ToFauna<AdapterAccount>
  *
  * > This schema is adapted for use in Fauna and based upon our main [schema](https://authjs.dev/reference/core/adapters#models)
  *
+ * #### Custom collection names
+ * If you want to use custom collection names, you can pass them as an option to the adapter, like this:
+ *
+ * ```javascript
+ * FaunaAdapter(client, {
+ *   collectionNames: {
+ *     user: "CustomUser",
+ *     account: "CustomAccount",
+ *     session: "CustomSession",
+ *     verificationToken: "CustomVerificationToken",
+ *   }
+ * })
+ * ```
+ *
+ * Make sure the collection names you pass to the provider match the collection names of your Fauna database.
+ *
  * ### Migrating from v1
  * In v2, we've renamed the collections to use uppercase naming, in accordance with Fauna best practices. If you're migrating from v1, you'll need to rename your collections to match the new naming scheme.
  * Additionally, we've renamed the indexes to match the new method-like index names.
@@ -191,33 +223,39 @@ export type FaunaAccount = ToFauna<AdapterAccount>
  * ```
  *
  **/
-export function FaunaAdapter(client: Client): Adapter {
+export function FaunaAdapter(client: Client, config?: AdapterConfig): Adapter {
+  const { collectionNames = defaultCollectionNames } = config || {}
+  const User = new Module(collectionNames.user)
+  const Session = new Module(collectionNames.session)
+  const Account = new Module(collectionNames.account)
+  const VerificationToken = new Module(collectionNames.verificationToken)
+
   return {
     async createUser(user) {
       const response = await client.query<FaunaUser>(
-        fql`User.create(${format.to(user)})`,
+        fql`${User}.create(${format.to(user)})`,
       )
       return format.from(response.data)
     },
     async getUser(id) {
       const response = await client.query<FaunaUser | NullDocument>(
-        fql`User.byId(${id})`,
+        fql`${User}.byId(${id})`,
       )
       if (response.data instanceof NullDocument) return null
       return format.from(response.data)
     },
     async getUserByEmail(email) {
       const response = await client.query<FaunaUser>(
-        fql`User.byEmail(${email}).first()`,
+        fql`${User}.byEmail(${email}).first()`,
       )
       if (response.data === null) return null
       return format.from(response.data)
     },
     async getUserByAccount({ provider, providerAccountId }) {
       const response = await client.query<FaunaUser>(fql`
-        let account = Account.byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first()
+        let account = ${Account}.byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first()
         if (account != null) {
-          User.byId(account.userId)
+          ${User}.byId(account.userId)
         } else {
           null
         }
@@ -228,39 +266,39 @@ export function FaunaAdapter(client: Client): Adapter {
       const _user: Partial<AdapterUser> = { ...user }
       delete _user.id
       const response = await client.query<FaunaUser>(
-        fql`User.byId(${user.id}).update(${format.to(_user)})`,
+        fql`${User}.byId(${user.id}).update(${format.to(_user)})`,
       )
       return format.from(response.data)
     },
     async deleteUser(userId) {
       await client.query(fql`
         // Delete the user's sessions
-        Session.byUserId(${userId}).forEach(session => session.delete())
+        ${Session}.byUserId(${userId}).forEach(session => session.delete())
         
         // Delete the user's accounts
-        Account.byUserId(${userId}).forEach(account => account.delete())
+        ${Account}.byUserId(${userId}).forEach(account => account.delete())
         
         // Delete the user
-        User.byId(${userId}).delete()
+        ${User}.byId(${userId}).delete()
       `)
     },
     async linkAccount(account) {
       await client.query<FaunaAccount>(
-        fql`Account.create(${format.to(account)})`,
+        fql`${Account}.create(${format.to(account)})`,
       )
       return account
     },
     async unlinkAccount({ provider, providerAccountId }) {
       const response = await client.query<FaunaAccount>(
-        fql`Account.byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first().delete()`,
+        fql`${Account}.byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first().delete()`,
       )
       return format.from<AdapterAccount>(response.data)
     },
     async getSessionAndUser(sessionToken) {
       const response = await client.query<[FaunaUser, FaunaSession]>(fql`
-        let session = Session.bySessionToken(${sessionToken}).first()
+        let session = ${Session}.bySessionToken(${sessionToken}).first()
         if (session != null) {
-          let user = User.byId(session.userId)
+          let user = ${User}.byId(session.userId)
           if (user != null) {
             [user, session]
           } else {
@@ -276,13 +314,13 @@ export function FaunaAdapter(client: Client): Adapter {
     },
     async createSession(session) {
       await client.query<FaunaSession>(
-        fql`Session.create(${format.to(session)})`,
+        fql`${Session}.create(${format.to(session)})`,
       )
       return session
     },
     async updateSession(session) {
       const response = await client.query<FaunaSession>(
-        fql`Session.bySessionToken(${
+        fql`${Session}.bySessionToken(${
           session.sessionToken
         }).first().update(${format.to(session)})`,
       )
@@ -290,12 +328,12 @@ export function FaunaAdapter(client: Client): Adapter {
     },
     async deleteSession(sessionToken) {
       await client.query(
-        fql`Session.bySessionToken(${sessionToken}).first().delete()`,
+        fql`${Session}.bySessionToken(${sessionToken}).first().delete()`,
       )
     },
     async createVerificationToken(verificationToken) {
       await client.query<FaunaVerificationToken>(
-        fql`VerificationToken.create(${format.to(
+        fql`${VerificationToken}.create(${format.to(
           verificationToken,
         )})`,
       )
@@ -303,12 +341,12 @@ export function FaunaAdapter(client: Client): Adapter {
     },
     async useVerificationToken({ identifier, token }) {
       const response = await client.query<FaunaVerificationToken>(
-        fql`VerificationToken.byIdentifierAndToken(${identifier}, ${token}).first()`,
+        fql`${VerificationToken}.byIdentifierAndToken(${identifier}, ${token}).first()`,
       )
       if (response.data === null) return null
       // Delete the verification token so it can only be used once
       await client.query(
-        fql`VerificationToken.byId(${response.data.id}).delete()`,
+        fql`${VerificationToken}.byId(${response.data.id}).delete()`,
       )
       const _verificationToken: Partial<FaunaVerificationToken> = { ...response.data }
       delete _verificationToken.id

--- a/packages/adapter-fauna/test/index.test.ts
+++ b/packages/adapter-fauna/test/index.test.ts
@@ -17,14 +17,11 @@ const client = new Client({
   endpoint: new URL("http://localhost:8443"),
 })
 
-const adapter = FaunaAdapter(client)
-
 runBasicTests({
-  adapter,
+  adapter: FaunaAdapter(client),
   db: {
     // UUID is not a valid ID in Fauna (see https://docs.fauna.com/fauna/current/reference/fql_reference/types#id)
     id: () => String(Math.floor(Math.random() * 10 ** 18)),
-    disconnect: async () => client.close(),
     user: async (id) => {
       const response = await client.query<FaunaUser>(
         fql`User.byId(${id})`,
@@ -47,6 +44,48 @@ runBasicTests({
     async verificationToken({ identifier, token }) {
       const response = await client.query<FaunaVerificationToken>(
         fql`VerificationToken.byIdentifierAndToken(${identifier}, ${token}).first()`,
+      )
+      const _verificationToken: Partial<FaunaVerificationToken> = { ...response.data }
+      delete _verificationToken.id
+      return format.from(_verificationToken)
+    },
+  },
+})
+
+runBasicTests({
+  adapter: FaunaAdapter(client, {
+    collectionNames: {
+      user: "CustomUser",
+      account: "CustomAccount",
+      session: "CustomSession",
+      verificationToken: "CustomVerificationToken",
+    }
+  }),
+  db: {
+    // UUID is not a valid ID in Fauna (see https://docs.fauna.com/fauna/current/reference/fql_reference/types#id)
+    id: () => String(Math.floor(Math.random() * 10 ** 18)),
+    user: async (id) => {
+      const response = await client.query<FaunaUser>(
+        fql`CustomUser.byId(${id})`,
+      )
+      if (response.data instanceof NullDocument) return null
+      return format.from(response.data)
+    },
+    async session(sessionToken) {
+      const response = await client.query<FaunaSession>(
+        fql`CustomSession.bySessionToken(${sessionToken}).first()`,
+      )
+      return format.from(response.data)
+    },
+    async account({ provider, providerAccountId }) {
+      const response = await client.query<FaunaAccount>(
+        fql`CustomAccount.byProviderAndProviderAccountId(${provider}, ${providerAccountId}).first()`,
+      )
+      return format.from(response.data)
+    },
+    async verificationToken({ identifier, token }) {
+      const response = await client.query<FaunaVerificationToken>(
+        fql`CustomVerificationToken.byIdentifierAndToken(${identifier}, ${token}).first()`,
       )
       const _verificationToken: Partial<FaunaVerificationToken> = { ...response.data }
       delete _verificationToken.id

--- a/packages/adapter-fauna/test/test.sh
+++ b/packages/adapter-fauna/test/test.sh
@@ -10,8 +10,8 @@ docker run -d --rm \
   -p ${FAUNADB_PORT}:${FAUNADB_PORT} \
   fauna/faunadb
 
-echo "Waiting 10s for db to start..."
-sleep 10
+echo "Waiting 15s for db to start..."
+sleep 15
 
 # Create collections and indexes
 fauna schema push --url=http://localhost:8443 --force --secret=${FAUNA_ADMIN_KEY}


### PR DESCRIPTION
## ☕️ Reasoning

Some people may want to use custom auth collection names in their Fauna database. This PR adresses that need by accepting a config option in the Fauna provider with a `collectionNames` option, to which the custom collection names can be passed. The adapter will then use the passed collection names when accessing the auth documents from the Fauna database.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
