### PR TITLE
chore(docs): cleanup unnecessary css related to nextra focus ring

### DIFF
--- a/docs/pages/global.css
+++ b/docs/pages/global.css
@@ -177,11 +177,6 @@ html[data-theme="dark"] .github-counter {
   animation: fadeOut 250ms ease-in;
 }
 
-/* Nextra Tabs buttons - fix ring cutoff from overflow-hidden */
-button[id^="headlessui-tabs-tab"] {
-  margin: 0 3px 0 3px;
-}
-
 #carbonads_bak {
   @apply flex flex-col gap-1 rounded-md bg-neutral-100 p-3 text-xs text-neutral-500 dark:bg-neutral-800 dark:!text-neutral-400;
 
@@ -205,11 +200,6 @@ button[id^="headlessui-tabs-tab"] {
     background-color: unset !important;
     padding: 0 !important;
   }
-}
-
-/* Sidebar hack for padding for focus ring */
-aside.nextra-sidebar-container .nextra-scrollbar > div {
-  padding: 4px;
 }
 
 .sponsoredBadge {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

Hi everyone,

Nextra resolved the issue of the focus ring being cut off by `overflow: hidden` in v3.0.0-alpha.35. It appears that the styles previously used to adjust the Nextra focus-visible effect are no longer necessary. Feel free to close this if I've overlooked anything.

**After changes**

![image](https://github.com/user-attachments/assets/c8ed1ed8-7e0c-4e69-ad84-6ba173f082a4)

![image](https://github.com/user-attachments/assets/a6432059-4adf-4a47-bc5c-48cf5e2fb438)

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
