### PR TITLE
fix(next-auth): improve typing for using Dynamic Route Segments with auth()

### DIFF
--- a/packages/next-auth/src/index.tsx
+++ b/packages/next-auth/src/index.tsx
@@ -79,7 +79,7 @@ import type {
   NextApiRequest,
   NextApiResponse,
 } from "next"
-import type { AppRouteHandlerFn } from "./lib/types.js"
+import type { AppRouteHandlerFn, AppRouteHandlerFnContext } from "./lib/types.js"
 import type { NextRequest } from "next/server"
 import type { NextAuthConfig, NextAuthRequest } from "./lib/index.js"
 export { AuthError, CredentialsSignin } from "@auth/core/errors"
@@ -233,7 +233,7 @@ export interface NextAuthResult {
     ((...args: []) => Promise<Session | null>) &
     ((...args: [GetServerSidePropsContext]) => Promise<Session | null>) &
     ((
-      ...args: [(req: NextAuthRequest) => ReturnType<AppRouteHandlerFn>]
+      ...args: [(req: NextAuthRequest, ctx: AppRouteHandlerFnContext) => ReturnType<AppRouteHandlerFn>]
     ) => AppRouteHandlerFn)
   /**
    * Sign in with a provider. If no provider is specified, the user will be redirected to the sign in page.

--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from "next/server"
  * AppRouteHandlerFnContext is the context that is passed to the handler as the
  * second argument.
  */
-type AppRouteHandlerFnContext = {
+export type AppRouteHandlerFnContext = {
   params?: Record<string, string | string[]>
 }
 /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
all the plumbing to pass context is already in place,
but the typescript definition doesn't allow `context` to be passed.
this allows dynamic route segments to be used in auth-wrapped api routes without hacky typescript `as any` overrides.
    

<!-- What changes are being made? What feature/bug is being fixed here? -->
this simply adds the typescript typings that reflect what's already being done under the hood.
## 🧢 Checklist

- [x] Documentation (behavior hasn't changed, this is already expected behavior, as seen by confusion in the above issue)
- [x] Tests (behavior hasn't changed)
- [x] Ready to be merged (in my opinion, yes. i'm already using this patch locally and it works great.)

## 🎫 Affected issues
Fixes: https://github.com/nextauthjs/next-auth/issues/9344