### PR TITLE
fix(ts): add compat types for `@auth/*-adapters` for v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 7.5.1
       - name: Setup Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
           fetch-depth: 2
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 7.5.1
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 7.5.1
+        uses: pnpm/action-setup@v4.0.0
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -87,9 +85,7 @@ jobs:
       - name: Init
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 7.5.1
+        uses: pnpm/action-setup@v4.0.0
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -99,17 +99,22 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
+    "@auth/core": "0.34.2",
     "next": "^12.2.5 || ^13 || ^14",
     "nodemailer": "^6.6.5",
     "react": "^17.0.2 || ^18",
     "react-dom": "^17.0.2 || ^18"
   },
   "peerDependenciesMeta": {
+    "@auth/core": {
+      "optional": true
+    },
     "nodemailer": {
       "optional": true
     }
   },
   "devDependencies": {
+    "@auth/core": "0.34.2",
     "@babel/cli": "^7.17.10",
     "@babel/core": "^7.18.2",
     "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",

--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -1,5 +1,4 @@
 import { Account, User, Awaitable } from "."
-// @ts-expect-error Used for backwards compatibility
 import type { Adapter as FutureAdapter } from "@auth/core/adapters"
 export interface AdapterUser extends User {
   id: string
@@ -68,14 +67,14 @@ export interface Adapter {
   getUserByEmail?: (email: string) => Awaitable<AdapterUser | null>
   /** Using the provider id and the id of the user for a specific account, get the user. */
   getUserByAccount?: (
-    providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">
+    providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">,
   ) => Awaitable<AdapterUser | null>
   updateUser?: (
-    user: Partial<AdapterUser> & Pick<AdapterUser, "id">
+    user: Partial<AdapterUser> & Pick<AdapterUser, "id">,
   ) => Awaitable<AdapterUser>
   /** @todo Implement */
   deleteUser?: (
-    userId: string
+    userId: string,
   ) => Promise<void> | Awaitable<AdapterUser | null | undefined>
   linkAccount?:
     | FutureAdapter["linkAccount"]
@@ -98,10 +97,10 @@ export interface Adapter {
     expires: Date
   }) => Awaitable<AdapterSession>
   getSessionAndUser?: (
-    sessionToken: string
+    sessionToken: string,
   ) => Awaitable<{ session: AdapterSession; user: AdapterUser } | null>
   updateSession?: (
-    session: Partial<AdapterSession> & Pick<AdapterSession, "sessionToken">
+    session: Partial<AdapterSession> & Pick<AdapterSession, "sessionToken">,
   ) => Awaitable<AdapterSession | null | undefined>
   /**
    * Deletes a session from the database.
@@ -109,10 +108,10 @@ export interface Adapter {
    * that is being deleted for logging purposes.
    */
   deleteSession?: (
-    sessionToken: string
+    sessionToken: string,
   ) => Promise<void> | Awaitable<AdapterSession | null | undefined>
   createVerificationToken?: (
-    verificationToken: VerificationToken
+    verificationToken: VerificationToken,
   ) => Awaitable<VerificationToken | null | undefined>
   /**
    * Return verification token from the database

--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -1,5 +1,6 @@
 import { Account, User, Awaitable } from "."
 import type { Adapter as FutureAdapter } from "@auth/core/adapters"
+
 export interface AdapterUser extends User {
   id: string
   email: string

--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -68,14 +68,14 @@ export interface Adapter {
   getUserByEmail?: (email: string) => Awaitable<AdapterUser | null>
   /** Using the provider id and the id of the user for a specific account, get the user. */
   getUserByAccount?: (
-    providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">,
+    providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">
   ) => Awaitable<AdapterUser | null>
   updateUser?: (
-    user: Partial<AdapterUser> & Pick<AdapterUser, "id">,
+    user: Partial<AdapterUser> & Pick<AdapterUser, "id">
   ) => Awaitable<AdapterUser>
   /** @todo Implement */
   deleteUser?: (
-    userId: string,
+    userId: string
   ) => Promise<void> | Awaitable<AdapterUser | null | undefined>
   linkAccount?:
     | FutureAdapter["linkAccount"]
@@ -98,10 +98,10 @@ export interface Adapter {
     expires: Date
   }) => Awaitable<AdapterSession>
   getSessionAndUser?: (
-    sessionToken: string,
+    sessionToken: string
   ) => Awaitable<{ session: AdapterSession; user: AdapterUser } | null>
   updateSession?: (
-    session: Partial<AdapterSession> & Pick<AdapterSession, "sessionToken">,
+    session: Partial<AdapterSession> & Pick<AdapterSession, "sessionToken">
   ) => Awaitable<AdapterSession | null | undefined>
   /**
    * Deletes a session from the database.
@@ -109,10 +109,10 @@ export interface Adapter {
    * that is being deleted for logging purposes.
    */
   deleteSession?: (
-    sessionToken: string,
+    sessionToken: string
   ) => Promise<void> | Awaitable<AdapterSession | null | undefined>
   createVerificationToken?: (
-    verificationToken: VerificationToken,
+    verificationToken: VerificationToken
   ) => Awaitable<VerificationToken | null | undefined>
   /**
    * Return verification token from the database

--- a/packages/next-auth/src/adapters.ts
+++ b/packages/next-auth/src/adapters.ts
@@ -1,5 +1,6 @@
 import { Account, User, Awaitable } from "."
-
+// @ts-expect-error Used for backwards compatibility
+import type { Adapter as FutureAdapter } from "@auth/core/adapters"
 export interface AdapterUser extends User {
   id: string
   email: string
@@ -60,7 +61,9 @@ export interface VerificationToken {
  * [Create a custom adapter](https://next-auth.js.org/tutorials/creating-a-database-adapter)
  */
 export interface Adapter {
-  createUser?: (user: Omit<AdapterUser, "id">) => Awaitable<AdapterUser>
+  createUser?:
+    | FutureAdapter["createUser"]
+    | ((user: Omit<AdapterUser, "id">) => Awaitable<AdapterUser>)
   getUser?: (id: string) => Awaitable<AdapterUser | null>
   getUserByEmail?: (email: string) => Awaitable<AdapterUser | null>
   /** Using the provider id and the id of the user for a specific account, get the user. */
@@ -74,13 +77,20 @@ export interface Adapter {
   deleteUser?: (
     userId: string
   ) => Promise<void> | Awaitable<AdapterUser | null | undefined>
-  linkAccount?: (
-    account: AdapterAccount
-  ) => Promise<void> | Awaitable<AdapterAccount | null | undefined>
+  linkAccount?:
+    | FutureAdapter["linkAccount"]
+    | ((
+        account: AdapterAccount,
+      ) => Promise<void> | Awaitable<AdapterAccount | null | undefined>)
   /** @todo Implement */
-  unlinkAccount?: (
-    providerAccountId: Pick<AdapterAccount, "provider" | "providerAccountId">
-  ) => Promise<void> | Awaitable<AdapterAccount | undefined>
+  unlinkAccount?:
+    | FutureAdapter["unlinkAccount"]
+    | ((
+        providerAccountId: Pick<
+          AdapterAccount,
+          "provider" | "providerAccountId"
+        >,
+      ) => Promise<void> | Awaitable<AdapterAccount | undefined>)
   /** Creates a session for the user and returns it. */
   createSession?: (session: {
     sessionToken: string

--- a/packages/next-auth/src/core/lib/callback-handler.ts
+++ b/packages/next-auth/src/core/lib/callback-handler.ts
@@ -104,6 +104,7 @@ export default async function callbackHandler(params: {
     } else {
       const { id: _, ...newUser } = { ...profile, emailVerified: new Date() }
       // Create user account if there isn't one for the email address already
+      // @ts-expect-error see adapters.ts' FutureAdapter["createUser"]
       user = await createUser(newUser)
       await events.createUser?.({ user })
       isNewUser = true
@@ -153,6 +154,7 @@ export default async function callbackHandler(params: {
       if (user) {
         // If the user is already signed in and the OAuth account isn't already associated
         // with another user account then we can go ahead and link the accounts safely.
+        // @ts-expect-error see adapters.ts' FutureAdapter["linkAccount"]
         await linkAccount({ ...account, userId: user.id })
         await events.linkAccount?.({ user, account, profile })
 
@@ -206,10 +208,12 @@ export default async function callbackHandler(params: {
         // create a new account for the user, link it to the OAuth acccount and
         // create a new session for them so they are signed in with it.
         const { id: _, ...newUser } = { ...profile, emailVerified: null }
+        // @ts-expect-error see adapters.ts' FutureAdapter["createUser"]
         user = await createUser(newUser)
       }
       await events.createUser?.({ user })
 
+      // @ts-expect-error see adapters.ts' FutureAdapter["linkAccount"]
       await linkAccount({ ...account, userId: user.id })
       await events.linkAccount?.({ user, account, profile })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,7 @@ importers:
 
   packages/next-auth:
     specifiers:
+      '@auth/core': 0.34.2
       '@babel/cli': ^7.17.10
       '@babel/core': ^7.18.2
       '@babel/plugin-proposal-optional-catch-binding': ^7.16.7
@@ -508,6 +509,7 @@ importers:
       preact-render-to-string: 5.2.0_preact@10.8.2
       uuid: 8.3.2
     devDependencies:
+      '@auth/core': 0.34.2
       '@babel/cli': 7.17.10_@babel+core@7.18.5
       '@babel/core': 7.18.5
       '@babel/plugin-proposal-optional-catch-binding': 7.16.7_@babel+core@7.18.5
@@ -704,6 +706,29 @@ packages:
     resolution: {integrity: sha512-qe3OXj/GivgkRcFZ2KQFDYfPW+qwOWvNXwIrw4u7g+R8WPmc8LzfV5NiEE8bxrIirD1A0oYerNsdyB9RrK1Ysw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
+
+  /@auth/core/0.34.2:
+    resolution: {integrity: sha512-KywHKRgLiF3l7PLyL73fjLSIBe1YNcA6sMeew4yMP6cfCWGXZrkkXd32AjRi1hlJ9nvovUBGZHvbn+LijO6ZeQ==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      jose: 5.6.3
+      oauth4webapi: 2.11.1
+      preact: 10.11.3
+      preact-render-to-string: 5.2.3_preact@10.11.3
+    dev: true
 
   /@aws-crypto/ie11-detection/2.0.0:
     resolution: {integrity: sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==}
@@ -7791,6 +7816,10 @@ packages:
     resolution: {integrity: sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==}
     dev: false
 
+  /@panva/hkdf/1.2.1:
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+    dev: true
+
   /@polka/url/1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
@@ -8478,6 +8507,10 @@ packages:
 
   /@types/cookie/0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
+    dev: true
+
+  /@types/cookie/0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
     dev: true
 
   /@types/debug/4.1.7:
@@ -11429,6 +11462,11 @@ packages:
   /cookie/0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+
+  /cookie/0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /copy-text-to-clipboard/3.0.1:
     resolution: {integrity: sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==}
@@ -17882,6 +17920,10 @@ packages:
     resolution: {integrity: sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==}
     dev: false
 
+  /jose/5.6.3:
+    resolution: {integrity: sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==}
+    dev: true
+
   /js-beautify/1.14.4:
     resolution: {integrity: sha512-+b4A9c3glceZEmxyIbxDOYB0ZJdReLvyU1077RqKsO4dZx9FUHjTOJn8VHwpg33QoucIykOiYbh7MfqBOghnrA==}
     engines: {node: '>=10'}
@@ -19768,6 +19810,10 @@ packages:
   /oauth/0.9.15:
     resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
     dev: false
+
+  /oauth4webapi/2.11.1:
+    resolution: {integrity: sha512-aNzOnL98bL6izG97zgnZs1PFEyO4WDVRhz2Pd066NPak44w5ESLRCYmJIyey8avSBPOMtBjhF3ZDDm7bIb7UOg==}
+    dev: true
 
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -21659,6 +21705,19 @@ packages:
       pretty-format: 3.8.0
     dev: false
 
+  /preact-render-to-string/5.2.3_preact@10.11.3:
+    resolution: {integrity: sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==}
+    peerDependencies:
+      preact: '>=10'
+    dependencies:
+      preact: 10.11.3
+      pretty-format: 3.8.0
+    dev: true
+
+  /preact/10.11.3:
+    resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
+    dev: true
+
   /preact/10.8.2:
     resolution: {integrity: sha512-AKGt0BsDSiAYzVS78jZ9qRwuorY2CoSZtf1iOC6gLb/3QyZt+fLT09aYJBjRc/BEcRc4j+j3ggERMdNE43i1LQ==}
     dev: false
@@ -21761,7 +21820,6 @@ packages:
 
   /pretty-format/3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
-    dev: false
 
   /pretty-hrtime/1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}


### PR DESCRIPTION
Fixes #9493

Import the `@auth/core/adapter` types as `FutureAdapter`.

Namely, all `@auth/*-adapter` packages should still support the old, but also the new signatures. So this is merely a fix of the currently broken v4 Adapter type