### PR TITLE
fix: DefaultPostgresUsersTable email column of DrizzleAdapter is allowed to be NULL

### DIFF
--- a/packages/adapter-drizzle/src/lib/pg.ts
+++ b/packages/adapter-drizzle/src/lib/pg.ts
@@ -360,7 +360,7 @@ export type DefaultPostgresUsersTable = PgTableWithColumns<{
     email: DefaultPostgresColumn<{
       columnType: "PgVarchar" | "PgText"
       data: string
-      notNull: true
+      notNull: boolean
       dataType: "string"
     }>
     emailVerified: DefaultPostgresColumn<{


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
- The email column should be allowed to be NULL because there may be no email address, such as in the case of Line Provider.
  - https://authjs.dev/getting-started/providers/line
- For the TypeORM Adapter, NULL is already allowed in the email column 
  - https://authjs.dev/getting-started/adapters/typeorm
https://github.com/nextauthjs/next-auth/blob/dafa3a702cf0dfdec13d6fa65566a23f416b2479/packages/adapter-typeorm/src/entities.ts#L29-L30

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues
- https://github.com/mikan3rd/visionaria/pull/26/files#r1692783156

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
