### PR TITLE
fix(provider): Azure AD image fetch try catch

### DIFF
--- a/packages/core/src/providers/azure-ad.ts
+++ b/packages/core/src/providers/azure-ad.ts
@@ -149,15 +149,19 @@ export default function AzureAD<P extends AzureADProfile>(
     },
     async profile(profile, tokens) {
       // https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#examples
-      const response = await fetch(
-        `https://graph.microsoft.com/v1.0/me/photos/${profilePhotoSize}x${profilePhotoSize}/$value`,
-        { headers: { Authorization: `Bearer ${tokens.access_token}` } }
-      )
+      let response = null
+
+      try {
+        response = await fetch(
+          `https://graph.microsoft.com/v1.0/me/photos/${profilePhotoSize}x${profilePhotoSize}/$value`,
+          { headers: { Authorization: `Bearer ${tokens.access_token}` } }
+        )
+      } catch {}
 
       // Confirm that profile photo was returned
-      let image
+      let image = null
       // TODO: Do this without Buffer
-      if (response.ok && typeof Buffer !== "undefined") {
+      if (response && response.ok && typeof Buffer !== "undefined") {
         try {
           const pictureBuffer = await response.arrayBuffer()
           const pictureBase64 = Buffer.from(pictureBuffer).toString("base64")


### PR DESCRIPTION
## ☕️ Reasoning

A try/catch statement has been added to the Azure AD provider to prevent an error when fetching a user's profile image. In my use case, I was unable to authenticate any users with Azure AD due to this fetch request failing. Now rather than completely failing it just won't return their profile image.

I've tested this for my use case and now I can authenticate users. It just doesn't return a profile image anymore since the fetch for the image failed.

## 🧢 Checklist

- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: [Azure AD provider fails when profile photo retrieval fails](https://github.com/nextauthjs/next-auth/issues/8508)