### PR TITLE
chore(docs): cleanup `error.mdx`

### DIFF
--- a/docs/pages/guides/pages/error.mdx
+++ b/docs/pages/guides/pages/error.mdx
@@ -10,7 +10,7 @@ In order to override Auth.js's `/api/auth/error` page we have to define our cust
 <Code>
 <Code.Next>
 
-```tsx filename="src/auth.ts"
+```ts filename="./auth.ts"
 const authConfig: NextAuthConfig = {
 ...
   pages: {

--- a/docs/pages/guides/pages/error.mdx
+++ b/docs/pages/guides/pages/error.mdx
@@ -5,7 +5,25 @@ import { Screenshot } from "@/components/Screenshot"
 
 Auth.js can be configured to display a custom error page when something goes wrong during the user authentication flow (sign in, sign out, etc..).
 
-Using the [example app](https://github.com/nextauthjs/next-auth-example), let's build a simple custom error page by creating `app/error/page.tsx` (Note: we can define custom pages to override Auth.js in `AuthConfig.pages`. By default, it will look for the route `/error`. If it doesn't exist, Auth.js will use `/api/auth/error`):
+In order to override Auth.js's `/api/auth/error` page we have to define our custom page in `AuthConfig.pages`:
+
+<Code>
+<Code.Next>
+
+```tsx filename="src/auth.ts"
+const authConfig: NextAuthConfig = {
+...
+  pages: {
+    error: "/error",
+  }
+...
+};
+```
+
+</Code.Next>
+</Code>
+
+Using the [example app](https://github.com/nextauthjs/next-auth-example), let's build a simple custom error page by creating `app/error/page.tsx` 
 
 <Code>
 <Code.Next>

--- a/docs/pages/guides/pages/error.mdx
+++ b/docs/pages/guides/pages/error.mdx
@@ -5,14 +5,12 @@ import { Screenshot } from "@/components/Screenshot"
 
 Auth.js can be configured to display a custom error page when something goes wrong during the user authentication flow (sign in, sign out, etc..).
 
-Using the [example app](https://github.com/nextauthjs/next-auth-example), let's build a simple custom error page:
+Using the [example app](https://github.com/nextauthjs/next-auth-example), let's build a simple custom error page by creating `app/error/page.tsx` (Note: we can define custom pages to override Auth.js in `AuthConfig.pages`. By default, it will look for the route `/error`. If it doesn't exist, Auth.js will use `/api/auth/error`):
 
 <Code>
 <Code.Next>
 
 ```tsx filename="app/error/page.tsx"
-import { signIn } from "../auth.ts"
-
 export default function AuthErrorPage() {
   return <>Oops</>
 }
@@ -38,7 +36,7 @@ So now we can update our custom error page with it:
 ```tsx filename="app/error/page.tsx"
 "use client"
 
-import { useParams, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 
 enum Error {
   Configuration = "Configuration",
@@ -60,8 +58,7 @@ export default function AuthErrorPage() {
 
   return (
     <div className="flex flex-col items-center justify-center w-full h-screen">
-      <a
-        href="#"
+      <div
         className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700 text-center"
       >
         <h5 className="mb-2 text-xl font-bold tracking-tight text-gray-900 dark:text-white flex flex-row justify-center items-center gap-2">
@@ -70,8 +67,7 @@ export default function AuthErrorPage() {
         <div className="font-normal text-gray-700 dark:text-gray-400">
           {errorMap[error] || "Please contact us if this error persists."}
         </div>
-      </a>
-      <div></div>
+      </div>
     </div>
   )
 }

--- a/docs/pages/guides/pages/error.mdx
+++ b/docs/pages/guides/pages/error.mdx
@@ -5,7 +5,7 @@ import { Screenshot } from "@/components/Screenshot"
 
 Auth.js can be configured to display a custom error page when something goes wrong during the user authentication flow (sign in, sign out, etc..).
 
-In order to override Auth.js's `/api/auth/error` page we have to define our custom page in `AuthConfig.pages`:
+In order to override Auth.js's `/api/auth/error` page we have to define our custom page in the AuthConfig:
 
 <Code>
 <Code.Next>


### PR DESCRIPTION

## ☕️ Reasoning

The work here is a documentation update: cleans up the mdx that renders: https://authjs.dev/guides/pages/error. There are a few unused imports and empty tags that can be removed.
Also, I thought it would be relevant to state that we still need to point the new error page in `AuthConfig`. I appreciate suggestions with better wording.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

N/A

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
