### PR TITLE
Add keycloak as default example provider.

### DIFF
--- a/apps/examples/nextjs/.env.local.example
+++ b/apps/examples/nextjs/.env.local.example
@@ -1,8 +1,9 @@
 AUTH_SECRET= # `npx auth secret` or `openssl rand -hex 32`
 
 # Hosted example provider. Credentials: bob/bob
+# This is for demonstration purposes. Never commit plain secrets to git.
 AUTH_KEYCLOAK_ID=authjs-test
-AUTH_KEYCLOAK_SECRET=secret
+AUTH_KEYCLOAK_SECRET=TaRCEBNyryNCa7aJ9VQwzsOyXkd7lqMs
 AUTH_KEYCLOAK_ISSUER=https://keycloak.authjs.dev/realms/master
 
 AUTH_AUTH0_ID=

--- a/apps/examples/nextjs/.env.local.example
+++ b/apps/examples/nextjs/.env.local.example
@@ -1,5 +1,10 @@
 AUTH_SECRET= # `npx auth secret` or `openssl rand -hex 32`
 
+# Hosted example provider. Credentials: bob/bob
+AUTH_KEYCLOAK_ID=authjs-test
+AUTH_KEYCLOAK_SECRET=secret
+AUTH_KEYCLOAK_ISSUER=https://keycloak.authjs.dev/realms/master
+
 AUTH_AUTH0_ID=
 AUTH_AUTH0_SECRET=
 AUTH_AUTH0_ISSUER=

--- a/apps/examples/nextjs/.env.local.example
+++ b/apps/examples/nextjs/.env.local.example
@@ -3,7 +3,7 @@ AUTH_SECRET= # `npx auth secret` or `openssl rand -hex 32`
 # Hosted example provider. Credentials: bob/bob
 # This is for demonstration purposes. Never commit plain secrets to git.
 AUTH_KEYCLOAK_ID=authjs-test
-AUTH_KEYCLOAK_SECRET=TaRCEBNyryNCa7aJ9VQwzsOyXkd7lqMs
+AUTH_KEYCLOAK_SECRET=Rrb3iPYXoMxyhFlSqfZ0bds0D79faQzS
 AUTH_KEYCLOAK_ISSUER=https://keycloak.authjs.dev/realms/master
 
 AUTH_AUTH0_ID=

--- a/apps/examples/nextjs/app/page.tsx
+++ b/apps/examples/nextjs/app/page.tsx
@@ -19,6 +19,11 @@ export default async function Index() {
           Client
         </CustomLink>{" "}
         examples to see how to secure pages and get session data.
+        <div>
+          To sign in, feel free to use the hosted keycloak provider that is
+          configured by default (credentials bob/bob) for testing or
+          demonstration purposes.
+        </div>
       </div>
       <div className="flex flex-col rounded-md bg-neutral-100">
         <div className="p-4 font-bold rounded-t-md bg-neutral-200">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Since we now have our own "dummy" provider, people can get started with the example project much easier. 
If we configure this dummy provider by default, you just have to run the app and use keycloak to log in. Then also the client-example will work right out of the box.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
