### PR TITLE
docs: add warning for missing type

### DIFF
--- a/docs/pages/guides/extending-the-session.mdx
+++ b/docs/pages/guides/extending-the-session.mdx
@@ -39,6 +39,10 @@ Then, to expose the user's id in the actual session, you can access `token.id` i
 
 Calls to `auth()` or `useSession()` will now have access to the user's id.
 
+<Callout type="warning">
+  By default `id` property does not exists in `jwt`, see the [Typescript Docs](https://authjs.dev/getting-started/typescript) for more info.
+</Callout>
+
 ## With Database
 
 If you are using a database session strategy, you can add the user's id to the session by modifying the `session` callback:

--- a/docs/pages/guides/extending-the-session.mdx
+++ b/docs/pages/guides/extending-the-session.mdx
@@ -12,12 +12,16 @@ This is `name`, `email`, and `image`.
 
 A common use case is to add the user's id to the session. Below it is shown how to do this based on the session strategy you are using.
 
+<Callout type="info">
+  By default, the `id` property does not exist on `token` or `session`. See the [TypeScript](https://authjs.dev/getting-started/typescript) on how to add it.
+</Callout>
+
 ## With JWT
 
 To have access to the user id, add the following to your Auth.js configuration:
 
 ```ts filename="auth.ts"
-  providers,
+  //  By default, the `id` property does not exist on `token` or `session`. See the [TypeScript](https://authjs.dev/getting-started/typescript) on how to add it.
   callbacks: {
     jwt({ token, user }) {
       if (user) { // User is available during sign-in
@@ -39,16 +43,12 @@ Then, to expose the user's id in the actual session, you can access `token.id` i
 
 Calls to `auth()` or `useSession()` will now have access to the user's id.
 
-<Callout type="warning">
-  By default `id` property does not exists in `jwt`, see the [Typescript Docs](https://authjs.dev/getting-started/typescript) for more info.
-</Callout>
-
 ## With Database
 
 If you are using a database session strategy, you can add the user's id to the session by modifying the `session` callback:
 
 ```ts filename="auth.ts"
-  providers,
+  //  By default, the `id` property does not exist on `session`. See the [TypeScript](https://authjs.dev/getting-started/typescript) on how to add it.
   callbacks: {
     session({ session, user }) {
       session.user.id = user.id


### PR DESCRIPTION
## ☕️ Reasoning

Adds a warning under [`"Extending the Session - with JWT"`](https://authjs.dev/guides/extending-the-session#with-jwt), to mention about the missing `id` property type in the `jwt` object.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: #11682

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
