### PR TITLE
Add default exports to adapter-prisma for better module support

### DIFF
--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "import": "./index.js"
+      "import": "./index.js",
+      "default": "./index.js"
     }
   },
   "license": "ISC",


### PR DESCRIPTION
## ☕️ Reasoning

When using Auth + Express in a ModernJS project, I ran throught this error

```
Error: No "exports" main defined in __PROJECT_PATH__/node_modules/@auth/core/package.json
  at exportsNotFound (node:internal/modules/esm/resolve:299:10)
  at packageExportsResolve (node:internal/modules/esm/resolve:589:13)
  at resolveExports (node:internal/modules/cjs/loader:621:36)
  at Function.Module._findPath (node:internal/modules/cjs/loader:711:31)
  at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1198:27)
  at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue (__PROJECT_PATH__/node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
  at Function.Module._resolveFilename (__PROJECT_PATH__/node_modules/esbuild-register/dist/node.js:4799:36)
  at Function.d._resolveFilename (__PROJECT_PATH__/node_modules/@modern-js/utils/dist/compiled/tsconfig-paths/index.js:1:7401)
  at Function.Module._load (node:internal/modules/cjs/loader:1038:27)
  at wrapModuleLoad (node:internal/modules/cjs/loader:212:19)
```

Inspired by https://github.com/nextauthjs/next-auth/pull/11224 I am adding the export here for adapter-prisma

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
