### PR TITLE
fix(docs): Typo in Prisma adapter docs

### DIFF
--- a/docs/pages/getting-started/adapters/prisma.mdx
+++ b/docs/pages/getting-started/adapters/prisma.mdx
@@ -134,7 +134,7 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
-  // Optional for WebAuthn support
+  // Optional for WebAuth support
   Authenticator Authenticator[]
 
   createdAt DateTime @default(now())


### PR DESCRIPTION
Removed extra `n` in the spelling for `WebAuth`.