### PR TITLE
fix(core): use NEXTAUTH_URL when getting the url during initialization

### DIFF
--- a/packages/next-auth/src/core/init.ts
+++ b/packages/next-auth/src/core/init.ts
@@ -42,7 +42,7 @@ export async function init({
   options: InternalOptions
   cookies: cookie.Cookie[]
 }> {
-  const url = parseUrl(origin)
+  const url = parseUrl(process.env.NEXTAUTH_URL ?? origin)
 
   const secret = createSecret({ authOptions, url })
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

When using an oauth based authentication process and the app is configured with a `basePath`, we need to set the `NEXTAUTH_URL` environment variable to tell next-auth / auth.js the base authentication path. However, it does not seem to respect it in all scenarios. For example, I am running next-auth v4.24.7 with a basePath configured as `/sso` and a `NEXTAUTH_URL=http://localhost:3000/sso/api/auth`. When I perform a `signIn('keycloak')`, it does send me to my auth provider (keycloak) BUT the `redirect_uri` gets set to `http://localhost:3000/api/auth/callback` (note the missing `/sso` base path).

## 🧢 Checklist

- [ ] ~Documentation~
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

I _think_ this fixes the following issues (at least for users using v4...sounds like the v5 beta stuff has this issue too): 
* #10009
* #9984
* #8841

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
