### PR TITLE
Fix MissingRequiredError when updating existing sessions

### DIFF
--- a/packages/adapter-edgedb/src/index.ts
+++ b/packages/adapter-edgedb/src/index.ts
@@ -283,7 +283,7 @@ export function EdgeDBAdapter(client: Client): Adapter {
           set {
             sessionToken := sessionToken ?? .sessionToken,
             expires := <datetime>expires ?? .expires,
-            user := user ?? .user
+            user := assert_exists(user ?? .user)
           }
         ) {
           sessionToken,


### PR DESCRIPTION
EdgeDB fails to correctly coalesce the value of the link causing an SESSION_ERROR in NextAuth

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

Add an `assert_exists` to the coalesce on the `user` link of the `Session` object. This causes EdgeDB to correctly coalesce the optional `userId` parameter, which provides an empty set for the `user` object if not provided

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
  - `updateSession` test failed before fix, passed afterwards. Tested with EdgeDB version 5.6
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:
-->

Fixes: [Issue #11552](https://github.com/nextauthjs/next-auth/issues/11552)

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
