### PR TITLE
WorkOS: `connection` is not a required field

### DIFF
--- a/packages/core/src/providers/workos.ts
+++ b/packages/core/src/providers/workos.ts
@@ -150,7 +150,7 @@ export interface WorkOSProfile extends Record<string, any> {
  * :::
  */
 export default function WorkOS<P extends WorkOSProfile>(
-  options: OAuthUserConfig<P> & { connection: string }
+  options: OAuthUserConfig<P> & { connection?: string }
 ): OAuthConfig<P> {
   const { issuer = "https://api.workos.com/", connection = "" } = options
 


### PR DESCRIPTION
```
// v4: works fine
WorkOSProvider({
    clientId: process.env.WORKOS_CLIENT_ID,
    clientSecret: process.env.WORKOS_API_KEY,
    allowDangerousEmailAccountLinking: true
    connection: 'workos'
  }),

// v5: WorkOS returns OAuthError, because connection='workos' is not valid value
  WorkOSProvider({
    clientId: process.env.WORKOS_CLIENT_ID,
    clientSecret: process.env.WORKOS_API_KEY,
    allowDangerousEmailAccountLinking: true
    connection: 'workos'
  } ),

// v5: type mismatched, but works fine
  WorkOSProvider({
    clientId: process.env.WORKOS_CLIENT_ID,
    clientSecret: process.env.WORKOS_API_KEY,
    allowDangerousEmailAccountLinking: true
  } as any),
```

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
