### PR TITLE
chore: swap out boringavatars.com placeholders

### DIFF
--- a/apps/dev/nextjs/components/header.tsx
+++ b/apps/dev/nextjs/components/header.tsx
@@ -17,7 +17,7 @@ export function Header({
         <img
           src={
             session?.user?.image ??
-            "https://source.boringavatars.com/marble/120"
+            `https://api.dicebear.com/9.x/thumbs/svg?seed=${Math.floor(Math.random() * 100000) + 1}&randomizeIds=true`
           }
           className={styles.avatar}
         />

--- a/apps/dev/sveltekit/src/auth.ts
+++ b/apps/dev/sveltekit/src/auth.ts
@@ -28,7 +28,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
         return {
           name: "Fill Murray",
           email: "bill@fillmurray.com",
-          image: "https://source.boringavatars.com/marble/120",
+          image: `https://api.dicebear.com/9.x/thumbs/svg?seed=234173&randomizeIds=true`,
           id: "1",
         }
       },

--- a/apps/dev/sveltekit/src/components/header.svelte
+++ b/apps/dev/sveltekit/src/components/header.svelte
@@ -9,7 +9,7 @@
       <img
         alt="Avatar"
         src={$page.data.session?.user?.image ??
-          "https://source.boringavatars.com/marble/120"}
+          `https://api.dicebear.com/9.x/thumbs/svg?seed=${Math.floor(Math.random() * 100000) + 1}&randomizeIds=true`}
         class="avatar"
       />
     </div>

--- a/apps/examples/nextjs/components/user-button.tsx
+++ b/apps/examples/nextjs/components/user-button.tsx
@@ -25,7 +25,7 @@ export default async function UserButton() {
               <AvatarImage
                 src={
                   session.user.image ??
-                  "https://source.boringavatars.com/marble/120"
+                  `https://api.dicebear.com/9.x/thumbs/svg?seed=${Math.floor(Math.random() * 100000) + 1}&randomizeIds=true`
                 }
                 alt={session.user.name ?? ""}
               />

--- a/apps/examples/sveltekit/src/components/header.svelte
+++ b/apps/examples/sveltekit/src/components/header.svelte
@@ -9,7 +9,7 @@
       <img
         alt="User avatar"
         src={$page.data?.session?.user?.image ??
-          "https://source.boringavatars.com/marble/120"}
+          `https://api.dicebear.com/9.x/thumbs/svg?seed=${Math.floor(Math.random() * 100000) + 1}&randomizeIds=true`}
         class="avatar"
       />
       {#if $page.data.session}

--- a/docs/pages/getting-started/session-management/get-session.mdx
+++ b/docs/pages/getting-started/session-management/get-session.mdx
@@ -143,8 +143,7 @@ Then you can access the `session` on the `$page.data` object in your page.
 
 <nav>
   <img
-    src={$page.data.session?.user?.image ??
-      "https://i.pravatar.cc/300"}
+    src={$page.data.session?.user?.image ?? "https://i.pravatar.cc/300"}
     alt="User Avatar"
   />
 </nav>

--- a/docs/pages/getting-started/session-management/get-session.mdx
+++ b/docs/pages/getting-started/session-management/get-session.mdx
@@ -99,7 +99,7 @@ export function UserAvatar({ session }: { session: Session | null }) {
   return (
     <div>
       <img
-        src={session?.user?.image ?? "https://source.boringavatars.com/marble/120"}
+        src={session?.user?.image ?? "https://i.pravatar.cc/300"}
         alt="User Avatar"
       />
     </div>
@@ -144,7 +144,7 @@ Then you can access the `session` on the `$page.data` object in your page.
 <nav>
   <img
     src={$page.data.session?.user?.image ??
-      "https://source.boringavatars.com/marble/120/"}
+      "https://i.pravatar.cc/300"}
     alt="User Avatar"
   />
 </nav>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

- Placeholder Avatar service dropped their free plan
- boringavatars.com no longer lets you link images from their `source.boringavatars.com` service directly
- You must buy a monthly subscription :( 
- Moved to [dicebear thumbs](https://www.dicebear.com/styles/thumbs/#options)
	- They're sponsored by BunnyCDN, so they have a much better chance of never getting a big bandwidth bill or anything similar. Also the images are officially `CC0` licensed. 

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
