### PR TITLE
fix(core): invalid url error when using custom error page

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,7 +153,8 @@ export async function Auth(
       return toResponse(page)
     }
 
-    return Response.redirect(`${pages.error}?error=Configuration`)
+    const url = `${internalRequest.url.origin}${pages.error}?error=Configuration`
+    return Response.redirect(url)
   }
 
   const isRedirect = request.headers?.has("X-Auth-Return-Redirect")


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

When a configuration error occurs and there is a custom error page (`pages.error` config option), `@auth/core` does not currently prepend the url origin to the path before passing it to `Response.redirect`, resulting in an invalid URL error.
![image](https://github.com/user-attachments/assets/1286ceb0-fee2-4499-b73d-30b3a40805dd)
Passing the full URL into the `pages.error` config option would fix this.
This PR copys the URL building code used to handle other error types, and adds it to the configuration error handling.


## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
