### PR TITLE
fix: fix import path typo for middleware in Next.js installation example

### DIFF
--- a/docs/pages/getting-started/installation.mdx
+++ b/docs/pages/getting-started/installation.mdx
@@ -79,7 +79,7 @@ export const { GET, POST } = handlers
 Add Middleware to keep the session alive.
 
 ```ts filename="./middleware.ts"
-export { auth as middleware } from "auth"
+export { auth as middleware } from "@/auth"
 ```
 
   </Code.Next>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
The current docs show an import from "auth", potentially causing confusion on if the user is needing to install the package from npm. Updated to reference v5 auth.ts file in root of project.
## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
--> 