### PR TITLE
fix: allow updating session in SessionProvider when logged out

### DIFF
--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -501,13 +501,11 @@ export function SessionProvider(props: SessionProviderProps) {
             : { body: { csrfToken: await getCsrfToken(), data } }
         )
         setLoading(false)
-        if (newSession) {
-          setSession(newSession)
-          broadcast().postMessage({
-            event: "session",
-            data: { trigger: "getSession" },
-          })
-        }
+        setSession(newSession)
+        broadcast().postMessage({
+          event: "session",
+          data: { trigger: "getSession" },
+        })
         return newSession
       },
     }),


### PR DESCRIPTION
## ☕️ Reasoning

Currently when after doing a `signOut()` request there is no way to update the session on the client side. If the session on the server is `null` `setSession` is never called. So the only way to make sure the client has an up to date value in the `SessionProvider` is to do a hard refresh.

Current:
```ts
  export const handleSignOutAction = async () => {
    "use server";
    return signOut({
      redirect: false,
    });
  };

  await handleSignOutAction();
  await session.update(); // currently after rerender useSession.session just returns the logged in session from the `SessionProvider`
```

After this PR:
```ts
  export const handleSignOutAction = async () => {
    "use server";
    return signOut({
      redirect: false,
    });
  };

  await handleSignOutAction();
  await session.update(); // after rerender useSession.session returns `null`
```

Potential problem that may arise is that `fetchData` on line 495 returns `null` when an the fetch errors. So In that case the SessionProvider will also be updated with `null` and the client will assume it's logged out.



## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

This issue is related, where it was not possible to update the session after loggin in: https://github.com/nextauthjs/next-auth/pull/11075

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
