### PR TITLE
docs(providers): update Foursquare API Docs URL

### DIFF
--- a/packages/core/src/providers/foursquare.ts
+++ b/packages/core/src/providers/foursquare.ts
@@ -38,7 +38,7 @@ import type { OAuthConfig, OAuthUserConfig } from "./index.js"
  *
  * ### Resources
  *
- *  - [FourSquare OAuth documentation](https://developer.foursquare.com/docs/places-api/authentication/#web-applications)
+ *  - [FourSquare OAuth documentation](https://docs.foursquare.com/developer/reference/authentication)
  *
  * ### Notes
  *


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
The link for the FourSquare OAuth documentation has changed. When clicking on the link, it redirects to a 404 page, so I updated the URL.

OLD: https://docs.foursquare.com/developer/docs/places-api/authentication/#web-applications
NEW: https://docs.foursquare.com/developer/reference/authentication
## 🧢 Checklist

- [x] Documentation
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
