### PR TITLE
chore(docs): fix getting-started Next.js framework link

### DIFF
--- a/docs/pages/getting-started/index.mdx
+++ b/docs/pages/getting-started/index.mdx
@@ -18,7 +18,7 @@ Select your framework of choice to get started, or view the example application 
 <div className="flex flex-wrap gap-2 justify-around items-start mt-8 mb-12 w-full">
   <div className="flex flex-col gap-2 group">
     <Link
-      href="/getting-started/installation?framework=nextjs"
+      href="/getting-started/installation?framework=next.js"
       className="flex relative flex-col flex-wrap justify-between items-center p-4 w-28 h-28 !no-underline rounded-lg border border-solid shadow-sm transition-colors duration-300 border-neutral-200 dark:border-neutral-800 dark:hover:bg-neutral-950 hover:bg-neutral-50"
     >
       <img


### PR DESCRIPTION
## ☕️ Reasoning

I was checking out the new docs and the link for Next in the "getting started" didn't work. This should fix it for now.

IMO, the way the "Code" component handles state with localStorage, strings, AND indexes is...rough. I suspect many more similar bugs will occur if not rewritten.

My recommended path for the future:
- Make definitions for all frameworks
```ts
type FrameworkSlug = "next" | "svelte" | "express";
type Framework = {
  name: string,
  slug: FrameworkSlug,
  component: JSX.Element
}

const NextJSAppRouter: Framework = {
  name: "Next.js",
  slug: "next",
  component: Code.Next
}
```
- Redefine `baseFrameworks` and `allFrameworks` to use ^
```ts
const baseFrameworks = [
NextJSAppRouter,
SvelteKit,
...
]
```
- Store the "slug" in localStorage instead of index
- Tie localStorage to react code more tightly (Jotai's [localStorage adapter](https://jotai.org/docs/guides/persistence) is a great example)

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
