### PR TITLE
Fix: coinbase provider authorization and access token url

### DIFF
--- a/packages/core/src/providers/coinbase.ts
+++ b/packages/core/src/providers/coinbase.ts
@@ -74,8 +74,8 @@ export default function Coinbase(
     name: "Coinbase",
     type: "oauth",
     authorization:
-      "https://www.coinbase.com/oauth/authorize?scope=wallet:user:email+wallet:user:read",
-    token: "https://api.coinbase.com/oauth/token",
+      "https://login.coinbase.com/oauth2/auth?scope=wallet:user:email+wallet:user:read",
+    token: "https://login.coinbase.com/oauth2/token",
     userinfo: "https://api.coinbase.com/v2/user",
     profile(profile) {
       return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Update the Coinbase provider with the latest urls for authorization and access token as specified in their [documentation](https://docs.cdp.coinbase.com/sign-in-with-coinbase/docs/sign-in-with-coinbase-integration/#registering-oauth2-client).

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
