### PR TITLE
fix: updated email for auth user in github endpoint

### DIFF
--- a/packages/next-auth/src/providers/github.ts
+++ b/packages/next-auth/src/providers/github.ts
@@ -76,8 +76,8 @@ export default function Github<P extends GithubProfile>(
 
         if (!profile.email) {
           // If the user does not have a public email, get another via the GitHub API
-          // See https://docs.github.com/en/rest/users/emails#list-public-email-addresses-for-the-authenticated-user
-          const res = await fetch("https://api.github.com/user/public_emails", {
+          // See https://docs.github.com/en/rest/users/emails#list-email-addresses-for-the-authenticated-user
+          const res = await fetch("https://api.github.com/user/emails", {
             headers: { Authorization: `token ${tokens.access_token}` },
           })
 

--- a/packages/next-auth/src/providers/github.ts
+++ b/packages/next-auth/src/providers/github.ts
@@ -77,7 +77,7 @@ export default function Github<P extends GithubProfile>(
         if (!profile.email) {
           // If the user does not have a public email, get another via the GitHub API
           // See https://docs.github.com/en/rest/users/emails#list-public-email-addresses-for-the-authenticated-user
-          const res = await fetch("https://api.github.com/user/emails", {
+          const res = await fetch("https://api.github.com/user/public_emails", {
             headers: { Authorization: `token ${tokens.access_token}` },
           })
 


### PR DESCRIPTION
https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-public-email-addresses-for-the-authenticated-user


## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

Email fetching for github provider  updated from `https://api.github.com/user/emails` to `https://api.github.com/user/public_emails` according to Github API docs.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->
Fixes #11895 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
