### PR TITLE
fix(providers): Update Foursquare profile callback + API version

### DIFF
--- a/packages/next-auth/src/providers/foursquare.js
+++ b/packages/next-auth/src/providers/foursquare.js
@@ -4,7 +4,7 @@ import { once } from "events"
 /** @type {import("src/providers").OAuthProvider} */
 /** @type {import(".").OAuthProvider} */
 export default function Foursquare(options) {
-  const { apiVersion = "20210801" } = options
+  const { apiVersion = "20230131" } = options
   return {
     id: "foursquare",
     name: "Foursquare",
@@ -40,7 +40,7 @@ export default function Foursquare(options) {
         return JSON.parse(Buffer.concat(parts))
       },
     },
-    profile({ response: { profile } }) {
+    profile({ response: { user: profile } }) {
       return {
         id: profile.id,
         name: `${profile.firstName} ${profile.lastName}`,


### PR DESCRIPTION
## ☕️ Reasoning

The Foursquare provider does not work in its current form, because their api returns in the following form:

```json

{ "response":
  { "user": 
    { "id": "...",
      "email": "..."
    }
  }
}
```
This pull request fixes it and uses the same form with NextAuth v4 as in `@auth/core` (see [here](https://github.com/nextauthjs/next-auth/blob/1bd4dd8316e33d14636e5345fc24e4ef380f4789/packages/core/src/providers/foursquare.ts#L87C5-L87C43)).

I also bumped the `apiVersion` property to match `@auth/core`, let me know if I should test it with a newer version, and maybe open a new PR to bump the version,


## 🧢 Checklist

- [x] Documentation - no need to update docs in my opinion
- [ ] Tests
- [x] Ready to be merged
## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
