### PR TITLE
chore(repo): gha listen to comment-edit events to run broken-link-checker

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -19,7 +19,7 @@ jobs:
         id: vercel_preview_url
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          preview_url_regexp: vercel.live(.*)authjs.vercel.app
+          preview_url_regexp: authjs.vercel.app
       - name: Install dependencies
         run: cd ./.github/broken-link-checker && pnpm install --ignore-workspace && pnpm build
       - name: Run link checker

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -19,7 +19,6 @@ jobs:
         id: vercel_preview_url
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          preview_url_regexp: authjs.vercel.app
       - name: Install dependencies
         run: cd ./.github/broken-link-checker && pnpm install --ignore-workspace && pnpm build
       - name: Run link checker

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -19,6 +19,7 @@ jobs:
         id: vercel_preview_url
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          preview_url_regexp: "authjs.vercel.app"
       - name: Install dependencies
         run: cd ./.github/broken-link-checker && pnpm install --ignore-workspace && pnpm build
       - name: Run link checker

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -17,14 +17,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
       - run: corepack enable
-      - name: Get Vercel Preview URL
-        id: vercelDeployment
-        uses: mishkeTz/get-vercel-preview-url-by-project-id@main
+      - uses: aaimio/vercel-preview-url-action@v2.2.0
+        id: vercel_preview_url
         with:
-          vercel_access_token: ${{ secrets.VERCEL_TOKEN }}
-          vercel_team_id: ${{ secrets.VERCEL_TEAM_ID }}
-          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          preview_url_regexp: /vercel.live(.*)authjs.vercel.app/
       - name: Install dependencies
         run: cd ./.github/broken-link-checker && pnpm install --ignore-workspace && pnpm build
       - name: Run link checker
@@ -32,4 +29,4 @@ jobs:
         id: broken-links
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERCEL_PREVIEW_URL: ${{ steps.vercelDeployment.outputs.preview_url }}
+          VERCEL_PREVIEW_URL: ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -19,7 +19,7 @@ jobs:
         id: vercel_preview_url
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          preview_url_regexp: /vercel.live(.*)authjs.vercel.app/
+          preview_url_regexp: vercel.live(.*)authjs.vercel.app
       - name: Install dependencies
         run: cd ./.github/broken-link-checker && pnpm install --ignore-workspace && pnpm build
       - name: Run link checker

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -1,10 +1,8 @@
 name: "Broken Link Checker"
+
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "docs/**"
+  issue_comment:
+    types: [edited]
 
 permissions:
   pull-requests: write

--- a/docs/pages/contributors.mdx
+++ b/docs/pages/contributors.mdx
@@ -2,7 +2,7 @@ import { Steps } from "nextra/components"
 
 # Contributors
 
-Maintaining Auth.js as an open source project is very hard work. All the core team members have regular jobs and the library is maintained and developed out of good will in our free time. Donations can enable the core team to eventually work full time on Auth.js to provide more features and an even better developer experience.
+Maintaining Auth.js as an open source project is very hard work. All the core team members have regular jobs and the library is maintained and developed out of good will in our free time. Donations can enable the core team to eventually work full time on Auth.js to provide more features and an even better developer experience!
 
 <div className="flex my-4 gap-2">
   <img src="/img/etc/opencollective-logomark.svg" width="64" />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

- Instead of requiring GHA Secrets and polling Vercel for completed preview deploy, listen to GitHub `comment-edited` events to get preview URL and trigger broken-link-checker
	- Using: https://github.com/marketplace/actions/capture-vercel-preview-url
- Allows us to run checker on "external" PR's as well


### Notes

- Previously were using: https://github.com/marketplace/actions/get-vercel-preview-url-by-project-id

### Todo

Not running in PR :thinking: Maybe needs to be merged to get triggered on those comment edited events correctly

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
