### PR TITLE
fix: apple provider checks should be `['state', 'nonce']`

### DIFF
--- a/packages/core/src/providers/apple.ts
+++ b/packages/core/src/providers/apple.ts
@@ -171,6 +171,8 @@ export default function Apple<P extends AppleProfile>(
       text: "#fff",
       bg: "#000",
     },
+    // https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server
+    checks: ['nonce', 'state'],
     options,
   }
 }

--- a/packages/core/src/providers/apple.ts
+++ b/packages/core/src/providers/apple.ts
@@ -172,7 +172,7 @@ export default function Apple<P extends AppleProfile>(
       bg: "#000",
     },
     // https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server
-    checks: ['nonce', 'state'],
+    checks: ["nonce", "state"],
     options,
   }
 }


### PR DESCRIPTION
## ☕️ Reasoning
This pr changes apple proivder checks config to `['state', 'nonce']` to align with [apple's doc](https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server)

## 🧢 Checklist
- [x] Ready to be merged

