### PR TITLE
fix(next-auth): proper handling of env for createActionURL

### DIFF
--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -60,12 +60,17 @@ export interface NextAuthConfig extends Omit<AuthConfig, "raw"> {
 }
 
 async function getSession(headers: Headers, config: NextAuthConfig) {
+  // Allows Next.js to replace the env variables with their values at build time
+  const envObject = {
+    AUTH_URL: process.env.AUTH_URL,
+    NEXTAUTH_URL: process.env.NEXTAUTH_URL
+  }
   const url = createActionURL(
     "session",
     // @ts-expect-error `x-forwarded-proto` is not nullable, next.js sets it by default
     headers.get("x-forwarded-proto"),
     headers,
-    process.env,
+    envObject,
     config
   )
   const request = new Request(url, {


### PR DESCRIPTION
## ☕️ Reasoning

Next.js replaces environment variables at build time but they need to be reference directly and cannot be accessed dynamically for this to work. https://github.com/nextauthjs/next-auth/commit/3c035ec62f2f21d7cab65504ba83fb1a9a13be01 broke this contract.

This PR fixes this by changing the next-auth caller to extract the variables directly from `process.env` and putting them in an object compatible with `createActionURL` from core. Other frameworks might have other inner workings in regards to this env handling, so I only made the changes in next-auth rather than refactoring `createActionURL` which would've affected other frameworks I'm not familiar with.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

N/A

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
