### PR TITLE
docs: update Nuxt community integrations

### DIFF
--- a/docs/pages/getting-started/integrations.mdx
+++ b/docs/pages/getting-started/integrations.mdx
@@ -48,8 +48,7 @@ them and are interested in collaborating, please do not hesitate to reach out!
 | Rakkas     | [Auth.js Integration Example](https://github.com/rakkasjs/rakkasjs/tree/main/examples/auth) |
 | SolidStart | [`@solid-mediakit/auth`](https://www.npmjs.com/package/@solid-mediakit/auth)                |
 | Astro      | [`auth-astro`](https://github.com/nowaythatworked/auth-astro)                               |
-| Nuxt       | [`@sidebase/nuxt-auth`](https://sidebase.io/nuxt-auth/)                                     |
-| Nuxt       | [`@hebilicious/authjs-nuxt`](https://authjs-nuxt.pages.dev/)                                |
+| Nuxt       | [`@sidebase/nuxt-auth`](https://auth.sidebase.io)                                           |
 
 ### Help needed
 


### PR DESCRIPTION

## ☕️ Reasoning

- Fixed the link for Sidebase Nuxt Auth
- Removed https://github.com/Hebilicious/authjs-nuxt as not maintained anymore

## 🧢 Checklist

- [x] Documentation