### PR TITLE
URL: protocol always ends with colon

### DIFF
--- a/packages/core/src/lib/utils/env.ts
+++ b/packages/core/src/lib/utils/env.ts
@@ -77,7 +77,7 @@ export function createActionURL(
     const detectedProtocol =
       headers.get("x-forwarded-proto") ?? protocol ?? "https"
 
-    url = new URL(`${detectedProtocol}://${detectedHost}`)
+    url = new URL(`${detectedProtocol}//${detectedHost}`)
   }
 
   // remove trailing slash


### PR DESCRIPTION
## ☕️ Reasoning

URL.protocol always ends with colon but the implementation adds another colon symbol, causing the URL constructor to throw invalid URL

See: https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol


