### PR TITLE
docs[drizzle]: replace "next-auth/adapters" to "@auth/core/adapters"

### DIFF
--- a/docs/pages/getting-started/adapters/drizzle.mdx
+++ b/docs/pages/getting-started/adapters/drizzle.mdx
@@ -55,7 +55,7 @@ import {
 } from "drizzle-orm/pg-core"
 import postgres from "postgres"
 import { drizzle } from "drizzle-orm/postgres-js"
-import type { AdapterAccountType } from "next-auth/adapters"
+import type { AdapterAccountType } from "@auth/core/adapters"
 
 const connectionString = "postgres://postgres:postgres@localhost:5432/drizzle"
 const pool = postgres(connectionString, { max: 1 })
@@ -154,7 +154,7 @@ import {
 } from "drizzle-orm/mysql-core"
 import mysql from "mysql2/promise"
 import { drizzle } from "drizzle-orm/mysql2"
-import type { AdapterAccountType } from "next-auth/adapters"
+import type { AdapterAccountType } from "@auth/core/adapters"
 
 export const connection = await mysql.createConnection({
   host: "host",
@@ -260,7 +260,7 @@ If you want to modify the schema or add additional fields, you can use the follo
 import { integer, sqliteTable, text, primaryKey } from "drizzle-orm/sqlite-core"
 import { createClient } from "@libsql/client"
 import { drizzle } from "drizzle-orm/libsql"
-import type { AdapterAccountType } from "next-auth/adapters"
+import type { AdapterAccountType } from "@auth/core/adapters"
 
 const client = createClient({
   url: "DATABASE_URL",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
I'm installing `authjs` with Svelte, so I would like to not install the `next-auth`.
[The `next-auth` only re-export it from core,](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/adapters.ts) so this work for both.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [X] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
