### PR TITLE
feat(providers): Add Postmark email provider

### DIFF
--- a/packages/core/src/providers/postmark.ts
+++ b/packages/core/src/providers/postmark.ts
@@ -1,0 +1,38 @@
+import type { EmailConfig, EmailUserConfig } from "./index.js"
+import { html, text } from "../lib/utils/email.js"
+
+/** @todo Document this */
+export default function Postmark(config: EmailUserConfig): EmailConfig {
+  return {
+    id: "postmark",
+    type: "email",
+    name: "Postmark",
+    from: "Auth.js <no-reply@authjs.dev>",
+    maxAge: 24 * 60 * 60,
+    async sendVerificationRequest(params) {
+      const { identifier: to, provider, url, theme } = params
+      const { host } = new URL(url)
+      if (!provider.apiKey) throw new TypeError("Missing Postmark API Key")
+      const res = await fetch("https://api.postmarkapp.com/email", {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-Postmark-Server-Token": provider.apiKey,
+        },
+        body: JSON.stringify({
+          From: provider.from,
+          To: to,
+          Subject: `Sign in to ${host}`,
+          TextBody: text({ url, host }),
+          HtmlBody: html({ url, host, theme }),
+          MessageStream: "outbound",
+        }),
+      })
+
+      if (!res.ok)
+        throw new Error("Postmark error: " + JSON.stringify(await res.json()))
+    },
+    options: config,
+  }
+}


### PR DESCRIPTION
### What
Add [Postmark](https://postmarkapp.com) support.

This only will require a single `AUTH_POSTMARK_KEY` to be set in addition to a database, and then you can use it as a passwordlss login option

### How

Similar to #9753