### PR TITLE
Update example.md

### DIFF
--- a/docs/docs/getting-started/example.md
+++ b/docs/docs/getting-started/example.md
@@ -43,8 +43,10 @@ export const authOptions = {
   ],
 }
 
-export default NextAuth(authOptions)
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };
 ```
+* For app router, the method has to be exported from `/app/api/auth/[...nextauth]/route.tsx` and the export has to be with get and post since app router treats `route.tsx` as the endpoint of that specific route.
 
 All requests to `/api/auth/*` (`signIn`, `callback`, `signOut`, etc.) will automatically be handled by NextAuth.js.
 


### PR DESCRIPTION
fix: updated documentation for app router at server side method export

I have already provided the solution in the documentation from here,
https://github.com/nextauthjs/next-auth/pull/11799/commits/7091df0e1a3d1208f69607def3f2336f83d4f506

## ☕️ Reasoning

App router does not treat an endpoint as an endpoint unless route.ts is provided with GET and POST method. But in the documentation, the method is only provided as an default export. 

This causes serious confusion to developers working with Next-Auth. There are multiple issues and reports on reddit and stackoverflow over this and this part of the documentation is the main source of problem.

Editing the last two lines (just exporting the main method as both GET and POST for the route to be treated as an endpoint)
Actually covers up all the confusion and issues.

## 🧢 Checklist

- [✅ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

In nextjs app router,
- /api/auth/** routes does not work
- no authentication takes place

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
