### PR TITLE
fix: Use sub instead of id in Gitlab

### DIFF
--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -120,7 +120,7 @@ export default function GitLab<P extends GitLabProfile>(
     userinfo: "https://gitlab.com/api/v4/user",
     profile(profile) {
       return {
-        id: profile.id.toString(),
+        id: profile.sub.toString(),
         name: profile.name ?? profile.username,
         email: profile.email,
         image: profile.avatar_url,

--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -120,7 +120,7 @@ export default function GitLab<P extends GitLabProfile>(
     userinfo: "https://gitlab.com/api/v4/user",
     profile(profile) {
       return {
-        id: profile.sub.toString(),
+        id: profile.sub?.toString(),
         name: profile.name ?? profile.username,
         email: profile.email,
         image: profile.avatar_url,


### PR DESCRIPTION
https://docs.gitlab.com/ee/integration/openid_connect_provider.html

The profile id is in the `sub` field not in the `id` field

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
https://docs.gitlab.com/ee/integration/openid_connect_provider.html
According to this documentation for Gitlab as an OIDC provider, "The ID of the user" is in the `sub` field. An `id` field is not provided. This change works with Gitlab Enterprise version 16.11 while editing nect-auth version 4.24.5 due to other issues that were fixed by downgrading.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests 
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->


## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
