### PR TITLE
Update Apple provider config

### DIFF
--- a/packages/core/src/providers/apple.ts
+++ b/packages/core/src/providers/apple.ts
@@ -120,6 +120,13 @@ export interface AppleProfile extends Record<string, any> {
  * })
  * ```
  * 
+ * 
+ * Apple requires the client secret to be a JWT. You can generate one using the following script:
+ * https://bal.so/apple-gen-secret
+ * 
+ * Read more: [Creating the Client Secret
+](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
+ * 
  * ### Resources
  * 
  * - Sign in with Apple [Overview](https://developer.apple.com/sign-in-with-apple/get-started/)
@@ -140,16 +147,7 @@ export interface AppleProfile extends Record<string, any> {
  * we might not pursue a resolution. You can ask for more help in [Discussions](https://authjs.dev/new/github-discussions).
  */
 export default function Apple<P extends AppleProfile>(
-  options: Omit<OAuthUserConfig<P>, "clientSecret"> & {
-    /**
-     * Apple requires the client secret to be a JWT. You can generate one using the following script:
-     * https://bal.so/apple-gen-secret
-     * 
-     * Read more: [Creating the Client Secret
-](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
-     */
-    clientSecret: string
-  }
+  options: OAuthUserConfig<P>,
 ): OAuthConfig<P> {
   return {
     id: "apple",
@@ -159,13 +157,8 @@ export default function Apple<P extends AppleProfile>(
     authorization: {
       params: { scope: "name email", response_mode: "form_post" },
     },
-    profile(profile) {
-      return {
-        id: profile.sub,
-        name: profile.name,
-        email: profile.email,
-        image: null,
-      }
+    client: {
+      token_endpoint_auth_method: "client_secret_post",
     },
     style: {
       text: "#fff",


### PR DESCRIPTION
## ☕️ Reasoning

**Sing In with Apple** is currently broken, but these changes bring it closer to working (and make it work in [Convex Auth](https://labs.convex.dev/auth)).

1. Don't require `clientSecret` when options are provided. This makes it needlessly hard to configure the provider. Setting the secret via an env var works perfectly fine. Plus the notice about generating the secret ID will be more visible in the main doc block (I haven't noticed it until working on this PR).
2. Add the correct `client.token_endpoint_auth_method`. This is required by Apple (it passes clientID and clientSecret to the `token` endpoint during code grant validation).
3. Remove the profile callback. It's worse than the built-in default callback, which will not set the `image` field, while this one sets it to `null` (which breaks DB adapters not expecting `null`s for `image`).

I expect it will be weird to be partially fixing a provider that will continue to not work, but at least this PR brings it closer to a working condition once the main blocking issue is resolved. So merge would be highly appreciated 🙏

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Relevant:
- #6788 (this is the main blocker in Auth.js, but it's fixed in Convex Auth)
- #8188 (dup)
- #8189 includes some of these changes, but is a much bigger PR

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
