### PR TITLE
fix(core/providers/osu): Correct the type of OsuProfile.id

### DIFF
--- a/packages/core/src/providers/osu.ts
+++ b/packages/core/src/providers/osu.ts
@@ -14,7 +14,7 @@ export interface OsuUserCompact {
   avatar_url: string
   country_code: string
   default_group: string
-  id: string
+  id: number
   is_active: boolean
   is_bot: boolean
   is_deleted: boolean
@@ -125,7 +125,7 @@ export default function Osu<P extends OsuProfile>(
     userinfo: "https://osu.ppy.sh/api/v2/me",
     profile(profile) {
       return {
-        id: profile.id,
+        id: profile.id.toString(),
         email: null,
         name: profile.username,
         image: profile.avatar_url,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->
## ☕️ Reasoning

This PR changes the type of `id` on `OsuProfile` from `string` to `number`, as the osu! API returns a number. Before this, database errors would occur (i.e. ``Argument `providerAccountId`: Invalid value provided. Expected String, provided Int.``)

I couldn't run `lint`, `format`, or `tests` because they all just give me weird errors... hoping that there's a GitHub action that does the tests for me once I submit this.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged

## 🎫 Affected issues

None

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 