### PR TITLE
[Provider][Strava] Convert profile.id to String to use with Prisma Adapter

### DIFF
--- a/packages/core/src/providers/strava.ts
+++ b/packages/core/src/providers/strava.ts
@@ -90,7 +90,7 @@ export default function Strava<P extends StravaProfile>(
     },
     profile(profile) {
       return {
-        id: profile.id,
+        id: String(profile.id),
         name: `${profile.firstname} ${profile.lastname}`,
         email: null,
         image: profile.profile,


### PR DESCRIPTION
## ☕️ Reasoning

Strava Provider returns profile.id as integer, however, Prisma Adapter expects a String (and does type checking at run time)
We need to convert the id (as integer) returned from the userinfo endpoint to a string

## 🧢 Checklist

- [x] Tested locally
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #11013 
