### PR TITLE
chore(docs): adds deep link to D1 Adapter doc

### DIFF
--- a/docs/pages/getting-started/adapters/d1.mdx
+++ b/docs/pages/getting-started/adapters/d1.mdx
@@ -19,7 +19,7 @@ npm install next-auth @auth/d1-adapter
 
 ### Environment Variables
 
-Environment variables in Cloudflare's platform are set either via a `wrangler.toml` configuration file, or in the [admin dashboard](https://dash.cloudflare.com).
+Environment variables in Cloudflare's platform are set either via a [`wrangler.toml`](https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables) configuration file, or in the [admin dashboard](https://dash.cloudflare.com/?to=/:account/pages/view/:pages-project/settings/environment-variables).
 
 ### Configuration
 


### PR DESCRIPTION
Adds a deep link to a Pages application's environment variables for the D1 adapter rather than using the generic dashboard home page link. This link prompts the users to select their account, Pages application, and then redirects them to the correct page where environment variables can be added/edited.

This deep linking functionality is built into the Cloudflare dashboard and is a best practice to improve user experience.