### PR TITLE
refactor: move as discovery to normalize providers

### DIFF
--- a/packages/core/src/lib/actions/callback/handle-login.ts
+++ b/packages/core/src/lib/actions/callback/handle-login.ts
@@ -287,7 +287,7 @@ export async function handleLoginOrRegister(
       ? await getUserByEmail(profile.email)
       : null
     if (userByEmail) {
-      const provider = options.provider as OAuthConfig<any>
+      const provider = options.provider as unknown as OAuthConfig<any>
       if (provider?.allowDangerousEmailAccountLinking) {
         // If you trust the oauth provider to correctly verify email addresses, you can opt-in to
         // account linking even when the user is not signed-in.

--- a/packages/core/src/lib/actions/callback/index.ts
+++ b/packages/core/src/lib/actions/callback/index.ts
@@ -58,7 +58,7 @@ export async function callback(
     if (provider.type === "oauth" || provider.type === "oidc") {
       // Use body if the response mode is set to form_post. For all other cases, use query
       const payload =
-        provider.authorization?.url.searchParams.get("response_mode") ===
+        provider.authorization.url.searchParams.get("response_mode") ===
         "form_post"
           ? body
           : query

--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -1,6 +1,5 @@
 import * as checks from "../callback/oauth/checks.js"
 
-import type { AuthorizationServer } from "oauth4webapi"
 import type { InternalOptions, RequestInternal } from "../../../types.js"
 import type { Cookie } from "../../utils/cookie.js"
 
@@ -14,12 +13,8 @@ export async function getAuthorizationUrl(
   options: InternalOptions<"oauth" | "oidc">
 ) {
   const { logger, provider } = options
-  let as: AuthorizationServer | undefined
-  let url: URL
 
-  const { url: u, as: a } = provider.authorization
-  url = u
-  as = a
+  const { url, as } = provider.authorization
 
   const authParams = url.searchParams
 

--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -1,6 +1,6 @@
 import * as checks from "../callback/oauth/checks.js"
-import * as o from "oauth4webapi"
 
+import type { AuthorizationServer } from "oauth4webapi"
 import type { InternalOptions, RequestInternal } from "../../../types.js"
 import type { Cookie } from "../../utils/cookie.js"
 
@@ -14,27 +14,12 @@ export async function getAuthorizationUrl(
   options: InternalOptions<"oauth" | "oidc">
 ) {
   const { logger, provider } = options
+  let as: AuthorizationServer | undefined
+  let url: URL
 
-  let url = provider.authorization?.url
-  let as: o.AuthorizationServer | undefined
-
-  // Falls back to authjs.dev if the user only passed params
-  if (!url || url.host === "authjs.dev") {
-    // If url is undefined, we assume that issuer is always defined
-    // We check this in assert.ts
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const issuer = new URL(provider.issuer!)
-    const discoveryResponse = await o.discoveryRequest(issuer)
-    const as = await o.processDiscoveryResponse(issuer, discoveryResponse)
-
-    if (!as.authorization_endpoint) {
-      throw new TypeError(
-        "Authorization server did not provide an authorization endpoint."
-      )
-    }
-
-    url = new URL(as.authorization_endpoint)
-  }
+  const { url: u, as: a } = provider.authorization
+  url = u
+  as = a
 
   const authParams = url.searchParams
 
@@ -55,7 +40,7 @@ export async function getAuthorizationUrl(
       // @ts-expect-error TODO:
       ...provider.authorization?.params,
     },
-    Object.fromEntries(provider.authorization?.url.searchParams ?? []),
+    Object.fromEntries(url.searchParams ?? []),
     query
   )
 
@@ -86,12 +71,6 @@ export async function getAuthorizationUrl(
   if (nonce) {
     authParams.set("nonce", nonce.value)
     cookies.push(nonce.cookie)
-  }
-
-  // TODO: This does not work in normalizeOAuth because authorization endpoint can come from discovery
-  // Need to make normalizeOAuth async
-  if (provider.type === "oidc" && !url.searchParams.has("scope")) {
-    url.searchParams.set("scope", "openid profile email")
   }
 
   logger.debug("authorization url is ready", { url, cookies, provider })

--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -65,7 +65,7 @@ export async function init({
   options: InternalOptions
   cookies: cookie.Cookie[]
 }> {
-  const { providers, provider } = parseProviders({
+  const { providers, provider } = await parseProviders({
     providers: authOptions.providers,
     url,
     providerId,

--- a/packages/core/src/lib/utils/cookie.ts
+++ b/packages/core/src/lib/utils/cookie.ts
@@ -127,6 +127,16 @@ export function defaultCookies(useSecureCookies: boolean) {
         maxAge: 60 * 15, // 15 minutes in seconds
       },
     },
+    authorizationServers: {
+      name: `${cookiePrefix}authjs.authorization-servers`,
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: useSecureCookies,
+        maxAge: 60 * 60 * 24 * 365, // 1 year in seconds
+      },
+    },
   } as const satisfies CookiesOptions
 }
 

--- a/packages/core/src/lib/utils/providers.ts
+++ b/packages/core/src/lib/utils/providers.ts
@@ -115,7 +115,7 @@ async function normalizeOAuth(
 
     if (!authorization) {
       throw new TypeError(
-        "The `authorization` options must be provided for this OAuth provider."
+        "The `authorization` option must be provided for this OAuth provider."
       )
     }
   }

--- a/packages/core/src/lib/utils/providers.ts
+++ b/packages/core/src/lib/utils/providers.ts
@@ -50,8 +50,6 @@ export default async function parseProviders(params: {
     })
   )
 
-  console.log({ providers })
-
   return {
     providers,
     provider: providers.find(({ id }) => id === providerId),

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -264,7 +264,7 @@ export type OAuthConfigInternal<Profile> = Omit<
    * The authorize URL should never be undefined after processing in `providers.ts`.
    * if the OAuth provider is OIDC, also returns the Authorization Server
    */
-  authorization: { url: URL; as?: AuthorizationServer }
+  authorization: { url: URL }
 
   token?: {
     url: URL
@@ -293,6 +293,7 @@ export type OAuthConfigInternal<Profile> = Omit<
 export type OIDCConfigInternal<Profile> = OAuthConfigInternal<Profile> & {
   checks: OIDCConfig<Profile>["checks"]
   idToken: OIDCConfig<Profile>["idToken"]
+  as?: AuthorizationServer
 }
 
 export type OAuthUserConfig<Profile> = Omit<

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -2,6 +2,7 @@ import type { Client } from "oauth4webapi"
 import type { CommonProviderOptions } from "../providers/index.js"
 import type { Awaitable, Profile, TokenSet, User } from "../types.js"
 import type { AuthConfig } from "../index.js"
+import type { AuthorizationServer } from "oauth4webapi"
 
 // TODO: fix types
 type AuthorizationParameters = any
@@ -259,7 +260,12 @@ export type OAuthConfigInternal<Profile> = Omit<
   OAuthConfig<Profile>,
   OAuthEndpointType | "redirectProxyUrl"
 > & {
-  authorization?: { url: URL }
+  /**
+   * The authorize URL should never be undefined after processing in `providers.ts`.
+   * if the OAuth provider is OIDC, also returns the Authorization Server
+   */
+  authorization: { url: URL; as?: AuthorizationServer }
+
   token?: {
     url: URL
     request?: TokenEndpointHandler["request"]

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -200,6 +200,8 @@ export interface CookiesOptions {
   state: Partial<CookieOption>
   nonce: Partial<CookieOption>
   webauthnChallenge: Partial<CookieOption>
+  /** @internal */
+  authorizationServers: Partial<CookieOption>
 }
 
 /** TODO: Check if all these are used/correct */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Addressing some TODOs in `authorization-url` and `providers`:
- `OAuthConfigInternal['authorization']` now returns a `URL` and `AuthorizationServer` if the provider type is `oidc`. 
- At the normalize step, throw early if `c.authorization` is empty for OAuth 2 providers

 
## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
