### PR TITLE
Fix bug when using nodemailer with SES

### DIFF
--- a/packages/core/src/providers/nodemailer.ts
+++ b/packages/core/src/providers/nodemailer.ts
@@ -72,7 +72,9 @@ export default function Nodemailer(
         text: text({ url, host }),
         html: html({ url, host, theme }),
       })
-      const failed = result.rejected.concat(result.pending).filter(Boolean)
+      const rejected = result.rejected || []
+      const pending = result.pending || []
+      const failed = rejected.concat(pending).filter(Boolean)
       if (failed.length) {
         throw new Error(`Email (${failed.join(", ")}) could not be sent`)
       }


### PR DESCRIPTION
## ☕️ Reasoning

I was getting this error when trying to use Nodemailer and NextAuth with SES.

https://github.com/nodemailer/nodemailer/issues/1293

One solution is to expose an SMTP server, but I didn't like that option, so I fixed this issue with a few steps, one of which is this simple patch.

Here is the rest of my code to get this working with the SES client:
```
import NextAuth from "next-auth"
import { PrismaAdapter } from "@auth/prisma-adapter"
import { prisma } from "@/prisma"
import Nodemailer from "next-auth/providers/nodemailer"
import { SESClient, SendRawEmailCommand } from '@aws-sdk/client-ses';

const sesClient = new SESClient({
  region: 'us-west-2',
});

const ses = {
  config: sesClient.config,
  send: async (command: SendRawEmailCommand) => {
    return await sesClient.send(command);
  }
};
const aws = { SendRawEmailCommand };

export const { handlers, auth, signIn, signOut } = NextAuth({
  adapter: PrismaAdapter(prisma),
  providers: [
    Nodemailer({
      name: "Email",
      server: {
        SES: { ses, aws },
      },
      from: process.env.EMAIL_FROM,
    })
  ]
})

```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

This is the only somewhat related issue I found:
https://github.com/nextauthjs/next-auth/discussions/5136
