### PR TITLE
fix: strip `code_verifier` from request body when the provider doesn't support PKCE

### DIFF
--- a/apps/dev/nextjs/auth.config.ts
+++ b/apps/dev/nextjs/auth.config.ts
@@ -49,14 +49,6 @@ export default {
       if (trigger === "update") token.name = session.user.name
       return token
     },
-    async session({ session, token }) {
-      return {
-        ...session,
-        user: {
-          ...token,
-        },
-      }
-    },
   },
   basePath: "/auth",
 } satisfies NextAuthConfig

--- a/apps/dev/nextjs/auth.config.ts
+++ b/apps/dev/nextjs/auth.config.ts
@@ -5,6 +5,7 @@ import Google from "next-auth/providers/google"
 import Facebook from "next-auth/providers/facebook"
 import Twitter from "next-auth/providers/twitter"
 import Keycloak from "next-auth/providers/keycloak"
+import LinkedIn from "next-auth/providers/linkedin"
 
 declare module "next-auth" {
   /**
@@ -41,6 +42,7 @@ export default {
     Keycloak,
     Facebook,
     Twitter,
+    LinkedIn,
   ].filter(Boolean) as NextAuthConfig["providers"],
   callbacks: {
     jwt({ token, trigger, session }) {

--- a/apps/dev/nextjs/components/header.tsx
+++ b/apps/dev/nextjs/components/header.tsx
@@ -16,7 +16,8 @@ export function Header({
       <div className={styles.signedInStatus}>
         <img
           src={
-            session?.user?.image ?? "https://source.boringavatars.com/beam/120"
+            session?.user?.image ??
+            "https://source.boringavatars.com/marble/120"
           }
           className={styles.avatar}
         />

--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -109,7 +109,18 @@ export async function handleOAuth(
     client,
     codeGrantParams,
     redirect_uri,
-    codeVerifier ?? "auth" // TODO: review fallback code verifier
+    codeVerifier ?? "auth", // TODO: review fallback code verifier,
+    {
+      [o.experimental_customFetch]: (...args) => {
+        if (
+          !provider.checks.includes("pkce") &&
+          args[1]?.body instanceof URLSearchParams
+        ) {
+          args[1].body.delete("code_verifier")
+        }
+        return fetch(...args)
+      },
+    }
   )
 
   if (provider.token?.conform) {

--- a/packages/core/src/providers/linkedin.ts
+++ b/packages/core/src/providers/linkedin.ts
@@ -79,14 +79,6 @@ export default function LinkedIn<P extends LinkedInProfile>(
     type: "oidc",
     client: { token_endpoint_auth_method: "client_secret_post" },
     issuer: "https://www.linkedin.com/oauth",
-    async profile(profile) {
-      return {
-        id: profile.sub,
-        name: profile.name,
-        email: profile.email,
-        image: profile.picture,
-      }
-    },
     style: { bg: "#069", text: "#fff" },
     checks: ["state"],
     options,

--- a/packages/core/src/providers/linkedin.ts
+++ b/packages/core/src/providers/linkedin.ts
@@ -88,6 +88,7 @@ export default function LinkedIn<P extends LinkedInProfile>(
       }
     },
     style: { bg: "#069", text: "#fff" },
+    checks: ["state"],
     options,
   }
 }


### PR DESCRIPTION
Fixes #8831

Some providers choke when there is a `code_verifier` param on a request that they cannot handle (like LinkedIn not supporting PKCE), even if this is not according to the spec. 

Per spec:
> The authorization server MUST ignore unrecognized request parameters.

https://datatracker.ietf.org/doc/html/rfc6749#section-3.2

> Servers that support PKCE are required to support "S256", and servers that do not support PKCE will simply ignore the unknown "code_verifier".

https://datatracker.ietf.org/doc/html/rfc7636#section-7.2

This PR strips the unwanted param if the provider is configured without `checks: ["pkce"]`