### PR TITLE
Update linkedin.ts to support new scopes

### DIFF
--- a/packages/next-auth/src/providers/linkedin.ts
+++ b/packages/next-auth/src/providers/linkedin.ts
@@ -28,7 +28,7 @@ export default function LinkedIn<P extends LinkedInProfile>(
     type: "oauth",
     authorization: {
       url: "https://www.linkedin.com/oauth/v2/authorization",
-      params: { scope: "r_liteprofile r_emailaddress" },
+      params: { scope: "openid profile email" },
     },
     token: "https://www.linkedin.com/oauth/v2/accessToken",
     client: {


### PR DESCRIPTION
LinkedIn has updated scopes for OAuth and doesn't support older scopes anymore.

```
https://next-auth.js.org/errors#oauth_callback_handler_error unauthorized_scope_error {
  error: {
    message: 'unauthorized_scope_error',
    stack: 'Error: unauthorized_scope_error\n' +
      '    at oAuthCallback (webpack-internal:///(rsc)/./node_modules/next-auth/core/lib/oauth/callback.js:39:19)\n' +
      '    at Object.callback (webpack-internal:///(rsc)/./node_modules/next-auth/core/routes/callback.js:52:39)\n' +
      '    at AuthHandler (webpack-internal:///(rsc)/./node_modules/next-auth/core/index.js:208:41)\n' +
      '    at async NextAuthRouteHandler (webpack-internal:///(rsc)/./node_modules/next-auth/next/index.js:69:28)\n' +
      '    at async NextAuth._args$ (webpack-internal:///(rsc)/./node_modules/next-auth/next/index.js:105:16)\n' + 
      '    at async C:\\D\\project-giga\\node_modules\\next\\dist\\compiled\\next-server\\app-route.runtime.dev.js:6:55038\n' +
      '    at async ek.execute (C:\\D\\project-giga\\node_modules\\next\\dist\\compiled\\next-server\\app-route.runtime.dev.js:6:45808)\n' +
      '    at async ek.handle (C:\\D\\project-giga\\node_modules\\next\\dist\\compiled\\next-server\\app-route.runtime.dev.js:6:56292)\n' +
      '    at async doRender (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\base-server.js:1377:42)\n' +  
      '    at async cacheEntry.responseCache.get.routeKind (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\base-server.js:1587:40)\n' +
      '    at async DevServer.renderToResponseWithComponentsImpl (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\base-server.js:1507:28)\n' +
      '    at async DevServer.renderPageComponent (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\base-server.js:1931:24)\n' +
      '    at async DevServer.renderToResponseImpl (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\base-server.js:1969:32)\n' +
      '    at async DevServer.pipeImpl (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\base-server.js:920:25)\n' +
      '    at async NextNodeServer.handleCatchallRenderRequest (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\next-server.js:272:17)\n' +
      '    at async DevServer.handleRequestImpl (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\base-server.js:816:17)\n' +
      '    at async C:\\D\\project-giga\\node_modules\\next\\dist\\server\\dev\\next-dev-server.js:339:20\n' +     
      '    at async Span.traceAsyncFn (C:\\D\\project-giga\\node_modules\\next\\dist\\trace\\trace.js:154:20)\n' + 
      '    at async DevServer.handleRequest (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\dev\\next-dev-server.js:336:24)\n' +
      '    at async invokeRender (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\lib\\router-server.js:174:21)\n' +
      '    at async handleRequest (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\lib\\router-server.js:353:24)\n' +
      '    at async requestHandlerImpl (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\lib\\router-server.js:377:13)\n' +
      '    at async Server.requestListener (C:\\D\\project-giga\\node_modules\\next\\dist\\server\\lib\\start-server.js:141:13)',
    name: 'Error'
  },
  error_description: 'Scope &quot;r_emailaddress&quot; is not authorized for your application',
  providerId: 'linkedin',
  message: 'unauthorized_scope_error'
}
```

## ☕️ Reasoning

LinkedIn OAuth Scopes are changed from "r_liteprofile r_emailaddress" to "openid profile email"

## 📌 Resources

- [Sign In with LinkedIn using OpenID Connect](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2)
