### PR TITLE
fix(sveltekit): remove trailing slash in webAuthn `baseUrl`

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/webauthn.ts
+++ b/packages/frameworks-sveltekit/src/lib/webauthn.ts
@@ -18,7 +18,7 @@ import type { LiteralUnion } from "./types.js"
  * @returns WebAuthn response or error
  */
 async function webAuthnOptions(providerId: string, options?: SignInOptions) {
-  const baseUrl = `${base}/auth/`
+  const baseUrl = `${base}/auth`
 
   // @ts-expect-error
   const params = new URLSearchParams(options)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Fixes a 404 by removing an extra `/` in the URL

https://github.com/nextauthjs/next-auth/blob/d53d47c7b9fe992613af79b9f11275bedc63e620/packages/frameworks-sveltekit/src/lib/webauthn.ts#L21

https://github.com/nextauthjs/next-auth/blob/d53d47c7b9fe992613af79b9f11275bedc63e620/packages/frameworks-sveltekit/src/lib/webauthn.ts#L27

```
Request URL: http://localhost:5173/auth//webauthn-options/webauthn?action=register
Request Method: GET
Status Code: 404 Not Found (from service worker)
```

## The Fix

```diff
- const baseUrl = `${base}/auth/`
+ const baseUrl = `${base}/auth`
```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/10947

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
