### PR TITLE
fix(providers): dropbox userinfo request is post (#11397)

### DIFF
--- a/packages/core/src/providers/dropbox.ts
+++ b/packages/core/src/providers/dropbox.ts
@@ -69,10 +69,25 @@ export default function Dropbox(
     id: "dropbox",
     name: "Dropbox",
     type: "oauth",
-    authorization:
-      "https://www.dropbox.com/oauth2/authorize?token_access_type=offline&scope=account_info.read",
+    authorization: {
+      url: "https://www.dropbox.com/oauth2/authorize",
+      params: {
+          access_type: "offline",
+          scope: "account_info.read",
+      }
+    },
     token: "https://api.dropboxapi.com/oauth2/token",
-    userinfo: "https://api.dropboxapi.com/2/users/get_current_account",
+    userinfo: {
+      url: "https://api.dropboxapi.com/2/users/get_current_account",
+      async request({ tokens, provider }) {
+        return await fetch(provider.userinfo?.url as URL, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${tokens.access_token}`
+          },
+        }).then(async (res) => await res.json())
+      }
+    },
     profile(profile) {
       return {
         id: profile.account_id,


### PR DESCRIPTION
## ☕️ Reasoning

Dropbox provider doesn't work, error when fetching userinfo because request needs to be POST instead of GET. Thanks to [FujioHidekatsu](https://github.com/FujioHidekatsu)

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/11397