### PR TITLE
fixed typo with export default function in nextJs

### DIFF
--- a/docs/components/OAuthProviderInstructions/content/components/SignInCode.tsx
+++ b/docs/components/OAuthProviderInstructions/content/components/SignInCode.tsx
@@ -22,7 +22,7 @@ export function SignInCode({ providerId, providerName, highlight }: Props) {
             __html: highlight(`
 import { signIn } from "@/auth"
  
-export function SignIn() {
+export default function SignIn() {
   return (
     <form
       action={async () => {


### PR DESCRIPTION
## ☕️ Reasoning

The export statement for the SignIn component is being corrected from a named export to a default export. The original code used export function SignIn, which is a named export, whereas export default function SignIn is the standard way to export a single component in Next.js and React projects. 

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:
-->
Fixes: [Link](https://authjs.dev/getting-started/authentication/oauth) 


## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)

<img width="572" alt="opensource" src="https://github.com/user-attachments/assets/d660f52c-e6a0-4c3d-b7b4-fa49a04abfe2">