### PR TITLE
feat(drizzle): adapter runnuble on the edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,5 +240,8 @@
     "patchedDependencies": {
       "@balazsorban/monorepo-release@0.5.1": "patches/@balazsorban__monorepo-release@0.5.1.patch"
     }
+  },
+  "dependencies": {
+    "v4-uuid": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -240,8 +240,5 @@
     "patchedDependencies": {
       "@balazsorban/monorepo-release@0.5.1": "patches/@balazsorban__monorepo-release@0.5.1.patch"
     }
-  },
-  "dependencies": {
-    "v4-uuid": "^1.1.0"
   }
 }

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -46,7 +46,8 @@
     "dev": "drizzle-kit generate:mysql --schema=src/schema.ts --out=.drizzle && tsc -w"
   },
   "dependencies": {
-    "@auth/core": "workspace:*"
+    "@auth/core": "workspace:*",
+    "v4-uuid": "^1.1.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.4",

--- a/packages/adapter-drizzle/src/index.ts
+++ b/packages/adapter-drizzle/src/index.ts
@@ -24,6 +24,7 @@ import { DefaultMySqlSchema, MySqlDrizzleAdapter } from "./lib/mysql.js"
 import { DefaultPostgresSchema, PostgresDrizzleAdapter } from "./lib/pg.js"
 import { DefaultSQLiteSchema, SQLiteDrizzleAdapter } from "./lib/sqlite.js"
 import { DefaultSchema, SqlFlavorOptions } from "./lib/utils.js"
+// import uuid from 'v4-uuid';
 
 import type { Adapter } from "@auth/core/adapters"
 /**
@@ -84,10 +85,10 @@ import type { Adapter } from "@auth/core/adapters"
  *  integer
  * } from "drizzle-orm/pg-core"
  * import type { AdapterAccount } from '@auth/core/adapters'
- * import { randomUUID } from "crypto"
+ * import uuid from 'v4-uuid';
  *
  * export const users = pgTable("user", {
- *  id: text("id").primaryKey().$defaultFn(() => randomUUID()),
+ *  id: text("id").primaryKey().$defaultFn(() => uuid()),
  *  name: text("name"),
  *  email: text("email").notNull(),
  *  emailVerified: timestamp("emailVerified", { mode: "date" }),
@@ -152,7 +153,7 @@ import type { Adapter } from "@auth/core/adapters"
  * import type { AdapterAccount } from "@auth/core/adapters"
  *
  * export const users = mysqlTable("user", {
- *  id: varchar("id", { length: 255 }).primaryKey().$defaultFn(() => randomUUID()),
+ *  id: varchar("id", { length: 255 }).primaryKey().$defaultFn(() => uuid()),
  *  name: varchar("name", { length: 255 }),
  *  email: varchar("email", { length: 255 }).notNull(),
  *  emailVerified: timestamp("emailVerified", { mode: "date", fsp: 3 }),
@@ -211,7 +212,7 @@ import type { Adapter } from "@auth/core/adapters"
  * import type { AdapterAccount } from "@auth/core/adapters"
  *
  * export const users = sqliteTable("user", {
- *  id: text("id").primaryKey().$defaultFn(() => randomUUID()),
+ *  id: text("id").primaryKey().$defaultFn(() => uuid()),
  *  name: text("name"),
  *  email: text("email").notNull(),
  *  emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),

--- a/packages/adapter-drizzle/src/lib/mysql.ts
+++ b/packages/adapter-drizzle/src/lib/mysql.ts
@@ -20,10 +20,12 @@ import type {
   VerificationToken,
 } from "@auth/core/adapters"
 
+import uuid from 'v4-uuid';
+
 export const mysqlUsersTable = mysqlTable("user", {
   id: varchar("id", { length: 255 })
     .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
+    .$defaultFn(() => uuid()),
   name: varchar("name", { length: 255 }),
   email: varchar("email", { length: 255 }).notNull(),
   emailVerified: timestamp("emailVerified", { mode: "date", fsp: 3 }),
@@ -94,7 +96,7 @@ export function MySqlDrizzleAdapter(
 
       await client
         .insert(usersTable)
-        .values(hasDefaultId ? data : { ...data, id: crypto.randomUUID() })
+        .values(hasDefaultId ? data : { ...data, id: uuid() })
 
       return client
         .select()

--- a/packages/adapter-drizzle/src/lib/pg.ts
+++ b/packages/adapter-drizzle/src/lib/pg.ts
@@ -19,10 +19,12 @@ import type {
   VerificationToken,
 } from "@auth/core/adapters"
 
+import uuid from 'v4-uuid';
+
 export const postgresUsersTable = pgTable("user", {
   id: text("id")
     .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
+    .$defaultFn(() => uuid()),
   name: text("name"),
   email: text("email").notNull(),
   emailVerified: timestamp("emailVerified", { mode: "date" }),
@@ -95,7 +97,7 @@ export function PostgresDrizzleAdapter(
 
       return client
         .insert(usersTable)
-        .values(hasDefaultId ? data : { ...data, id: crypto.randomUUID() })
+        .values(hasDefaultId ? data : { ...data, id: uuid() })
         .returning()
         .then((res) => res[0])
     },

--- a/packages/adapter-drizzle/src/lib/sqlite.ts
+++ b/packages/adapter-drizzle/src/lib/sqlite.ts
@@ -17,10 +17,12 @@ import type {
   VerificationToken,
 } from "@auth/core/adapters"
 
+import uuid from 'v4-uuid';
+
 export const sqliteUsersTable = sqliteTable("user", {
   id: text("id")
     .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
+    .$defaultFn(() => uuid()),
   name: text("name"),
   email: text("email").notNull(),
   emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),
@@ -89,7 +91,7 @@ export function SQLiteDrizzleAdapter(
 
       return client
         .insert(usersTable)
-        .values(hasDefaultId ? data : { ...data, id: crypto.randomUUID() })
+        .values(hasDefaultId ? data : { ...data, id: uuid() })
         .returning()
         .get()
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,10 @@ patchedDependencies:
 importers:
 
   .:
+    dependencies:
+      v4-uuid:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@actions/core':
         specifier: ^1.10.0
@@ -301,6 +305,9 @@ importers:
       '@auth/core':
         specifier: workspace:*
         version: link:../core
+      v4-uuid:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.4
@@ -24274,6 +24281,11 @@ packages:
       diff: 5.1.0
       kleur: 4.1.5
       sade: 1.8.1
+    dev: false
+
+  /v4-uuid@1.1.0:
+    resolution: {integrity: sha512-osa5a9XnMc5G4Z+n7hK+hhY7Qx4MDArd2vuNKlL3MiekpABMXAY9+9tNXCUg13D6HxTJ6M34X5c3ui/H4hKifA==}
+    engines: {node: '>=6.9'}
     dev: false
 
   /v8-compile-cache-lib@3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,6 @@ patchedDependencies:
 importers:
 
   .:
-    dependencies:
-      v4-uuid:
-        specifier: ^1.1.0
-        version: 1.1.0
     devDependencies:
       '@actions/core':
         specifier: ^1.10.0


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Current version of the drizzle adapter cannot run on the edge (vercel/cloudflare/...) this is due to the usage of the node `crypto` library which is not available on the browser. In order to make it available on the browser, I have replaced it with https://github.com/streamich/v4-uuid

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

Authors now claims to be compatible with the edge, but current version of drizzle adapter is not: https://authjs.dev/getting-started/migrating-to-v5#edge-compatibility

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
