### PR TITLE
Re-enable ability for the token request to be overriden completely

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -102,9 +102,10 @@ export interface Theme {
  * Some of them are available with different casing,
  * but they refer to the same value.
  */
-export type TokenSet = Partial<
-  OAuth2TokenEndpointResponse | OpenIDTokenEndpointResponse
-> & {
+export type TokenSet = (
+  | OAuth2TokenEndpointResponse
+  | OpenIDTokenEndpointResponse
+) & {
   /**
    * Date of when the `access_token` expires in seconds.
    * This value is calculated from the `expires_in` value.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

When dealing with a custom oauth provider that has a non compliant token endpoint this functionality allows this library to be used. This functionality was present in v4 of the library. 

In v5 this has been removed. A conform endpoint has been added for internal use to manipulate the response from token endpoints. However this does help if the request does not conform exactly to the standard. 

As an example the company I work for requires some extra parameters to be sent in the token request (including the state parameter) Other than that the solution is oauth compliant. It would be a shame if we couldn't use v5 because of this restraint.

Another example I can see in the v5 branch is the tiktok provider which I assume is currently broken by its requirement to have a custom token request. 

This PR implements the existing type contract that was carried over from the v4 branch but not implemented.


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

There are quite a few issues and comments about not being able to control the request endpoint

https://github.com/nextauthjs/next-auth/issues/10852
https://github.com/nextauthjs/next-auth/issues/10732
https://github.com/nextauthjs/next-auth/discussions/10829

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
