### PR TITLE
Fix trailing slash in third-party-api example.

### DIFF
--- a/apps/examples/nextjs/app/[...proxy]/route.tsx
+++ b/apps/examples/nextjs/app/[...proxy]/route.tsx
@@ -21,11 +21,11 @@ export async function handler(request: NextRequest) {
 
   let backendUrl =
     process.env.THIRD_PARTY_API_EXAMPLE_BACKEND ??
-    "https://authjs-third-party-backend.authjs.dev/"
+    "https://authjs-third-party-backend.authjs.dev"
 
   let url = request.nextUrl.href.replace(request.nextUrl.origin, backendUrl)
   let result = await fetch(url, { headers, body: request.body })
-  console.log("fetched", result)
+
   return stripContentEncoding(result)
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The third party api-example currently adds one trailing slash to the backend url too many.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
