### PR TITLE
chore(docs): fix createUserSchema reference to signInSchema

### DIFF
--- a/docs/pages/getting-started/authentication/credentials.mdx
+++ b/docs/pages/getting-started/authentication/credentials.mdx
@@ -238,7 +238,7 @@ export const { handlers, auth } = NextAuth({
           let user = null
 
           const { email, password } =
-            await createUserSchema.parseAsync(credentials)
+            await signInSchema.parseAsync(credentials)
 
           // logic to salt and hash password
           const pwHash = saltAndHashPassword(password)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

The exported object from `./lib/zod.ts` is `signInSchema` and not `createUserSchema` as is used in the docs:

```./lib/zod.ts
// ./lib/zod.ts
import { TypeOf, object, string } from "zod"
 
export const signInSchema = object({
  email: string({ required_error: "Email is required" })
    .min(1, "Email is required")
    .email("Invalid email"),
  password: string({ required_error: "Password is required" })
    .min(1, "Password is required")
    .min(8, "Password must be more than 8 characters")
    .max(32, "Password must be less than 32 characters"),
})
```

I fixed the invalid `createUserSchema` reference to `signInSchema`.

Page containing the error: https://authjs.dev/getting-started/authentication/credentials

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
