### PR TITLE
fix: `createActionURL` set detectedProtocol correctly

### DIFF
--- a/packages/core/src/lib/utils/env.ts
+++ b/packages/core/src/lib/utils/env.ts
@@ -76,8 +76,9 @@ export function createActionURL(
     const detectedHost = headers.get("x-forwarded-host") ?? headers.get("host")
     const detectedProtocol =
       headers.get("x-forwarded-proto") ?? protocol ?? "https"
-
-    url = new URL(`${detectedProtocol}://${detectedHost}`)
+    const _protocol = detectedProtocol.endsWith(":") ? detectedProtocol : detectedProtocol + ':'
+    
+    url = new URL(`${_protocol}//${detectedHost}`)
   }
 
   // remove trailing slash

--- a/packages/core/test/env.test.ts
+++ b/packages/core/test/env.test.ts
@@ -108,7 +108,7 @@ describe("config is inferred from environment variables", () => {
 })
 
 describe("createActionURL", () => {
-  const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => { })
+  const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 
   afterEach(() => {
     consoleWarnSpy.mockClear()
@@ -160,6 +160,56 @@ describe("createActionURL", () => {
         basePath: "/auth",
       },
       expected: "https://example.com/auth/signin",
+    },
+    {
+      args: {
+        action: "signin",
+        protocol: "http:",
+        headers: new Headers({
+          "x-forwarded-host": "example.com",
+        }),
+        env: {},
+        basePath: "/auth",
+      },
+      expected: "http://example.com/auth/signin",
+    },
+    {
+      args: {
+        action: "signin",
+        protocol: "https:",
+        headers: new Headers({
+          "x-forwarded-host": "example.com",
+        }),
+        env: {},
+        basePath: "/auth",
+      },
+      expected: "https://example.com/auth/signin",
+    },
+    {
+      args: {
+        action: "signin",
+        protocol: undefined,
+        headers: new Headers({
+          "x-forwarded-host": "example.com",
+          "x-forwarded-proto": "https:",
+        }),
+        env: {},
+        basePath: "/auth",
+      },
+      expected: "https://example.com/auth/signin",
+    },
+    {
+      args: {
+        action: "signin",
+        protocol: undefined,
+        headers: new Headers({
+          "x-forwarded-host": "example.com",
+          "x-forwarded-proto": "http:",
+        }),
+        env: {},
+        basePath: "/auth",
+      },
+      expected: "http://example.com/auth/signin",
     },
     {
       args: {

--- a/packages/core/test/env.test.ts
+++ b/packages/core/test/env.test.ts
@@ -191,7 +191,7 @@ describe("createActionURL", () => {
         protocol: undefined,
         headers: new Headers({
           "x-forwarded-host": "example.com",
-          "x-forwarded-proto": "https:",
+          "x-forwarded-proto": "https",
         }),
         env: {},
         basePath: "/auth",
@@ -204,7 +204,7 @@ describe("createActionURL", () => {
         protocol: undefined,
         headers: new Headers({
           "x-forwarded-host": "example.com",
-          "x-forwarded-proto": "http:",
+          "x-forwarded-proto": "http",
         }),
         env: {},
         basePath: "/auth",


### PR DESCRIPTION
## ☕️ Reasoning
the newest implementation of `createActionURL` occasionally throws ERR_INVALID_URL because of double colons in protocol

this fix just checks if the detectedProtocol ends with a colon, and if not it adds it before creating the url with the detected host

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
Fixes: #10408

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
