### PR TITLE
fix(next-auth): allow next@14.3.0-canary to peer deps

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -83,7 +83,7 @@
   "peerDependencies": {
     "@simplewebauthn/browser": "^9.0.1",
     "@simplewebauthn/server": "^9.0.2",
-    "next": "^14 || ^15.0.0-0",
+    "next": "^14.0.0-0 || ^15.0.0-0",
     "nodemailer": "^6.6.5",
     "react": "^18.2.0 || ^19.0.0-0"
   },


### PR DESCRIPTION
## ☕️ Reasoning

Currently 14.3.0-canary releases cannot be installed along with next-auth, so fix that.

```
npm ERR! While resolving: pinboard@0.1.0
npm ERR! Found: next@14.3.0-canary.61
npm ERR! node_modules/next
npm ERR!   next@"14.3.0-canary.61" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer next@"^14 || ^15.0.0-0" from next-auth@5.0.0-beta.19
npm ERR! node_modules/next-auth
npm ERR!   next-auth@"^5.0.0-beta.19" from the root project
```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
