### PR TITLE
fix(core): revert #11050

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,6 +98,7 @@
     "dev": "pnpm css && pnpm providers && tsc -w",
     "test:e2e": "playwright test -c ../utils/playwright.config.ts",
     "test": "vitest run -c ../utils/vitest.config.ts",
+    "test:watch": "vitest -c ../utils/vitest.config.ts",
     "providers": "node scripts/generate-providers"
   },
   "devDependencies": {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -193,7 +193,7 @@ export class InvalidCallbackUrl extends AuthError {
  * 1. The user is redirected to the signin page, with `error=CredentialsSignin&code=credentials` in the URL. `code` is configurable.
  * 2. If you throw this error in a framework that handles form actions server-side, this error is thrown, instead of redirecting the user, so you'll need to handle.
  */
-export class CredentialsSignin extends Error {
+export class CredentialsSignin extends SignInError {
   static type = "CredentialsSignin"
   /**
    * The error code that is set in the `code` query parameter of the redirect URL.

--- a/packages/core/src/lib/actions/callback/index.ts
+++ b/packages/core/src/lib/actions/callback/index.ts
@@ -324,12 +324,8 @@ export async function callback(
       )
       const user = userFromAuthorize
 
-      if (!user) {
-        console.error(
-          "Read more at https://errors.authjs.dev/#credentialssignin"
-        )
-        throw new CredentialsSignin()
-      } else user.id = user.id?.toString() ?? crypto.randomUUID()
+      if (!user) throw new CredentialsSignin()
+      else user.id = user.id?.toString() ?? crypto.randomUUID()
 
       const account = {
         providerAccountId: user.id,

--- a/packages/core/test/actions/callback.test.ts
+++ b/packages/core/test/actions/callback.test.ts
@@ -7,6 +7,7 @@ import Credentials from "../../src/providers/credentials.js"
 
 import { makeAuthRequest } from "../utils.js"
 import { skipCSRFCheck } from "../../src/index.js"
+import { CredentialsSignin } from "../../src/errors.js"
 
 describe("assert GET callback action", () => {
   beforeEach(() => {
@@ -67,48 +68,107 @@ describe("assert GET callback action", () => {
       `https://login.example.com?state=${encodedState}`
     )
   })
-})
 
-it("should redirect to the custom error page is custom error page is defined", async () => {
-  const { response } = await makeAuthRequest({
-    action: "callback",
-    path: "/credentials",
-    config: {
-      pages: {
-        error: "/custom/error",
+  it("should redirect to the custom error page is custom error page is defined", async () => {
+    const { response } = await makeAuthRequest({
+      action: "callback",
+      path: "/credentials",
+      config: {
+        pages: {
+          error: "/custom/error",
+        },
+        providers: [Credentials],
       },
-      providers: [Credentials],
-    },
-  })
+    })
 
-  expect(response.status).toEqual(302)
-  expect(response.headers.get("location")).toEqual(
-    `https://authjs.test/custom/error?error=Configuration`
-  )
+    expect(response.status).toEqual(302)
+    expect(response.headers.get("location")).toEqual(
+      `https://authjs.test/custom/error?error=Configuration`
+    )
+  })
 })
 
-it("should stay on signin page if the provider is credentials and authorize returns null", async () => {
-  const { response } = await makeAuthRequest({
-    action: "callback",
-    path: "/credentials",
-    body: {
-      username: "foo",
-      password: "bar",
-    },
-    config: {
-      skipCSRFCheck,
-      providers: [
-        Credentials({
-          authorize() {
-            return null
-          },
-        }),
-      ],
-    },
-  })
+describe("assert POST callback action", () => {
+  describe("Credentials provider", () => {
+    it("should return error=CredentialSignin and code=credentials if authorize returns null", async () => {
+      const { response } = await makeAuthRequest({
+        action: "callback",
+        path: "/credentials",
+        body: {
+          username: "foo",
+          password: "bar",
+        },
+        config: {
+          skipCSRFCheck,
+          providers: [
+            Credentials({
+              authorize() {
+                return null
+              },
+            }),
+          ],
+        },
+      })
 
-  expect(response.status).toEqual(302)
-  expect(response.headers.get("location")).toEqual(
-    `https://authjs.test/auth/signin?error=CredentialsSignin&code=credentials`
-  )
+      expect(response.status).toEqual(302)
+      expect(response.headers.get("location")).toEqual(
+        `https://authjs.test/auth/signin?error=CredentialsSignin&code=credentials`
+      )
+    })
+
+    it("should return error=Configuration if authorize throws an Error that is not extending from CredentialSignin", async () => {
+      const { response } = await makeAuthRequest({
+        action: "callback",
+        path: "/credentials",
+        body: {
+          username: "foo",
+          password: "bar",
+        },
+        config: {
+          skipCSRFCheck,
+          providers: [
+            Credentials({
+              authorize() {
+                throw new Error()
+              },
+            }),
+          ],
+        },
+      })
+
+      expect(response.status).toEqual(302)
+      expect(response.headers.get("location")).toEqual(
+        `https://authjs.test/auth/error?error=Configuration`
+      )
+    })
+
+    it("should return error=CredentialsSignin and code=custom if authorize throws an custom Error that is extending from CredentialSignin", async () => {
+      class CustomSigninError extends CredentialsSignin {
+        code = "custom"
+      }
+      const { response } = await makeAuthRequest({
+        action: "callback",
+        path: "/credentials",
+        body: {
+          username: "foo",
+          password: "bar",
+        },
+        config: {
+          skipCSRFCheck,
+          providers: [
+            Credentials({
+              authorize() {
+                throw new CustomSigninError()
+              },
+            }),
+          ],
+        },
+      })
+
+      expect(response.status).toEqual(302)
+      expect(response.headers.get("location")).toEqual(
+        `https://authjs.test/auth/signin?error=CredentialsSignin&code=custom`
+      )
+    })
+  })
 })

--- a/packages/core/test/actions/callback.test.ts
+++ b/packages/core/test/actions/callback.test.ts
@@ -6,6 +6,7 @@ import GitHub from "../../src/providers/github.js"
 import Credentials from "../../src/providers/credentials.js"
 
 import { makeAuthRequest } from "../utils.js"
+import { skipCSRFCheck } from "../../src/index.js"
 
 describe("assert GET callback action", () => {
   beforeEach(() => {
@@ -83,5 +84,31 @@ it("should redirect to the custom error page is custom error page is defined", a
   expect(response.status).toEqual(302)
   expect(response.headers.get("location")).toEqual(
     `https://authjs.test/custom/error?error=Configuration`
+  )
+})
+
+it("should stay on signin page if the provider is credentials and authorize returns null", async () => {
+  const { response } = await makeAuthRequest({
+    action: "callback",
+    path: "/credentials",
+    body: {
+      username: "foo",
+      password: "bar",
+    },
+    config: {
+      skipCSRFCheck,
+      providers: [
+        Credentials({
+          authorize() {
+            return null
+          },
+        }),
+      ],
+    },
+  })
+
+  expect(response.status).toEqual(302)
+  expect(response.headers.get("location")).toEqual(
+    `https://authjs.test/auth/signin?error=CredentialsSignin&code=credentials`
   )
 })


### PR DESCRIPTION
in #11050 we accidentally introduced a regression issue for the `authorize` function of the `CredentialProvider`. Returning `null` in this callback is now throwing a `ConfigurationError` which should not be the case. 

This PR reverts the changes in #11050 and adds some tests to avoid regressing in the future.

Fixes #11074 #11190 #11428