### PR TITLE
fix: don't require secret at build-time

### DIFF
--- a/apps/dev/nextjs/.env.local.example
+++ b/apps/dev/nextjs/.env.local.example
@@ -5,7 +5,7 @@
 # https://generate-secret.vercel.app/32 to generate a secret.
 # Note: Changing a secret may invalidate existing sessions
 # and/or verification tokens.
-NEXTAUTH_SECRET=secret
+AUTH_SECRET=secret
 
 AUTH_ASGARDEO_CLIENT_ID=
 AUTH_ASGARDEO_CLIENT_SECRET=

--- a/apps/examples/nextjs/Dockerfile
+++ b/apps/examples/nextjs/Dockerfile
@@ -22,9 +22,7 @@ COPY . .
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
-# This should be replaced with an actual secret in production.
-# REVIEW: Can we make this not required during build?
-RUN AUTH_SECRET=dummy npm run build
+RUN npm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/packages/core/src/lib/utils/assert.ts
+++ b/packages/core/src/lib/utils/assert.ts
@@ -97,7 +97,7 @@ export function assertConfig(
     return new UntrustedHost(`Host must be trusted. URL was: ${request.url}`)
   }
 
-  if (!options.secret) {
+  if (!options.secret?.length) {
     return new MissingSecret("Please define a `secret`.")
   }
 

--- a/packages/core/src/lib/utils/env.ts
+++ b/packages/core/src/lib/utils/env.ts
@@ -23,12 +23,6 @@ export function setEnvDefaults(envObject: any, config: AuthConfig) {
     }
   }
 
-  if (!config.secret?.length) {
-    throw new MissingSecret(
-      "Missing secret, please set AUTH_SECRET or config.secret"
-    )
-  }
-
   config.redirectProxyUrl ??= envObject.AUTH_REDIRECT_PROXY_URL
   config.trustHost ??= !!(
     envObject.AUTH_URL ??

--- a/packages/core/test/env.test.ts
+++ b/packages/core/test/env.test.ts
@@ -26,7 +26,6 @@ beforeEach(() => {
 describe("config is inferred from environment variables", () => {
   it("providers (client id, client secret, issuer, api key)", () => {
     const env = {
-      AUTH_SECRET: "asdf",
       AUTH_AUTH0_ID: "asdf",
       AUTH_AUTH0_SECRET: "fdsa",
       AUTH_AUTH0_ISSUER: "https://example.com",
@@ -64,22 +63,19 @@ describe("config is inferred from environment variables", () => {
   })
 
   it("AUTH_REDIRECT_PROXY_URL", () => {
-    const env = {
-      AUTH_REDIRECT_PROXY_URL: "http://example.com",
-      AUTH_SECRET: "asdf",
-    }
+    const env = { AUTH_REDIRECT_PROXY_URL: "http://example.com" }
     setEnvDefaults(env, authConfig)
     expect(authConfig.redirectProxyUrl).toBe(env.AUTH_REDIRECT_PROXY_URL)
   })
 
   it("AUTH_URL", () => {
-    const env = { AUTH_URL: "http://n/api/auth", AUTH_SECRET: "asdf" }
+    const env = { AUTH_URL: "http://n/api/auth" }
     setEnvDefaults(env, authConfig)
     expect(authConfig.basePath).toBe("/api/auth")
   })
 
   it("AUTH_URL + prefer config", () => {
-    const env = { AUTH_URL: "http://n/api/auth", AUTH_SECRET: "asdf" }
+    const env = { AUTH_URL: "http://n/api/auth" }
     const fromConfig = "/basepath-from-config"
     authConfig.basePath = fromConfig
     setEnvDefaults(env, authConfig)
@@ -87,20 +83,17 @@ describe("config is inferred from environment variables", () => {
   })
 
   it("AUTH_URL, but invalid value", () => {
-    const env = { AUTH_URL: "secret", AUTH_SECRET: "asdf" }
+    const env = { AUTH_URL: "secret" }
     setEnvDefaults(env, authConfig)
     expect(authConfig.basePath).toBe("/auth")
   })
 
   it.each([
-    [{ AUTH_TRUST_HOST: "1", AUTH_SECRET: "asdf" }, { trustHost: true }],
-    [{ VERCEL: "1", AUTH_SECRET: "asdf" }, { trustHost: true }],
-    [{ NODE_ENV: "development", AUTH_SECRET: "asdf" }, { trustHost: true }],
-    [{ NODE_ENV: "test", AUTH_SECRET: "asdf" }, { trustHost: true }],
-    [
-      { AUTH_URL: "http://example.com", AUTH_SECRET: "asdf" },
-      { trustHost: true },
-    ],
+    [{ AUTH_TRUST_HOST: "1" }, { trustHost: true }],
+    [{ VERCEL: "1" }, { trustHost: true }],
+    [{ NODE_ENV: "development" }, { trustHost: true }],
+    [{ NODE_ENV: "test" }, { trustHost: true }],
+    [{ AUTH_URL: "http://example.com" }, { trustHost: true }],
   ])(`%j`, (env, expected) => {
     setEnvDefaults(env, authConfig)
     expect(authConfig).toMatchObject(expected)


### PR DESCRIPTION
Follow-up on https://github.com/nextauthjs/next-auth/pull/10305

`setEnvDefaults` might be invoked during build which started throwing an error in #10305.

This reverts the early check and makes sure that the runtime check correctly catches an unavailable secret value, avoiding the cryptic message shown in #10305

Fixes #10538