### PR TITLE
fix(docs): correct invalid closing tag in custom error page sample code

### DIFF
--- a/docs/pages/guides/pages/error.mdx
+++ b/docs/pages/guides/pages/error.mdx
@@ -86,7 +86,7 @@ export default function AuthErrorPage() {
         <div className="font-normal text-gray-700 dark:text-gray-400">
           {errorMap[error] || "Please contact us if this error persists."}
         </div>
-      </div>
+      </a>
     </div>
   )
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

This PR fixes an invalid closing tag in the custom error page sample code provided in the [documentation](https://authjs.dev/guides/pages/error). The `<a>` tag was incorrectly closed with a `</div>` instead of `</a>`, which could lead to rendering issues.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

No open issue was filed for this fix, but it corrects a documentation error.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
