### PR TITLE
feat(email) allow for custom mail implementations

### DIFF
--- a/packages/core/src/providers/email.ts
+++ b/packages/core/src/providers/email.ts
@@ -30,8 +30,8 @@ export interface EmailConfig extends CommonProviderOptions {
   id: string
   type: EmailProviderType
   name: string
-  from: string
-  maxAge: number
+  from?: string
+  maxAge?: number
   sendVerificationRequest: (params: {
     identifier: string
     url: string
@@ -49,7 +49,7 @@ export interface EmailConfig extends CommonProviderOptions {
   server?: NodemailerConfig["server"]
   generateVerificationToken?: () => Awaitable<string>
   normalizeIdentifier?: (identifier: string) => string
-  options: EmailUserConfig
+  options?: EmailUserConfig
 }
 
 export type EmailUserConfig = Omit<Partial<EmailConfig>, "options" | "type">

--- a/packages/core/src/providers/nodemailer.ts
+++ b/packages/core/src/providers/nodemailer.ts
@@ -1,13 +1,13 @@
 import { createTransport } from "nodemailer"
-import { html, text } from "../lib/utils/email.js"
 import { AuthError } from "../errors.js"
+import { html, text } from "../lib/utils/email.js"
 
 import type { Transport, TransportOptions } from "nodemailer"
 import * as JSONTransport from "nodemailer/lib/json-transport/index.js"
 import * as SendmailTransport from "nodemailer/lib/sendmail-transport/index.js"
 import * as SESTransport from "nodemailer/lib/ses-transport/index.js"
-import * as SMTPTransport from "nodemailer/lib/smtp-transport/index.js"
 import * as SMTPPool from "nodemailer/lib/smtp-pool/index.js"
+import * as SMTPTransport from "nodemailer/lib/smtp-transport/index.js"
 import * as StreamTransport from "nodemailer/lib/stream-transport/index.js"
 import type { Awaitable, Theme } from "../types.js"
 import type { EmailConfig } from "./email.js"
@@ -40,7 +40,7 @@ export interface NodemailerConfig extends EmailConfig {
     theme: Theme
     request: Request
   }) => Awaitable<void>
-  options: NodemailerUserConfig
+  options?: NodemailerUserConfig
 }
 
 export type NodemailerUserConfig = Omit<


### PR DESCRIPTION
## ☕️ Reasoning

currently solutions using a custom configuration of `sendVerificationRequest` for the `nodemailer` provider still require a `server` config object passed even though it's type is not mandatory which is not need for implementations that for example use a sdk like `aws-ses` or `react-email`

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
