### PR TITLE
Note about Twitter/X OAuth 2

### DIFF
--- a/docs/pages/getting-started/providers/twitter.mdx
+++ b/docs/pages/getting-started/providers/twitter.mdx
@@ -3,7 +3,7 @@ import { Code } from "@/components/Code"
 
 <img align="right" src="/img/providers/twitter.svg" height="64" width="64" />
 
-# Twitter Provider
+# Twitter/X Provider
 
 ## Resources
 
@@ -97,17 +97,7 @@ app.use("/auth/*", ExpressAuth({ providers: [Twitter] }))
   </Code.Express>
 </Code>
 
-To enable OAuth 2.0, simply add version: "2.0" to your Provider configuration.
-
-```ts filename="./auth.ts" {4}
-Twitter({
-  clientId: process.env.TWITTER_ID,
-  clientSecret: process.env.TWITTER_SECRET,
-  version: "2.0", // opt-in to Twitter OAuth 2.0
-})
-```
-
 ### Notes
 
-- Email is currently not supported by Twitter OAuth 2.0.
-- You must enable the "Request email address from users" option in your app permissions if you want to obtain the users email address.
+- Auth.js now uses Twitter/X OAuth 2.0 by default. There's no need to set `version` anymore.
+- Email is currently not supported by Twitter/X OAuth 2.0.


### PR DESCRIPTION
## ☕️ Reasoning

The `version` option is not supported anymore and the call uses OAuth 2 by default.

## 🧢 Checklist

- [x] Documentation
- N/A Tests
- [ ] Update jsdoc in `packages/core/src/providers/twitter.ts`
- [ ] Ready to be merged
