### PR TITLE
chore(docs): fix links to migrate-to-v5 page

### DIFF
--- a/packages/next-auth/src/index.tsx
+++ b/packages/next-auth/src/index.tsx
@@ -1,5 +1,5 @@
 /**
- * _If you are looking to migrate from v4, visit the [Upgrade Guide (v5)](https://authjs.dev/guides/upgrade-to-v5)._
+ * _If you are looking to migrate from v4, visit the [Upgrade Guide (v5)](https://authjs.dev/getting-started/migrating-to-v5)._
  *
  * ## Installation
  *

--- a/packages/next-auth/src/jwt.ts
+++ b/packages/next-auth/src/jwt.ts
@@ -1,6 +1,6 @@
 /**
  * :::warning Not recommended
- * In NextAuth.js v5 or newer, we recommend other authentication methods server-side. Read more at: https://authjs.dev/guides/upgrade-to-v5#authenticating-server-side
+ * In NextAuth.js v5 or newer, we recommend other authentication methods server-side. Read more at: https://authjs.dev/getting-started/migrating-to-v5#authenticating-server-side
  * :::
  *
  * @module jwt

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -74,7 +74,7 @@ async function getSession(headers: Headers, config: NextAuthConfig) {
     callbacks: {
       ...config.callbacks,
       // Since we are server-side, we don't need to filter out the session data
-      // See https://authjs.dev/guides/upgrade-to-v5/v5#authenticating-server-side
+      // See https://authjs.dev/getting-started/migrating-to-v5#authenticating-server-side
       // TODO: Taint the session data to prevent accidental leakage to the client
       // https://react.devreference/nextjs/react/experimental_taintObjectReference
       async session(...args) {

--- a/packages/next-auth/src/middleware.ts
+++ b/packages/next-auth/src/middleware.ts
@@ -1,6 +1,6 @@
 /**
  * :::warning Deprecated
- * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5#authenticating-server-side
+ * This module is replaced in v5. Read more at: https://authjs.dev/getting-started/migrating-to-v5#authenticating-server-side
  * :::
  *
  * @module middleware
@@ -9,7 +9,7 @@
 throw new ReferenceError(
   [
     '"next-auth/middleware" is deprecated. If you are not ready to migrate, keep using "next-auth@4".',
-    "Read more on https://authjs.dev/guides/upgrade-to-v5",
+    "Read more on https://authjs.dev/getting-started/migrating-to-v5",
   ].join("\n")
 )
 

--- a/packages/next-auth/src/next.ts
+++ b/packages/next-auth/src/next.ts
@@ -1,6 +1,6 @@
 /**
  * :::warning Deprecated
- * This module is replaced in v5. Read more at: https://authjs.dev/guides/upgrade-to-v5#authenticating-server-side
+ * This module is replaced in v5. Read more at: https://authjs.dev/getting-started/migrating-to-v5#authenticating-server-side
  * :::
  *
  * @module next
@@ -9,7 +9,7 @@
 throw new ReferenceError(
   [
     '"next-auth/next" is deprecated. If you are not ready to migrate, keep using "next-auth@4".',
-    "Read more on https://authjs.dev/guides/upgrade-to-v5",
+    "Read more on https://authjs.dev/getting-started/migrating-to-v5",
   ].join("\n")
 )
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The URL of the migration guide changed from https://authjs.dev/guides/upgrade-to-v5 to https://authjs.dev/getting-started/migrating-to-v5, but the docs still reference the old link, which results in a 404.

I fixed this by changing all links I could found.

It would maybe make sense to create a redirect for the old URL, in case the page is linked somewhere else. But I didn't do this here in case that's not desired, since it's not necessarily required.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests (n/a)
- [ ] Ready to be merged

## 🎫 Affected issues

none

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
