### PR TITLE
fix: correctly set defaults for route handlers

### DIFF
--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -155,7 +155,9 @@ export function initAuth(
         return async (
           ...args: Parameters<NextAuthMiddleware | AppRouteHandlerFn>
         ) => {
-          return handleAuth(args, config(args[0]), userMiddlewareOrRoute)
+          const _config = config(args[0])
+          onLazyLoad?.(_config)
+          return handleAuth(args, _config, userMiddlewareOrRoute)
         }
       }
       // API Routes, getServerSideProps


### PR DESCRIPTION
## ☕️ Reasoning
Best I can tell, default setting of config options isn't happening for route handlers and middleware when you do lazy initialization. This means that basic defaults, like `basePath` don't get properly passed through, causing issues.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

