### PR TITLE
chore(docs): update refresh-token-rotation.mdx to specify setting error on session

### DIFF
--- a/docs/pages/guides/refresh-token-rotation.mdx
+++ b/docs/pages/guides/refresh-token-rotation.mdx
@@ -215,6 +215,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return session
     },
   },
+  session: ({ session, token }) => {
+      session.error = token.error;
+      return session;
+  }
 })
 
 declare module "next-auth" {

--- a/docs/pages/guides/refresh-token-rotation.mdx
+++ b/docs/pages/guides/refresh-token-rotation.mdx
@@ -119,6 +119,10 @@ export const { handlers, auth } = NextAuth({
       }
     },
   },
+  session: ({ session, token }) => {
+      session.error = token.error;
+      return session;
+  }
 })
 
 declare module "next-auth" {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

The [Refresh Token Rotation guide](https://authjs.dev/guides/refresh-token-rotation) offers a helpful code snippet example for refreshing an access tokens using the jwt callback.

However, this code snippet is incomplete. The reason being, the snippet does not include the session callback required for setting the "RefreshTokenError". Therefore, the section on [error handling](https://authjs.dev/guides/refresh-token-rotation#error-handling) would not work, as the error is never set on the session. The opening sentence of the [JWT strategy section](https://authjs.dev/guides/refresh-token-rotation#jwt-strategy) does mention utilising the session callback, so I believe it has just been unintentionally left out.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #11653

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: [INSERT_ISSUE_LINK_HERE](https://github.com/nextauthjs/next-auth/issues/11653)
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
