### PR TITLE
fix: change API domain for twitter provider

### DIFF
--- a/packages/core/src/providers/twitter.ts
+++ b/packages/core/src/providers/twitter.ts
@@ -1,7 +1,7 @@
 /**
  * <div style={{backgroundColor: "#000", display: "flex", justifyContent: "space-between", color: "#fff", padding: 16}}>
  * <span>Built-in <b>Twitter</b> integration.</span>
- * <a href="https://www.twitter.com/">
+ * <a href="https://www.x.com/">
  *   <img style={{display: "block"}} src="https://authjs.dev/img/providers/twitter.svg" height="48" />
  * </a>
  * </div>
@@ -11,7 +11,7 @@
 import type { OAuthConfig, OAuthUserConfig } from "./index.js"
 
 /**
- * [Users lookup](https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me)
+ * [Users lookup](https://developer.x.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me)
  */
 export interface TwitterProfile {
   data: {
@@ -125,7 +125,7 @@ export interface TwitterProfile {
  *
  * ### Resources
  *
- * - [Twitter App documentation](https://developer.twitter.com/en/apps)
+ * - [Twitter App documentation](https://developer.x.com/en/apps)
  *
  * ## OAuth 2
  * Twitter supports OAuth 2, which is currently opt-in. To enable it, simply add version: "2.0" to your Provider configuration:
@@ -185,10 +185,10 @@ export default function Twitter(
     type: "oauth",
     checks: ["pkce", "state"],
     authorization:
-      "https://twitter.com/i/oauth2/authorize?scope=users.read tweet.read offline.access",
-    token: "https://api.twitter.com/2/oauth2/token",
+      "https://x.com/i/oauth2/authorize?scope=users.read tweet.read offline.access",
+    token: "https://api.x.com/2/oauth2/token",
     userinfo:
-      "https://api.twitter.com/2/users/me?user.fields=profile_image_url",
+      "https://api.x.com/2/users/me?user.fields=profile_image_url",
     profile({ data }) {
       return {
         id: data.id,


### PR DESCRIPTION
## ☕️ Reasoning

Switch X.com (former Twitter) API domain from twitter.com to x.com. When users switching between different accounts on  x.com, the `twitter.com/i/oauth2` endpoint still functional but not yet sync with up-to-date log in state. That's means:

- The user previously logged in to twitter.com with account A.
- Now, when visiting twitter.com, there is a forced redirect to x.com.
- The user switches to account B on x.com.
- The user then comes to our app and signs in with their Twitter account.
- However, the authentication confirmation page shows account A instead of account B.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes:
- https://github.com/nextauthjs/next-auth/issues/10967
- https://github.com/nextauthjs/next-auth/issues/10988
