### PR TITLE
fix(docs): add middleware prerequisite

### DIFF
--- a/docs/docs/configuration/nextjs.md
+++ b/docs/docs/configuration/nextjs.md
@@ -131,6 +131,8 @@ You must set the same secret in the middleware that you use in NextAuth. The eas
 
 Alternatively, you can provide the secret using the [`secret`](#secret) option in the middleware config.
 
+When using an adapter, you must set the [session strategy](/configuration/options#session) to `jwt`, because the middleware only supports jwt sessions.
+
 **We strongly recommend** replacing the `secret` value completely with this `NEXTAUTH_SECRET` environment variable.
 
 ### Basic usage

--- a/docs/docs/tutorials/securing-pages-and-api-routes.md
+++ b/docs/docs/tutorials/securing-pages-and-api-routes.md
@@ -56,9 +56,9 @@ export { default } from "next-auth/middleware"
 export const config = { matcher: ["/dashboard"] }
 ```
 
-For the time being, the `withAuth` middleware only supports `"jwt"` as [session strategy](https://next-auth.js.org/configuration/options#session).
+When using an adapter, you must set the [session strategy](/configuration/options#session) to `jwt`, because the middleware only supports jwt sessions.
 
-More details can be found [here](https://next-auth.js.org/configuration/nextjs#middleware).
+More details can be found [here](/configuration/nextjs#middleware).
 
 :::tip
 To include all `dashboard` nested routes (sub pages like `/dashboard/settings`, `/dashboard/profile`) you can pass `matcher: "/dashboard/:path*"` to `config`.


### PR DESCRIPTION
## ☕️ Reasoning

Currently, the Next.js middleware only supports the jwt session strategy. When using an adapter, the default session strategy is database. It is not well documented that you need to set the session strategy to jwt when using an adapter in order to use the middleware. I added this to the docs.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/10276

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
