### PR TITLE
fix(qwik): re-export missing core types from @auth/qwik

### DIFF
--- a/apps/dev/qwik/src/routes/plugin@auth.ts
+++ b/apps/dev/qwik/src/routes/plugin@auth.ts
@@ -1,5 +1,13 @@
-import { QwikAuth$ } from "@auth/qwik"
+import { DefaultSession, QwikAuth$ } from "@auth/qwik"
 import GitHub from "@auth/qwik/providers/github"
+
+declare module "@auth/qwik" {
+  interface Session {
+    user: {
+      roles: string[]
+    } & DefaultSession["user"]
+  }
+}
 
 export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
   () => ({

--- a/apps/examples/qwik/src/routes/plugin@auth.ts
+++ b/apps/examples/qwik/src/routes/plugin@auth.ts
@@ -1,5 +1,13 @@
-import { QwikAuth$ } from "@auth/qwik";
+import { DefaultSession, QwikAuth$ } from "@auth/qwik";
 import GitHub from "@auth/qwik/providers/github";
+
+declare module "@auth/qwik" {
+  interface Session {
+    user: {
+      roles: string[];
+    } & DefaultSession["user"];
+  }
+}
 
 export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
   () => ({

--- a/docs/pages/getting-started/typescript.mdx
+++ b/docs/pages/getting-started/typescript.mdx
@@ -77,6 +77,49 @@ export const { auth, handlers } = NextAuth({
 ```
 
 </Code.Next>
+<Code.Qwik>
+
+```ts filename="plugin@auth.ts"
+import { DefaultSession, QwikAuth$ } from "@auth/qwik"
+
+declare module "@auth/qwik" {
+  /**
+   * Returned by the `useSession` hook and the `session` object in the sharedMap
+   */
+  interface Session {
+    user: {
+      /** The user's postal address. */
+      address: string
+      /**
+       * By default, TypeScript merges new interface properties and overwrites existing ones.
+       * In this case, the default session user properties will be overwritten,
+       * with the new ones defined above. To keep the default session user properties,
+       * you need to add them back into the newly declared interface.
+       */
+    } & DefaultSession["user"]
+  }
+}
+
+export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
+  () => ({
+    callbacks: {
+      session({ session, token, user }) {
+        // `session.user.address` is now a valid property, and will be type-checked
+        // in places like `useSession().user` or `sharedMap.get('session').user`
+        return {
+          ...session,
+          user: {
+            ...session.user,
+            address: user.address,
+          },
+        }
+      },
+    },
+  })
+)
+```
+
+</Code.Qwik>
 <Code.Svelte>
 
 ```ts filename="auth.ts"

--- a/packages/frameworks-qwik/package.json
+++ b/packages/frameworks-qwik/package.json
@@ -28,6 +28,9 @@
       "types": "./index.d.ts",
       "import": "./index.qwik.js"
     },
+    "./adapters": {
+      "types": "./adapters.d.ts"
+    },
     "./providers": {
       "types": "./providers/index.d.ts"
     },

--- a/packages/frameworks-qwik/src/adapters.ts
+++ b/packages/frameworks-qwik/src/adapters.ts
@@ -1,0 +1,1 @@
+export type * from "@auth/core/adapters"

--- a/packages/frameworks-qwik/src/index.ts
+++ b/packages/frameworks-qwik/src/index.ts
@@ -124,6 +124,16 @@ import { EnvGetter } from "@builder.io/qwik-city/middleware/request-handler"
 import { isServer } from "@builder.io/qwik/build"
 import { parseString, splitCookiesString } from "set-cookie-parser"
 
+export { AuthError, CredentialsSignin } from "@auth/core/errors"
+
+export type {
+  Account,
+  DefaultSession,
+  Profile,
+  Session,
+  User,
+} from "@auth/core/types"
+
 /** Configure the {@link QwikAuth$} method. */
 export interface QwikAuthConfig extends Omit<AuthConfig, "raw"> {}
 


### PR DESCRIPTION
## ☕️ Reasoning
This PR allows `@auth/qwik` users to extend `User`, `Session`, `Account`, etc. and to have proper typing by:
* re-exporting core types
* exporting adapters types definition
* documenting how to extend `User`, `Session`, `Account`, etc. with `@auth/qwik`
* updating the Qwik example app

## 🧢 Checklist
- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
Fixes #11897 #11643 #11672 

## 📌 Resources
- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
