### PR TITLE
Make broadcast channel a singleton to prevent unnecessary `/session` requests

### DIFF
--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -69,15 +69,22 @@ export const __NEXTAUTH: AuthClientConfig = {
   _getSession: () => {},
 }
 
+let broadcastChannel: BroadcastChannel | null = null
+
 function broadcast() {
-  if (typeof BroadcastChannel !== "undefined") {
-    return new BroadcastChannel("next-auth")
+  if (typeof BroadcastChannel === "undefined") {
+    return {
+      postMessage: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }
   }
-  return {
-    postMessage: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
+
+  if (broadcastChannel === null) {
+    broadcastChannel = new BroadcastChannel("next-auth")
   }
+
+  return broadcastChannel
 }
 
 // TODO:


### PR DESCRIPTION
## ☕️ Reasoning

Usually, posting a message to a `BroadcastChannel` should not trigger the `message` event within the same window. However, if there two (or more) `BroadcastChannel` instances within the same window, posting on one instance triggers the `message` event on all other instances.

Wrapping `new Broadcast("next-auth")` in a `broadcast()` function means that every `broadcast().postMessage(...)` call is done on a new instance. As a result, the `message` event listener, which sits on a different `BroadcastChannel` instance, calls `__NEXTAUTH._getSession` within the same window - even though `postMessage` was probably called by a `getSession` call in the first place.

Also, `broadcast().removeEventListener(...)` in `useEffect` does not have any effect since it isn't called on the `BroadcastChannel` instance on which `addEventListener` has been called. In React's `StrictMode` [all effects run twice](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development) in development, and since the `unsubscribe` isn't working, there are two event listeners firing for each message event.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
