### PR TITLE
feat(adapter-pg): define foreign keys, use single queries

### DIFF
--- a/packages/adapter-pg/schema.sql
+++ b/packages/adapter-pg/schema.sql
@@ -1,4 +1,15 @@
-\set ON_ERROR_STOP true
+BEGIN TRANSACTION;
+
+CREATE TABLE users
+(
+  id SERIAL,
+  name VARCHAR(255),
+  email VARCHAR(255),
+  "emailVerified" TIMESTAMPTZ,
+  image TEXT,
+
+  PRIMARY KEY (id)
+);
 
 CREATE TABLE verification_token
 (
@@ -24,26 +35,18 @@ CREATE TABLE accounts
   session_state TEXT,
   token_type TEXT,
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  FOREIGN KEY ("userId") REFERENCES users(id) ON DELETE CASCADE
 );
 
 CREATE TABLE sessions
 (
-  id SERIAL,
+  "sessionToken" VARCHAR(255) NOT NULL,
   "userId" INTEGER NOT NULL,
   expires TIMESTAMPTZ NOT NULL,
-  "sessionToken" VARCHAR(255) NOT NULL,
 
-  PRIMARY KEY (id)
+  PRIMARY KEY ("sessionToken"),
+  FOREIGN KEY ("userId") REFERENCES users(id) ON DELETE CASCADE
 );
 
-CREATE TABLE users
-(
-  id SERIAL,
-  name VARCHAR(255),
-  email VARCHAR(255),
-  "emailVerified" TIMESTAMPTZ,
-  image TEXT,
-
-  PRIMARY KEY (id)
-);
+COMMIT;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

- Foreign keys are added linking `userId` to the `id` in `users` with cascading delete. The delete user query can now be a single one due to cascading deletes.
- The `id` in `sessions` is deleted and the primary key replaced with `sessionToken`, which needs to be unique anyways. Turning it into the primary key should also speed up `WHERE sessionToken` queries.
- Queries that were previously a `SELECT` then `UPDATE` are now a single `UPDATE` to ensure atomicity. This required creating a rather ugly `createParameterizedUpdate` function to only join together `key = $2` if it exists in the passed-in object. I was unable to figure out the right incantation of TypeScript types to make `createParameterizedUpdate` type-safe but happy to accept any suggestions to fix this.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
