### PR TITLE
chore(docs): Add Neon's Postgres documents for edge runtime

### DIFF
--- a/docs/pages/getting-started/adapters/pg.mdx
+++ b/docs/pages/getting-started/adapters/pg.mdx
@@ -51,6 +51,26 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 })
 ```
 
+If you are using [Neon](https://neon.tech)'s PostgreSQL like [Vercel Postgres](https://vercel.com/docs/postgres), you can use `@neondatabase/serverless` to work with edge runtime.
+
+```ts filename="./auth.ts"
+import NextAuth from "next-auth"
+import PostgresAdapter from "@auth/pg-adapter"
+import { Pool } from "@neondatabase/serverless"
+
+// *DO NOT* create a `Pool` here, outside the request handler.
+// Neon's Postgres cannot keep a pool alive between requests.
+
+export const { handlers, auth, signIn, signOut } = NextAuth(() => {
+  // Create a `Pool` inside the request handler.
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  return {
+    adapter: PostgresAdapter(pool),
+    providers: [],
+  }
+})
+```
+
 </Code.Next>
 <Code.Svelte>
 
@@ -72,6 +92,26 @@ const pool = new Pool({
 export const { handle, signIn, signOut } = SvelteKitAuth({
   adapter: PostgresAdapter(pool),
   providers: [],
+})
+```
+
+If you are using [Neon](https://neon.tech)'s PostgreSQL like [Vercel Postgres](https://vercel.com/docs/postgres), you can use `@neondatabase/serverless` to work with edge runtime.
+
+```ts filename="./src/auth.ts"
+import { SvelteKitAuth } from "@auth/sveltekit"
+import PostgresAdapter from "@auth/pg-adapter"
+import { Pool } from "@neondatabase/serverless"
+
+// *DO NOT* create a `Pool` here, outside the request handler.
+// Neon's Postgres cannot keep a pool alive between requests.
+
+export const { handle, signIn, signOut } = SvelteKitAuth(() => {
+  // Create a `Pool` inside the request handler.
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  return {
+    adapter: PostgresAdapter(pool),
+    providers: [],
+  }
 })
 ```
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

Vercel's database uses Neon's serverless Postgres, so it can use Edge Runtime.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

No Issue.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
