### PR TITLE
Add `Ory` provider

### DIFF
--- a/packages/core/src/providers/ory.ts
+++ b/packages/core/src/providers/ory.ts
@@ -1,16 +1,16 @@
 /**
  * <div style={{backgroundColor: "#000", display: "flex", justifyContent: "space-between", color: "#fff", padding: 16}}>
- * <span>Built-in <b>Ory Hydra</b> integration.</span>
- * <a href="https://www.ory.sh/hydra/">
+ * <span>Built-in <b>Ory</b> integration.</span>
+ * <a href="https://www.ory.sh/">
  *   <img style={{display: "block"}} src="https://authjs.dev/img/providers/ory.svg" height="48" />
  * </a>
  * </div>
  *
- * @module providers/ory-hydra
+ * @module providers/ory
  */
 import type { OIDCConfig, OIDCUserConfig } from "./index.js"
 
-export interface OryHydraProfile extends Record<string, any> {
+export interface DefaultOryProfile extends Record<string, any> {
   iss: string
   ver: string
   sub: string
@@ -20,53 +20,55 @@ export interface OryHydraProfile extends Record<string, any> {
   jti: string
   amr: string
   email?: string
+  email_verified?: boolean
+  preferred_username?: string
+  website?: string
+  given_name?: string
+  family_name?: string
+  name?: string
+  updated_at?: Date
 }
 
 /**
- * Add login with self-hosted Ory Hydra to your app.
+ * Add login with Ory to your app.
  *
  * ### Setup
  *
  * #### Callback URL
+ *
  * ```
- * https://example.com/api/auth/callback/hydra
+ * https://example.com/api/auth/callback/ory
  * ```
  *
  * #### Configuration
- *```ts
- * import { Auth } from "@auth/core"
- * import OryHydra from "@auth/core/providers/ory-hydra"
+ *```js
+ * import Auth from "@auth/core"
+ * import Ory from "@auth/core/providers/ory"
  *
  * const request = new Request(origin)
  * const response = await Auth(request, {
- *   providers: [
- *     OryHydra({
- *       clientId: ORY_HYDRA_CLIENT_ID,
- *       clientSecret: ORY_HYDRA_CLIENT_SECRET,
- *       issuer: ORY_HYDRA_ISSUER,
- *     }),
- *   ],
+ *   providers: [Ory({
+ *     clientId: ORY_CLIENT_ID,
+ *     clientSecret: ORY_CLIENT_SECRET,
+ *     issuer: ORY_SDK_URL // https://ory.yourdomain.com
+ *   })],
  * })
  * ```
  *
  * ### Resources
  *
- *  - [Ory Hydra documentation](https://www.ory.sh/docs/hydra/5min-tutorial)
+ *  - [Ory + Auth.js integration](https://www.ory.sh/docs/getting-started/integrate-auth/auth-js)
+ *  - [Ory Documentation](https://www.ory.sh/docs)
  *
  * ### Notes
  *
- * Ory Hydra can be setup using the default Ory Network setup or self-hosted on your own
- * infrastructure.
+ * This set up is optimized for Ory Network, a managed service by Ory. To use Auth.js with self-hosted Ory Hydra, use the `OryHydra` provider.
  *
- * This provider is best for self-hosted Ory Hydra instances. For the Ory Network, use the
- * `Ory` provider.
- *
- * By default, Auth.js assumes that the Ory Hydra provider is
- * based on the [Open ID Connect](https://openid.net/specs/openid-connect-core-1_0.html) specification.
+ * The Ory integration is based on the [Open ID Connect](https://openid.net/specs/openid-connect-core-1_0.html) specification.
  *
  * :::tip
  *
- * The Ory Hydra provider comes with a [default configuration](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/ory-hydra.ts).
+ * The Ory provider comes with a [default configuration](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/ory.ts).
  * To override the defaults for your use case, check out [customizing a built-in OAuth provider](https://authjs.dev/guides/configuring-oauth-providers).
  *
  * :::
@@ -81,13 +83,14 @@ export interface OryHydraProfile extends Record<string, any> {
  *
  * :::
  */
-export default function OryHydra<P extends OryHydraProfile>(
+export default function Ory<P extends DefaultOryProfile>(
   options: OIDCUserConfig<P>
 ): OIDCConfig<P> {
   return {
-    id: "hydra",
-    name: "Ory Hydra",
-    type: "oidc",
+    id: "ory",
+    name: "Ory",
+    type: 'oidc',
+    checks: ["pkce", "state", "nonce"],
     style: {
       bg: "#fff",
       text: "#0F172A",


### PR DESCRIPTION
## ☕️ Reasoning

Adds support for Ory.

Ory supports two ways to run IAM - self-hosted or as a managed service. This PR adds a provider for the managed service and separates the managed provider and the self-hosted provider.

We can optionally also deprecate the `OryHydra` provider as it is incorrectly named and replace it just with the Ory provider.

## 🧢 Checklist

- [x] Documentation
- [x] ~Tests~
- [x] Ready to be merged

## 🎫 Affected issues

None

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
