### PR TITLE
fix(providers): set the issue url to be the correct production one in vipps provider

### DIFF
--- a/packages/core/src/providers/vipps.ts
+++ b/packages/core/src/providers/vipps.ts
@@ -76,7 +76,7 @@ export default function Vipps(
     id: "vipps",
     name: "Vipps",
     type: "oidc",
-    issuer: "https://apitest.vipps.no/access-management-1.0/access/",
+    issuer: "https://api.vipps.no/access-management-1.0/access/",
     authorization: { params: { scope: "openid name email" } },
     idToken: false,
     style: { brandColor: "#f05c18" },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

This is to fix a typo in the vipps provider. The issue was using the testing url. This PR sets the correct issuer url to be the production one.

## 🧢 Checklist

- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
