### PR TITLE
Update Supabase adapter docs to specify jwt strategy

### DIFF
--- a/docs/pages/getting-started/adapters/supabase.mdx
+++ b/docs/pages/getting-started/adapters/supabase.mdx
@@ -259,14 +259,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     secret: process.env.SUPABASE_SERVICE_ROLE_KEY,
   }),
   callbacks: {
-    async session({ session, user }) {
+    async session({ session, token }) {
       const signingSecret = process.env.SUPABASE_JWT_SECRET
       if (signingSecret) {
         const payload = {
           aud: "authenticated",
           exp: Math.floor(new Date(session.expires).getTime() / 1000),
-          sub: user.id,
-          email: user.email,
+          sub: token.id,
+          email: token.email,
           role: "authenticated",
         }
         session.supabaseAccessToken = jwt.sign(payload, signingSecret)

--- a/docs/pages/getting-started/adapters/supabase.mdx
+++ b/docs/pages/getting-started/adapters/supabase.mdx
@@ -35,6 +35,7 @@ import { SupabaseAdapter } from "@auth/supabase-adapter"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [],
+  session: { strategy: "jwt" },
   adapter: SupabaseAdapter({
     url: process.env.SUPABASE_URL,
     secret: process.env.SUPABASE_SERVICE_ROLE_KEY,


### PR DESCRIPTION
## ☕️ Reasoning
Using the doc as provided in [here ](https://authjs.dev/getting-started/adapters/supabase) was causing me the following problem: `[auth][cause]: JWEInvalid: Invalid Compact JWE`, what solved the problem was specifying the `strategy` as `jwt`, however that caused another issue related to `user.id` and `user.email` being used(they are null when `strategy: jwt`) instead of `token.id` and `token.email` 

## 🧢 Checklist
- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
