### PR TITLE
fix(next-auth): Add support for Next.js basePath configuration

### DIFF
--- a/docs/pages/getting-started/deployment.mdx
+++ b/docs/pages/getting-started/deployment.mdx
@@ -47,6 +47,29 @@ to `true`. This tells Auth.js to trust the `X-Forwarded-Host` header from the re
 
 This environment variable is mostly unnecessary with v5 as the host is inferred from the request headers. However, if you are using a different base path, you can set this environment variable as well. For example, `AUTH_URL=http://localhost:3000/web/auth` or `AUTH_URL=https://company.com/app1/auth`
 
+#### Using Next.js `basePath`
+
+If you have configured a `basePath` in your `next.config.js`, you must also set the `nextJsBasePath` option in your NextAuth.js configuration:
+
+```ts
+// next.config.js
+module.exports = { basePath: "/my-app" }
+
+// auth.ts
+export const { handlers, auth } = NextAuth({
+  basePath: "/my-app/api/auth",
+  nextJsBasePath: "/my-app", // Required when using Next.js basePath
+  // ...
+})
+```
+
+<Callout type="info">
+  The `nextJsBasePath` option is required because Next.js does not include the
+  basePath in the request URL when processing API routes. Without this
+  configuration, NextAuth.js will not be able to correctly handle authentication
+  requests.
+</Callout>
+
 ### `AUTH_REDIRECT_PROXY_URL`
 
 > **_NOTE:_** Some providers (eg Apple) do not support [redirect proxy](https://github.com/nextauthjs/next-auth/blob/3ec06842682a31e53fceabca701a362abda1e7dd/packages/core/src/lib/utils/providers.ts#L48) usage.

--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -3,25 +3,21 @@ import { NextRequest } from "next/server"
 import type { NextAuthConfig } from "./index.js"
 import { setEnvDefaults as coreSetEnvDefaults } from "@auth/core"
 
-/** Estimate the base path from the config and request pathname. */
-function estimateBasePath(configPathName: string, requestPathname: string): string | undefined {
-  const configSegments = configPathName.slice(1).split("/")
-  const requestSegments = requestPathname.slice(1).split("/")
-  if (configSegments[0] === requestSegments[0]) return undefined
+/** If Next.js base path is set, add it to the request's URL. */
+export function reqWithBasePathURL(
+  req: NextRequest,
+  config: NextAuthConfig
+): NextRequest {
+  if (!config.nextJsBasePath) return req
+  const url = new URL(req.nextUrl.href)
 
-  let i = 0
-  while (i < configSegments.length && i < requestSegments.length && configSegments[i] !== requestSegments[0]) {
-    i++
+  // Check if basePath is already included in the pathname
+  if (url.pathname.startsWith(config.nextJsBasePath + "/")) {
+    return req
   }
-  return "/" + configSegments.slice(0, i).join("/")
-}
 
-/** If next.js base path set, estimate the base path and add it to the request's URL. */
-export function reqWithBasePathURL(req: NextRequest, config: NextAuthConfig): NextRequest {
-  const { href, origin, pathname } = req.nextUrl
-  const estimatedBasePath = estimateBasePath(config.basePath || "/api/auth", pathname)
-  if (!estimatedBasePath) return req
-  return new NextRequest(href.replace(pathname, estimatedBasePath + pathname), req)
+  url.pathname = config.nextJsBasePath + url.pathname
+  return new NextRequest(url.toString(), req)
 }
 
 /** If `NEXTAUTH_URL` or `AUTH_URL` is defined, override the request's URL. */

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -3,7 +3,7 @@ import { Auth, createActionURL, type AuthConfig } from "@auth/core"
 import { headers } from "next/headers"
 // @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
 import { NextResponse } from "next/server"
-import { reqWithEnvURL } from "./env.js"
+import { reqWithBasePathURL, reqWithEnvURL } from "./env.js"
 
 import type { AuthAction, Awaitable, Session } from "@auth/core/types"
 import type {
@@ -234,7 +234,7 @@ async function handleAuth(
   config: NextAuthConfig,
   userMiddlewareOrRoute?: NextAuthMiddleware | AppRouteHandlerFn
 ) {
-  const request = reqWithEnvURL(args[0])
+  const request = reqWithBasePathURL(reqWithEnvURL(args[0]), config)
   const sessionResponse = await getSession(request.headers, config)
   const auth = await sessionResponse.json()
 

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -18,6 +18,24 @@ import type { NextFetchEvent, NextMiddleware, NextRequest } from "next/server"
 /** Configure NextAuth.js. */
 export interface NextAuthConfig extends Omit<AuthConfig, "raw"> {
   /**
+   * The base path configured in your Next.js application (next.config.js).
+   * If you have set `basePath` in your Next.js config, you must provide the same value here.
+   *
+   * @example
+   * ```ts
+   * // next.config.js
+   * module.exports = { basePath: "/my-app" }
+   *
+   * // auth.ts
+   * export const { handlers, auth } = NextAuth({
+   *   basePath: "/my-app/api/auth",
+   *   nextJsBasePath: "/my-app",
+   *   // ...
+   * })
+   * ```
+   */
+  nextJsBasePath?: string
+  /**
    * Callbacks are asynchronous functions you can use to control what happens when an auth-related action is performed.
    * Callbacks **allow you to implement access controls without a database** or to **integrate with external databases or APIs**.
    */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

When I add basePath configuration to Next.JS config, the API routes are broken.
If both AUTH_URL and NextAuth basePath configurations are empty,  NextAuth will look like it works correctly. But, OAuth redirects callback URI is omitted basePath, so will fail.

In case of settings with AUTH_URL with full path: http://localhost:3000/basepath/api/auth, or adding NextAuth basePath configuration like /basepath/api/auth, NextAuth will raise Unknown Action Error.

I’ve investigated this error and figured out that it is caused by the Next.JS specification or bug. NextAuth parses the NextRequest URL and creates an action with the request URL. But, Next.JS with basePath configuration reports that the URL does not contain basePath. The simple Next.JS project here reproduces this issue. 
 https://github.com/k3k8/nextjs-base-path-issue

This issue has been reported in the Next.JS repository, but has not yet received any responses from the members. (https://github.com/vercel/next.js/issues/60956)
I suspect that the Next.JS app router should rewrite from an inbound URL to an internal one. Thus this is likely to be a specification, in my opinion.

Consequently, I’ve decided to fix this problem with next-auth components. The problem is caused by the Next.JS specification; my commits are only on the next-auth package. No commits are on core libraries.

I’ve created reqWithBasePathURL and estimateBasePath on packages/next-auth/src/lib/env.ts and modified reqWithEnvURL call point.

Configuration sample:
 Next.Js baesPaht: “/base_path”, NextAuth config.basePath: “/base_path/api/auth” 
The reqWithEnvURL called POST or GET request, and req: NextRequest contains like this:
http://localhost:3000/api/auth/session  The estimateBasePath function estimates from the request URL and config.BasePath.


If you set a Next.JS `basePath` such as `/base_path`, the NextAuth config	should be contain full path to auth dir. AUTH_URL: http://localhost:3000/base_path/api/auth, or basePath: /base_path/api/auth.
Configuring the full path to AUTH_URL is a v4 specification, and this correct configuration also works. AUTH_URL: http://locahost:3000/, basePath: /base_path/api/auth

These configuration rules are obeyed on document one (https://authjs.dev/reference/warnings#env-url-basepath-redundant).

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->
#9274 
#9984 
#10009 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
