### PR TITLE
Add cookie documentation migrating-to-v5.mdx

### DIFF
--- a/docs/pages/getting-started/migrating-to-v5.mdx
+++ b/docs/pages/getting-started/migrating-to-v5.mdx
@@ -345,9 +345,9 @@ export type {
 
 </Steps>
 
-
 ## Cookies
-- The `next-auth` prefix is renamed to `authjs`
+
+- The `next-auth` prefix is renamed to `authjs`.
 
 ## Summary
 

--- a/docs/pages/getting-started/migrating-to-v5.mdx
+++ b/docs/pages/getting-started/migrating-to-v5.mdx
@@ -345,6 +345,10 @@ export type {
 
 </Steps>
 
+
+## Cookies
+- The `next-auth` prefix is renamed to `authjs`
+
 ## Summary
 
 We hope this migration goes smoothly for everyone! If you have any questions or get stuck anywhere, feel free to create [a new issue](https://github.com/nextauthjs/next-auth/issues/new) on GitHub, or come chat with us in the [Discord](https://discord.authjs.dev) server.


### PR DESCRIPTION
Some projects might use the cookies in a middleware. It is important to mention the refactor.