### PR TITLE
support bun.sh

### DIFF
--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -176,7 +176,7 @@ export function initAuth(
           const auth = await authResponse.json()
 
           for (const cookie of authResponse.headers.getSetCookie())
-            if ("headers" in response)
+            if ("headers" in response && typeof response.headers.append === "function")
               response.headers.append("set-cookie", cookie)
             else response.appendHeader("set-cookie", cookie)
 

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -161,8 +161,11 @@ export function initAuth(
         }
       }
       // API Routes, getServerSideProps
-      const request = "req" in args[0] ? args[0].req : args[0]
-      const response: any = "res" in args[0] ? args[0].res : args[1]
+      // API Routes, getServerSideProps
+      const isReqResObject = "req" in args[0] && "res" in args[0] && "method" in args[0];
+      const request = isReqResObject ? args[0].req : args[0];
+      const response: any = isReqResObject ? args[0].res : args[1];
+      
       // @ts-expect-error -- request is NextRequest
       const _config = await config(request)
       onLazyLoad?.(_config)


### PR DESCRIPTION
## ☕️ Reasoning

When the runtime is bun, the `Request` object has the key `req` in it. That would make this check to fails.
In bun, response.headers is a read-only header object, so no `append` method on it.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
