### PR TITLE
fix(next-auth): force `session.update()` to trigger session update

### DIFF
--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -483,9 +483,7 @@ export function SessionProvider(props: SessionProviderProps) {
           "session",
           __NEXTAUTH,
           logger,
-          typeof data === "undefined"
-            ? undefined
-            : { body: { csrfToken: await getCsrfToken(), data } }
+          { body: { csrfToken: await getCsrfToken(), data } }
         )
         setLoading(false)
         if (newSession) {


### PR DESCRIPTION
When calling session.update() without data, data will be undefined.  If data is undefined, then req is undefined and in fetchData when req.body is not defined, the method will not be set to POST nor will the csrf token be included.  I think that is why when you call session.update(), it doesn't actually trigger an update and the only way to get it to trigger an update is to call the function with data.  Maybe this is by design, but it was confusing as I would expect session.update() to trigger a session update even without providing data (in the case where session data or user data has changed elsewhere)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
