### PR TITLE
fix: grammatical error

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -245,7 +245,7 @@ export class JWTSessionError extends AuthError {
 }
 
 /**
- * Thrown if Auth.js is misonfigured. This could happen if you configured an Email provider but did not set up a database adapter,
+ * Thrown if Auth.js is misconfigured. This could happen if you configured an Email provider but did not set up a database adapter,
  * or tried using a `strategy: "database"` session without a database adapter.
  * In both cases, make sure you either remove the configuration or add the missing adapter.
  *


### PR DESCRIPTION
## ☕️ Reasoning

I changed just a small grammatical error to reflect in the project's documentation.


## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

None, just a simple change.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
