### PR TITLE
fix(next): fix Turbopack compat issue with `next/*.js`

### DIFF
--- a/packages/next-auth/src/index.ts
+++ b/packages/next-auth/src/index.ts
@@ -83,7 +83,8 @@ import type {
   AppRouteHandlerFn,
   AppRouteHandlerFnContext,
 } from "./lib/types.js"
-import type { NextRequest } from "next/server.js"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import type { NextRequest } from "next/server"
 import type { NextAuthConfig, NextAuthRequest } from "./lib/index.js"
 export { AuthError, CredentialsSignin } from "@auth/core/errors"
 

--- a/packages/next-auth/src/lib/actions.ts
+++ b/packages/next-auth/src/lib/actions.ts
@@ -1,6 +1,8 @@
 import { Auth, raw, skipCSRFCheck, createActionURL } from "@auth/core"
-import { headers as nextHeaders, cookies } from "next/headers.js"
-import { redirect } from "next/navigation.js"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import { headers as nextHeaders, cookies } from "next/headers"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import { redirect } from "next/navigation"
 
 import type { NextAuthConfig } from "./index.js"
 import type { NextAuthResult, Session } from "../index.js"

--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -1,4 +1,5 @@
-import { NextRequest } from "next/server.js"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import { NextRequest } from "next/server"
 import type { NextAuthConfig } from "./index.js"
 import { setEnvDefaults as coreSetEnvDefaults } from "@auth/core"
 

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -1,6 +1,8 @@
 import { Auth, createActionURL, type AuthConfig } from "@auth/core"
-import { headers } from "next/headers.js"
-import { NextResponse } from "next/server.js"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import { headers } from "next/headers"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import { NextResponse } from "next/server"
 import { reqWithEnvURL } from "./env.js"
 
 import type { AuthAction, Awaitable, Session } from "@auth/core/types"
@@ -10,11 +12,8 @@ import type {
   NextApiResponse,
 } from "next"
 import type { AppRouteHandlerFn } from "./types.js"
-import type {
-  NextFetchEvent,
-  NextMiddleware,
-  NextRequest,
-} from "next/server.js"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import type { NextFetchEvent, NextMiddleware, NextRequest } from "next/server"
 
 /** Configure NextAuth.js. */
 export interface NextAuthConfig extends Omit<AuthConfig, "raw"> {
@@ -163,7 +162,6 @@ export function initAuth(
       // API Routes, getServerSideProps
       const request = "req" in args[0] ? args[0].req : args[0]
       const response: any = "res" in args[0] ? args[0].res : args[1]
-      // @ts-expect-error -- request is NextRequest
       const _config = await config(request)
       onLazyLoad?.(_config)
 
@@ -265,7 +263,6 @@ async function handleAuth(
     const augmentedReq = request as NextAuthRequest
     augmentedReq.auth = auth
     response =
-      // @ts-expect-error
       (await userMiddlewareOrRoute(augmentedReq, args[1])) ??
       NextResponse.next()
   } else if (!authorized) {

--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -1,4 +1,5 @@
-import type { NextRequest } from "next/server.js"
+// @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
+import type { NextRequest } from "next/server"
 
 /**
  * AppRouteHandlerFnContext is the context that is passed to the handler as the


### PR DESCRIPTION
Fixes #11127

A change was introduced in https://github.com/nextauthjs/next-auth/pull/9953 that broke usage with Turbopack, as it does not handle `next/*.js` imports as Webpack does.

The problem is that Next.js currently does not have a `package.json#exports` field, and `moduleResolution: "NodeNext"` breaks. https://github.com/vercel/next.js/pull/68455 will hopefully fix this, so we can drop the `// @ts-expect-error` comments.

Ref: https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports