### PR TITLE
Fix #11944 - Removed explicit undefined values before passing to Prisma

### DIFF
--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -23,6 +23,12 @@ import type {
   AdapterUser,
 } from "@auth/core/adapters"
 
+function stripUndefined(data: Record<string, any>): Record<string, any> {
+  return Object.fromEntries(
+    Object.entries(data).filter(([_, v]) => v !== undefined)
+  );
+}
+
 export function PrismaAdapter(
   prisma: PrismaClient | ReturnType<PrismaClient["$extends"]>
 ): Adapter {
@@ -31,10 +37,7 @@ export function PrismaAdapter(
     // We need to let Prisma generate the ID because our default UUID is incompatible with MongoDB
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     createUser: ({ id, ...data }) => {
-      const filteredData = Object.fromEntries(
-        Object.entries(data).filter(([_, v]) => v !== undefined)
-      );
-      return p.user.create({ data: filteredData });
+      return p.user.create({ data: stripUndefined(data) });
     },
     getUser: (id) => p.user.findUnique({ where: { id } }),
     getUserByEmail: (email) => p.user.findUnique({ where: { email } }),
@@ -46,11 +49,8 @@ export function PrismaAdapter(
       return (account?.user as AdapterUser) ?? null
     },
     updateUser: ({ id, ...data }) => {
-      const filteredData = Object.fromEntries(
-        Object.entries(data).filter(([_, v]) => v !== undefined)
-      );
       return p.user.update({
-        where: { id }, data: filteredData
+        where: { id }, data: stripUndefined(data)
       }) as Promise<AdapterUser>
     },
     deleteUser: (id) =>
@@ -71,27 +71,19 @@ export function PrismaAdapter(
       return { user, session } as { user: AdapterUser; session: AdapterSession }
     },
     createSession: (data) => {
-      const filteredData = Object.fromEntries(
-        Object.entries(data).filter(([_, v]) => v !== undefined)
-      );
-      return p.session.create({ data: filteredData })
+      return p.session.create({ data: stripUndefined(data) })
     },
     updateSession: (data) => {
-      const filteredData = Object.fromEntries(
-        Object.entries(data).filter(([_, v]) => v !== undefined)
-      );
       return p.session.update({
-        where: { sessionToken: data.sessionToken }, data: filteredData
+        where: { sessionToken: data.sessionToken },
+        data: stripUndefined(data),
       })
     },
     deleteSession: (sessionToken) =>
       p.session.delete({ where: { sessionToken } }),
     async createVerificationToken(data) {
-      const filteredData = Object.fromEntries(
-        Object.entries(data).filter(([_, v]) => v !== undefined)
-      );
       const verificationToken = await p.verificationToken.create({
-        data: filteredData
+        data: stripUndefined(data),
       })
       // @ts-expect-errors // MongoDB needs an ID, but we don't
       if (verificationToken.id) delete verificationToken.id
@@ -119,11 +111,8 @@ export function PrismaAdapter(
       }) as Promise<AdapterAccount | null>
     },
     async createAuthenticator(authenticator) {
-      const filteredData = Object.fromEntries(
-        Object.entries(authenticator).filter(([_, v]) => v !== undefined)
-      );
       return p.authenticator.create({
-        data: filteredData,
+        data: stripUndefined(data),
       })
     },
     async getAuthenticator(credentialID) {

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -31,7 +31,10 @@ export function PrismaAdapter(
     // We need to let Prisma generate the ID because our default UUID is incompatible with MongoDB
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     createUser: ({ id, ...data }) => {
-      return p.user.create({ data })
+      const filteredData = Object.fromEntries(
+        Object.entries(data).filter(([_, v]) => v !== undefined)
+      );
+      return p.user.create({ data: filteredData });
     },
     getUser: (id) => p.user.findUnique({ where: { id } }),
     getUserByEmail: (email) => p.user.findUnique({ where: { email } }),
@@ -42,8 +45,14 @@ export function PrismaAdapter(
       })
       return (account?.user as AdapterUser) ?? null
     },
-    updateUser: ({ id, ...data }) =>
-      p.user.update({ where: { id }, data }) as Promise<AdapterUser>,
+    updateUser: ({ id, ...data }) => {
+      const filteredData = Object.fromEntries(
+        Object.entries(data).filter(([_, v]) => v !== undefined)
+      );
+      return p.user.update({
+        where: { id }, data: filteredData
+      }) as Promise<AdapterUser>
+    },
     deleteUser: (id) =>
       p.user.delete({ where: { id } }) as Promise<AdapterUser>,
     linkAccount: (data) =>
@@ -61,13 +70,29 @@ export function PrismaAdapter(
       const { user, ...session } = userAndSession
       return { user, session } as { user: AdapterUser; session: AdapterSession }
     },
-    createSession: (data) => p.session.create({ data }),
-    updateSession: (data) =>
-      p.session.update({ where: { sessionToken: data.sessionToken }, data }),
+    createSession: (data) => {
+      const filteredData = Object.fromEntries(
+        Object.entries(data).filter(([_, v]) => v !== undefined)
+      );
+      return p.session.create({ data: filteredData })
+    },
+    updateSession: (data) => {
+      const filteredData = Object.fromEntries(
+        Object.entries(data).filter(([_, v]) => v !== undefined)
+      );
+      return p.session.update({
+        where: { sessionToken: data.sessionToken }, data: filteredData
+      })
+    },
     deleteSession: (sessionToken) =>
       p.session.delete({ where: { sessionToken } }),
     async createVerificationToken(data) {
-      const verificationToken = await p.verificationToken.create({ data })
+      const filteredData = Object.fromEntries(
+        Object.entries(data).filter(([_, v]) => v !== undefined)
+      );
+      const verificationToken = await p.verificationToken.create({
+        data: filteredData
+      })
       // @ts-expect-errors // MongoDB needs an ID, but we don't
       if (verificationToken.id) delete verificationToken.id
       return verificationToken
@@ -94,8 +119,11 @@ export function PrismaAdapter(
       }) as Promise<AdapterAccount | null>
     },
     async createAuthenticator(authenticator) {
+      const filteredData = Object.fromEntries(
+        Object.entries(authenticator).filter(([_, v]) => v !== undefined)
+      );
       return p.authenticator.create({
-        data: authenticator,
+        data: filteredData,
       })
     },
     async getAuthenticator(credentialID) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

This addresses #11944 - Prisma now throws errors if you pass explicit undefined values as part of a create, if you have the preview feature "strictUndefinedChecks" on.  So this change filters out any explicit undefined values.  It has no tests, and was done in the simplest possible way.  I'm looking for feedback on the implementation to prepare for a merge and how you might want to see it tested.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: #11944 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
