### PR TITLE
ar(fix) [DPCP-62]: Normalize Body Value if Token Hash is present

### DIFF
--- a/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
+++ b/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
@@ -31,7 +31,7 @@ export async function createCSRFToken({
 }: CreateCSRFTokenParams) {
   if (cookieValue) {
     const [csrfToken, csrfTokenHash] = cookieValue.split("|")
-    const [bodyValueToken] = bodyValue?.split("|") || [];
+    const [bodyValueToken] = bodyValue?.split("|") || []
 
     const expectedCsrfTokenHash = await createHash(
       `${csrfToken}${options.secret}`

--- a/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
+++ b/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
@@ -31,7 +31,7 @@ export async function createCSRFToken({
 }: CreateCSRFTokenParams) {
   if (cookieValue) {
     const [csrfToken, csrfTokenHash] = cookieValue.split("|")
-    const [bodyValueToken] = bodyValue.split("|")
+    const [bodyValueToken] = bodyValue?.split("|")
 
     const expectedCsrfTokenHash = await createHash(
       `${csrfToken}${options.secret}`

--- a/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
+++ b/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
@@ -31,6 +31,7 @@ export async function createCSRFToken({
 }: CreateCSRFTokenParams) {
   if (cookieValue) {
     const [csrfToken, csrfTokenHash] = cookieValue.split("|")
+    const [bodyValueToken] = bodyValue.split("|")
 
     const expectedCsrfTokenHash = await createHash(
       `${csrfToken}${options.secret}`
@@ -40,7 +41,7 @@ export async function createCSRFToken({
       // If hash matches then we trust the CSRF token value
       // If this is a POST request and the CSRF Token in the POST request matches
       // the cookie we have already verified is the one we have set, then the token is verified!
-      const csrfTokenVerified = isPost && csrfToken === bodyValue
+      const csrfTokenVerified = isPost && csrfToken === bodyValueToken
 
       return { csrfTokenVerified, csrfToken }
     }

--- a/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
+++ b/packages/core/src/lib/actions/callback/oauth/csrf-token.ts
@@ -31,7 +31,7 @@ export async function createCSRFToken({
 }: CreateCSRFTokenParams) {
   if (cookieValue) {
     const [csrfToken, csrfTokenHash] = cookieValue.split("|")
-    const [bodyValueToken] = bodyValue?.split("|")
+    const [bodyValueToken] = bodyValue?.split("|") || [];
 
     const expectedCsrfTokenHash = await createHash(
       `${csrfToken}${options.secret}`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Depending on different cookie policies / layer 6 proxying / cardinal factors, the bodyValue for the CSRFToken might include the token hash.
Less than regressing it in case it comes directly from the form data, we can normalize/coerce it to account for that extra possibility.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

I didn't create an issue because I've solved it locally.

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
