### PR TITLE
docs: remove duplicated search bar in mobile menu

### DIFF
--- a/docs/components/DocSearch/wrapper.tsx
+++ b/docs/components/DocSearch/wrapper.tsx
@@ -48,7 +48,7 @@ export default function () {
   }, [])
 
   return (
-    <div className="relative max-md:hidden">
+    <div className="relative md:hidden">
       <InstantSearch
         indexName="next-auth"
         // @ts-expect-error

--- a/docs/components/DocSearch/wrapper.tsx
+++ b/docs/components/DocSearch/wrapper.tsx
@@ -48,7 +48,7 @@ export default function () {
   }, [])
 
   return (
-    <div className="relative">
+    <div className="relative searchbar">
       <InstantSearch
         indexName="next-auth"
         // @ts-expect-error

--- a/docs/components/DocSearch/wrapper.tsx
+++ b/docs/components/DocSearch/wrapper.tsx
@@ -48,7 +48,7 @@ export default function () {
   }, [])
 
   return (
-    <div className="relative max-sm:hidden">
+    <div className="relative max-md:hidden">
       <InstantSearch
         indexName="next-auth"
         // @ts-expect-error

--- a/docs/components/DocSearch/wrapper.tsx
+++ b/docs/components/DocSearch/wrapper.tsx
@@ -48,7 +48,7 @@ export default function () {
   }, [])
 
   return (
-    <div className="relative searchbar">
+    <div className="relative max-sm:hidden">
       <InstantSearch
         indexName="next-auth"
         // @ts-expect-error

--- a/docs/components/DocSearch/wrapper.tsx
+++ b/docs/components/DocSearch/wrapper.tsx
@@ -48,7 +48,7 @@ export default function () {
   }, [])
 
   return (
-    <div className="relative md:hidden">
+    <div className="relative max-md:hidden">
       <InstantSearch
         indexName="next-auth"
         // @ts-expect-error

--- a/docs/pages/global.css
+++ b/docs/pages/global.css
@@ -257,3 +257,7 @@ div.nextra-search kbd {
     opacity: 0;
   }
 }
+
+div#__next div:has(nav > div.searchbar) + div > aside div:has(div.searchbar) {
+  display: none;
+}

--- a/docs/pages/global.css
+++ b/docs/pages/global.css
@@ -257,7 +257,3 @@ div.nextra-search kbd {
     opacity: 0;
   }
 }
-
-div#__next div:has(nav > div.searchbar) + div > aside div:has(div.searchbar) {
-  display: none;
-}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
This pull request fixes the issue of the duplicated search bar in the mobile menu and adds a unique identifier for the search bar. The changes are limited to CSS styles to remove the duplicate HTML. However, I encountered a problem where the project breaks when attempting to format the CSS styles (which is quite unusual).

### Before
![before-header](https://github.com/user-attachments/assets/9b2cb289-d21f-48f0-832d-177d859fd3b9)
### After
![after-header](https://github.com/user-attachments/assets/ed232f46-a552-4476-bf01-c7a7b4af54ac)

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
