### PR TITLE
Feat: use @octokit/types for GitHub provider TypeScript types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,6 +101,7 @@
     "providers": "node scripts/generate-providers"
   },
   "devDependencies": {
+    "@octokit/types": "^13.5.0",
     "@simplewebauthn/browser": "9.0.1",
     "@simplewebauthn/server": "9.0.3",
     "@simplewebauthn/types": "^9.0.1",

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -11,62 +11,13 @@
 
 import type { OAuthConfig, OAuthUserConfig } from "./index.js"
 
-export interface GitHubEmail {
-  email: string
-  primary: boolean
-  verified: boolean
-  visibility: "public" | "private"
-}
+import type { Endpoints as GitHubEndpoints } from "@octokit/types";
+
+type listEmailsResponse = GitHubEndpoints["GET /user/emails"]["response"]["data"];
+export type GitHubEmail = listEmailsResponse[number];
 
 /** @see [Get the authenticated user](https://docs.github.com/en/rest/users/users#get-the-authenticated-user) */
-export interface GitHubProfile {
-  login: string
-  id: number
-  node_id: string
-  avatar_url: string
-  gravatar_id: string | null
-  url: string
-  html_url: string
-  followers_url: string
-  following_url: string
-  gists_url: string
-  starred_url: string
-  subscriptions_url: string
-  organizations_url: string
-  repos_url: string
-  events_url: string
-  received_events_url: string
-  type: string
-  site_admin: boolean
-  name: string | null
-  company: string | null
-  blog: string | null
-  location: string | null
-  email: string | null
-  hireable: boolean | null
-  bio: string | null
-  twitter_username?: string | null
-  public_repos: number
-  public_gists: number
-  followers: number
-  following: number
-  created_at: string
-  updated_at: string
-  private_gists?: number
-  total_private_repos?: number
-  owned_private_repos?: number
-  disk_usage?: number
-  suspended_at?: string | null
-  collaborators?: number
-  two_factor_authentication: boolean
-  plan?: {
-    collaborators: number
-    name: string
-    space: number
-    private_repos: number
-  }
-  [claim: string]: unknown
-}
+export type GitHubProfile = GitHubEndpoints["GET /user"]["response"]["data"];
 
 /**
  * Add GitHub login to your page and make requests to [GitHub APIs](https://docs.github.com/en/rest).


### PR DESCRIPTION
## ☕️ Reasoning

Manually maintained TypeScript types take extra effort and can become out of sync with actual GitHub API responses

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

N/A

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
