### PR TITLE
docs: fix search results overlapping

### DIFF
--- a/docs/components/DocSearch/wrapper.tsx
+++ b/docs/components/DocSearch/wrapper.tsx
@@ -58,7 +58,7 @@ export default function () {
         <NoResultsBoundary>
           <Hits
             hitComponent={Hit}
-            className="fixed top-28 left-2 md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-lg bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50"
+            className="fixed top-28 z-100 mt-[50px] md:mt-auto left-2 md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-lg bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50"
           />
         </NoResultsBoundary>
       </InstantSearch>
@@ -75,7 +75,7 @@ function NoResultsBoundary({ children }) {
     results.nbHits === 0
   ) {
     return (
-      <div className="fixed text-center top-28 left-2 md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-md bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50">
+      <div className="fixed text-center top-28 left-2 z-100 mt-[50px] md:mt-auto md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-md bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50">
         No Results
       </div>
     )

--- a/docs/components/DocSearch/wrapper.tsx
+++ b/docs/components/DocSearch/wrapper.tsx
@@ -58,7 +58,7 @@ export default function () {
         <NoResultsBoundary>
           <Hits
             hitComponent={Hit}
-            className="fixed top-28 z-100 mt-[50px] md:mt-auto left-2 md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-lg bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50"
+            className="fixed top-28 z-50 mt-[50px] md:mt-auto left-2 md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-lg bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50"
           />
         </NoResultsBoundary>
       </InstantSearch>
@@ -75,7 +75,7 @@ function NoResultsBoundary({ children }) {
     results.nbHits === 0
   ) {
     return (
-      <div className="fixed text-center top-28 left-2 z-100 mt-[50px] md:mt-auto md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-md bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50">
+      <div className="fixed text-center top-28 left-2 z-50 mt-[50px] md:mt-auto md:left-auto md:absolute md:right-0 w-[calc(100vw_-_16px)] md:top-12 p-2 md:w-96 rounded-md shadow-md bg-neutral-100 dark:bg-neutral-800 [&>ol]:flex [&>ol]:flex-col max-h-[calc(100dvh_-_120px)] overflow-y-auto [&>ol]:divide-y [&>ol]:divide-neutral-400/30 [&>ol]:dark:divide-neutral-900/50">
         No Results
       </div>
     )


### PR DESCRIPTION
There were two search bar present for devices less than of 768 px one direct from navbar and another when we open sidebar.
If we use the side bar search
it overlaps the results as 
![issue](https://github.com/user-attachments/assets/8dac84b2-8d53-456e-a02d-acf9d5f52b1f)


### Fixes
There were some z-index and margin issues in wrapper.tsx file
so after fixing the issue we have now this look
![11](https://github.com/user-attachments/assets/cfea7e7d-214d-4cfd-992f-2c6a8b0b06f3)
![22](https://github.com/user-attachments/assets/27d08a68-6153-4f67-964a-1f240d30087b)

Fixes #11478
