### PR TITLE
chore: fixes 404 error when visiting db adapters

### DIFF
--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -10,7 +10,7 @@
  * based session store (`strategy: "jwt"`),
  * but you can also use a database adapter to store the session in a database.
  *
- * Before you continue, Auth.js has a list of {@link https://authjs.dev/getting-started/adapters official database adapters}. If your database is listed there, you
+ * Before you continue, Auth.js has a list of {@link https://adapters.authjs.dev official database adapters}. If your database is listed there, you
  * probably do not need to create your own. If you are using a data solution that cannot be integrated with an official adapter, this module will help you create a compatible adapter.
  *
  * :::caution Note

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -10,7 +10,7 @@
  * based session store (`strategy: "jwt"`),
  * but you can also use a database adapter to store the session in a database.
  *
- * Before you continue, Auth.js has a list of {@link https://authjs.dev/reference/core/getting-started/adapters official database adapters}. If your database is listed there, you
+ * Before you continue, Auth.js has a list of {@link https://authjs.dev/getting-started/adapters official database adapters}. If your database is listed there, you
  * probably do not need to create your own. If you are using a data solution that cannot be integrated with an official adapter, this module will help you create a compatible adapter.
  *
  * :::caution Note


### PR DESCRIPTION
## ☕️ Reasoning

I wanted to fix the 404 error in the documentation.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Documentation points to database adapters, however, the current link leads to a 404 page