### PR TITLE
fix(getToken): make 'secret' optional when raw JWT is requested

### DIFF
--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -108,7 +108,7 @@ export async function decode<Payload = JWT>(
 }
 
 type GetTokenParamsBase = {
-  secret: JWTDecodeParams["secret"]
+  secret?: JWTDecodeParams["secret"]
   salt?: JWTDecodeParams["salt"]
 }
 
@@ -155,8 +155,7 @@ export async function getToken(
   } = params
 
   if (!req) throw new Error("Must pass `req` to JWT getToken()")
-  if (!secret)
-    throw new MissingSecret("Must pass `secret` if not set to JWT getToken()")
+  
 
   const headers =
     req.headers instanceof Headers ? req.headers : new Headers(req.headers)
@@ -179,6 +178,9 @@ export async function getToken(
   if (!token) return null
 
   if (raw) return token
+
+  if (!secret)
+    throw new MissingSecret("Must pass `secret` if not set to JWT getToken()")
 
   try {
     return await _decode({ token, secret, salt })

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -155,7 +155,6 @@ export async function getToken(
   } = params
 
   if (!req) throw new Error("Must pass `req` to JWT getToken()")
-  
 
   const headers =
     req.headers instanceof Headers ? req.headers : new Headers(req.headers)


### PR DESCRIPTION
## ☕️ Reasoning
This PR resolves an issue in the `getToken` function where the `secret` and `salt` parameters were required even when the `raw` option was set to `true`, leading to unnecessary validation errors. 

### Changes:
- Updated the `GetTokenParamsBase` type to make `secret` and `salt` optional.
- Modified the logic in `getToken` to ensure `secret` is only required when `raw: false`, allowing raw JWTs to be returned without needing to provide a `secret`.

This fix allows for a more flexible `getToken` usage where raw tokens can be retrieved without unnecessary parameters.

## 🧢 Checklist
- [x]  Ready to be merged


## 🎫 Affected issues
This PR fixes issue #11889.

Fixes #11889

## 📌 Resources
* [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
* [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
* [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
* [Contributing to Open Source](https://kcd.im/pull-request)