### PR TITLE
chore: clean up entry points for TypeDoc

### DIFF
--- a/docs/typedoc.config.cjs
+++ b/docs/typedoc.config.cjs
@@ -5,7 +5,7 @@ const path = require("node:path")
 
 const isSkipAdapters = process.env.TYPEDOC_SKIP_ADAPTERS ? "skip" : "adapter-"
 const excludePackages = new RegExp(
-  `(core|lib|next-auth|frameworks-(?!template)|${isSkipAdapters})`
+  `(core|next-auth|frameworks-(?!template)|${isSkipAdapters})`
 )
 
 const entryPoints = fs

--- a/docs/typedoc.config.cjs
+++ b/docs/typedoc.config.cjs
@@ -3,27 +3,22 @@
 const fs = require("node:fs")
 const path = require("node:path")
 
-const frameworks = fs
+const isSkipAdapters = process.env.TYPEDOC_SKIP_ADAPTERS ? "skip" : "adapter-"
+const excludePackages = new RegExp(
+  `(core|lib|next-auth|frameworks-(?!template)|${isSkipAdapters})`
+)
+
+const entryPoints = fs
   .readdirSync(path.resolve(__dirname, "../packages"))
-  .filter((dir) => dir.startsWith("frameworks-"))
-  .filter((dir) => dir !== "frameworks-template")
+  .filter((dir) => excludePackages.test(dir))
   .map((dir) => `../packages/${dir}`)
-
-frameworks.push("../packages/next-auth", "../packages/core")
-
-const adapters = process.env.TYPEDOC_SKIP_ADAPTERS
-  ? []
-  : fs
-      .readdirSync(path.resolve(__dirname, "../packages"))
-      .filter((dir) => dir.startsWith("adapter-"))
-      .map((dir) => `../packages/${dir}`)
 
 /**
  * @type {import('typedoc').TypeDocOptions & import('typedoc-plugin-markdown').PluginOptions}
  */
 module.exports = {
   // typedoc options
-  entryPoints: [...frameworks, ...adapters],
+  entryPoints,
   entryPointStrategy: "packages",
   out: "pages/reference",
   tsconfig: "./tsconfig.json",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
This pull request cleans up the filter entry points in the docs/typedoc.config.cjs file, which sets up the TypeDoc configuration. It introduces a regular expression that matches the expected packages.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
