### PR TITLE
fix(oauth-instructions): number alignment

### DIFF
--- a/docs/components/OAuthProviderInstructions/content/components/StepTitle.tsx
+++ b/docs/components/OAuthProviderInstructions/content/components/StepTitle.tsx
@@ -1,13 +1,16 @@
-import { ReactNode } from "react";
+import { ReactNode } from "react"
+import styles from "../overrides.module.css"
 
 interface Props {
-  children: ReactNode;
+  children: ReactNode
 }
 
 export function StepTitle({ children }: Props) {
   return (
-    <h3 className="font-semibold tracking-tight text-slate-900 dark:text-slate-100 mt-8 text-2xl">
+    <h3
+      className={`font-semibold tracking-tight text-slate-900 dark:text-slate-100 mt-8 text-2xl ${styles["step-title-align"]}`}
+    >
       {children}
     </h3>
-  );
+  )
 }

--- a/docs/components/OAuthProviderInstructions/content/components/StepTitle.tsx
+++ b/docs/components/OAuthProviderInstructions/content/components/StepTitle.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react"
-import styles from "../overrides.module.css"
 
 interface Props {
   children: ReactNode
@@ -8,7 +7,7 @@ interface Props {
 export function StepTitle({ children }: Props) {
   return (
     <h3
-      className={`font-semibold tracking-tight text-slate-900 dark:text-slate-100 mt-8 text-2xl ${styles["step-title-align"]}`}
+      className={`font-semibold tracking-tight text-slate-900 dark:text-slate-100 mt-8 text-2xl before:flex before:items-center before:justify-center before:!-mt-[1px]`}
     >
       {children}
     </h3>

--- a/docs/components/OAuthProviderInstructions/content/index.tsx
+++ b/docs/components/OAuthProviderInstructions/content/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 export function OAuthInstructions({ providerId, disabled = false }: Props) {
   const [highlighter, setHighlighter] = useState(null)
   useEffect(() => {
-    ; (async () => {
+    ;(async () => {
       const hl = await getHighlighter({
         themes: ["github-light", "github-dark"],
         langs: ["ts", "tsx", "bash"],

--- a/docs/components/OAuthProviderInstructions/content/overrides.module.css
+++ b/docs/components/OAuthProviderInstructions/content/overrides.module.css
@@ -1,8 +1,0 @@
-.step-title-align:before {
-  /* Make sure the number within the circle is aligned */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* Make sure circle is aligned against the title  */
-  margin-top: 1px !important;
-}

--- a/docs/components/OAuthProviderInstructions/content/overrides.module.css
+++ b/docs/components/OAuthProviderInstructions/content/overrides.module.css
@@ -1,0 +1,8 @@
+.step-title-align:before {
+  /* Make sure the number within the circle is aligned */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Make sure circle is aligned against the title  */
+  margin-top: 1px !important;
+}


### PR DESCRIPTION
## ☕️ Reasoning

### Before

<img width="600" alt="Screenshot 2024-04-14 at 11 00 16" src="https://github.com/nextauthjs/next-auth/assets/5938217/1f860652-c08e-4f60-8524-19bdd71f8b5f">

Number within the circle is misaligned.

### After

<img width="600" alt="Screenshot 2024-04-14 at 10 59 59" src="https://github.com/nextauthjs/next-auth/assets/5938217/82098cef-5b83-4af6-8016-da75709204c9">

Number is aligned...


## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

None

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
