### PR TITLE
Correct an error in the Entra docs regarding tenant configuration

### DIFF
--- a/docs/pages/getting-started/providers/microsoft-entra-id.mdx
+++ b/docs/pages/getting-started/providers/microsoft-entra-id.mdx
@@ -164,6 +164,6 @@ AUTH_MICROSOFT_ENTRA_ID_SECRET=<copy generated client secret value here>
 AUTH_MICROSOFT_ENTRA_ID_TENANT_ID=<copy the tenant id here>
 ```
 
-That will default the tenant to use the `common` authorization endpoint. [For more details see here](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols#endpoints).
+Note that this will enforce a single-tenant deployment; where only members of your organization will be able to sign in. For details on how to correctly set up a multi-tenant configuration, [see this Github issue](https://github.com/nextauthjs/next-auth/issues/8374)
 
 - Microsoft Entra returns the profile picture in an ArrayBuffer, instead of just a URL to the image, so our provider converts it to a base64 encoded image string and returns that instead. See: https://learn.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0&tabs=http#examples. The default image size is 48x48 to avoid [running out of space](https://next-auth.js.org/faq#:~:text=What%20are%20the%20disadvantages%20of%20JSON%20Web%20Tokens%3F) in case the session is saved as a JWT.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The current docs for Entra (and probably Azure too) are very confusing and essentially mislead people into setting up a configuration that will not work (and worse, will likely _appear_ to work for their own testing purposes while within their tenancy, and then will fail for external customers).

Since Azure is deprecated, it makes sense to simply make this correction going forward.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

This **DOES NOT FIX** but mitigates confusion around this issue: https://github.com/nextauthjs/next-auth/issues/8374

Note it would still be nice for some sort of compatibility workaround to be merged! **It's worth noting that in next@4.24.7 this worked if you excluded the AZURE_AD_TENANT_ID** 

```json
    "next-auth": "^4.24.7"
```
