### PR TITLE
fix(docs): credential provider broken links

### DIFF
--- a/packages/core/src/providers/credentials.ts
+++ b/packages/core/src/providers/credentials.ts
@@ -137,8 +137,7 @@ export type CredentialsProviderType = "Credentials"
  *   trustHost: true,
  * })
  * ```
- * @see [Username/Password Example](https://authjs.dev/guides/providers/credentials#example---username--password)
- * @see [Web3/Signin With Ethereum Example](https://authjs.dev/guides/providers/credentials#example---web3--signin-with-ethereum)
+ * @see [Credentials guide](https://authjs.dev/getting-started/authentication/credentials)
  */
 export default function Credentials<
   CredentialsInputs extends Record<string, CredentialInput> = Record<


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

There were two dead links in the `providers/credentials.ts` file. I've changed one of them to point to the [credentials provider page](https://authjs.dev/getting-started/providers/credentials) and removed the other which seems to be a dead reference.

## 🧢 Checklist

- [x ] Documentation
- [ ] Tests
- [ x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
