### PR TITLE
[DOCS] Update "Getting Starts > Installation" document 

### DIFF
--- a/docs/pages/getting-started/installation.mdx
+++ b/docs/pages/getting-started/installation.mdx
@@ -2,9 +2,9 @@ import { Steps, Callout } from "nextra/components"
 import { Code } from "@/components/Code"
 
 <Steps>
-### Installing Auth.js
+### Install Auth.js
 
-Start by installing the appropriate package for your framework.
+Start by installing the appropriate package for your framework:
 
 <Code>
   <Code.Next>
@@ -30,44 +30,46 @@ Start by installing the appropriate package for your framework.
 </Code>
 
 <Callout type="info">
-  Installing `@auth/core` is not necessary, as a user you should never have to
-  interact with `@auth/core`.
+  As a user, you should never have to interact with `@auth/core`, so installing it is not necessary. 
 </Callout>
 
 ### Setup Environment
 
-The only environment variable that is mandatory is the `AUTH_SECRET`. This is a random value used by the library to encrypt tokens and email
-verification hashes. (See [Deployment](/getting-started/deployment) to learn more). You can generate one via running:
+The only mandatory environment variable is `AUTH_SECRET`, a random value Auth.js uses to encrypt tokens and email
+verification hashes. Visit the [Deployment](/getting-started/deployment) document to learn more.
+
+You can generate the value for `AUTH_SECRET` by running the following command:
 
 ```bash
 npx auth secret
 ```
 
-Alternatively, you can use the following `openssl` command, which should be available on all Linux / Mac OS X systems.
+Alternatively, you can use the following [`openssl`](https://github.com/openssl/openssl) command, which should be available on all Linux and macOS systems:
 
 ```bash
 openssl rand -base64 33
 ```
 
-Then add it to your `.env.local` file:
+Use the output in the terminal as the value of `AUTH_SECRET` in your `.env.local` file:
 
 ```bash filename=".env.local"
 AUTH_SECRET=secret
 ```
 
-### Configure
+### Configure Auth.js
 
-Next, create the Auth.js config file and object. This is where you can control the behaviour of the library and specify custom authentication logic, adapters, etc. We recommend all frameworks to create an `auth.ts` file in the project. In this file we'll pass in all the options to the framework specific initalization function and then export the route handler(s), signin and signout methods, and more.
+Next, create the Auth.js config file and object, where you can control the library's behavior and specify custom authentication logic, adapters, etc.
+
+We recommend that you create an `auth.ts` file in the project, regardless of the framework you are using. You can use `auth.ts` to pass options to the framework-specific initialization function and export authentication route handlers, sign-in and sign-out methods, and more.
 
 <Callout type="info">
-  You can name this file whatever you want and place it wherever you like, these
-  are just conventions we've come up with.
+  You can name the Auth.js config file whatever you like and place it wherever you want within your project. The following are conventions we've developed.
 </Callout>
 
 <Code>
   <Code.Next>
 
-1. Start by creating a new `auth.ts` file at the root of your app with the following content.
+1. Create an `auth.ts` file under the root project directory with the following content:
 
 ```ts filename="./auth.ts"
 import NextAuth from "next-auth"
@@ -77,19 +79,28 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 })
 ```
 
-2. Add an Route Handler under `/app/api/auth/[...nextauth]/route.ts`.
+2. Create a [dynamic API route](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes) where you can use a [catch-all segment](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#catch-all-segments) to handle all authentication-related requests:
+    - If you haven't already, create an `api` directory under the `/app/` directory. 
+    - Create an `auth` directory under the newly created `/app/api/` directory.
+    - Create a `[...nextauth]` directory under the new `auth/` directory.
+    - Create a `route.ts` file under the `[...nextauth]/` directory.
+
+3. Add the following content to the `/app/api/auth/[...nextauth]/route.ts` file:
 
 <Callout>
-  This file must be an App Router Route Handler, however, the rest of your app
-  can stay under `page/` if you'd like.
+  This `route.ts` file must define an [App Router route handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers). However, the rest of your app can stay under `page/` if you'd like.
 </Callout>
 
 ```ts filename="./app/api/auth/[...nextauth]/route.ts"
-import { handlers } from "@/auth" // Referring to the auth.ts we just created
+import { handlers } from "@/auth" // Refers to the auth.ts file we just created
 export const { GET, POST } = handlers
 ```
 
-3. Add optional Middleware to keep the session alive, this will update the session expiry every time its called.
+4. Add optional [Next.js middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) to keep the session alive by updating the session expiry every time it's called:
+
+<Callout>
+  If you haven't already created a `middleware.ts` file in your Next.js project, follow the [Next.js middleware naming and file placement conventions](https://nextjs.org/docs/app/building-your-application/routing/middleware#convention) to do so.
+</Callout>
 
 ```ts filename="./middleware.ts"
 export { auth as middleware } from "@/auth"
@@ -145,13 +156,13 @@ app.set("trust proxy", true)
 app.use("/auth/*", ExpressAuth({ providers: [] }))
 ```
 
-Note this creates the Auth.js API, but does not yet protect resources. Continue on to [protecting resources](/getting-started/session-management/protecting) for more details.
+Note that this creates the Auth.js API but does not yet protect resources. For more details, continue to [protecting resources](/getting-started/session-management/protecting).
 
   </Code.Express>
 </Code>
 
-### Setup Authentication Methods
+### Auth.js Setup Completed
 
-With that, the basic setup is complete! Next we'll setup the first authentication methods and fill out that `providers` array.
+The basic Auth.js setup is complete! Next, we'll set up an authentication method and fill out the `providers` array defined in the `auth.ts` file.
 
 </Steps>

--- a/docs/pages/global.css
+++ b/docs/pages/global.css
@@ -257,3 +257,10 @@ div.nextra-search kbd {
     opacity: 0;
   }
 }
+
+ul ul, 
+ul ol,
+ol ul,
+ol ol {
+  @apply mb-6;
+}


### PR DESCRIPTION
## ☕️ Reasoning

This PR updates the "Getting Starts > Installation" document to improve a bit its diction and add more nuance to some of its steps, such as the directory hierarchy when creating the catch-all route to handle all authentication. The PR also adds additional contextual links to help the reader expand their knowledge on concepts that may be new, such as using `openssl` and Next.js middleware.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## ❓ Questions

### Nesting lists

I couldn't figure out how to update the rendering of lists in the MDX files. I am nesting a list within the steps, but the nested `<ul>` did not receive any bottom margin. I created a CSS rule for it on the `global.css` file, but please let me know if there's a better way to do so.

### Scope of document

I believe that the steps on this document for Next.js installation and setup only apply to App Router. Is that correct? If so, then I'd like to also mention that explicitly on the doc. Upon your confirmation, I can do so.

### Confusing caution note

I am not sure what this line in one of the caution notes is meant to represent:

```
However, the rest of your app can stay under `page/` if you’d like.
```

Is the goal of this note to tell the reader that they can put the rest of their Next.js files in directories other than the `api/.../[...nextauth]/` one?


Thanks for your assistance on clarifying this questions :) 

## 🎫 Affected issues

N/A

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
