### PR TITLE
chore: bring back atlassian provider

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_provider.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_provider.yml
@@ -26,6 +26,7 @@ body:
         - "42 School"
         - "Apple"
         - "Asgardeo"
+        - "Atlassian"
         - "Auth0"
         - "Authentik"
         - "Azure Active Directory"

--- a/apps/examples/nextjs/auth.ts
+++ b/apps/examples/nextjs/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth"
 import "next-auth/jwt"
 
 import Apple from "next-auth/providers/apple"
+import Atlassian from "next-auth/providers/atlassian"
 import Auth0 from "next-auth/providers/auth0"
 import AzureB2C from "next-auth/providers/azure-ad-b2c"
 import BankIDNorway from "next-auth/providers/bankid-no"
@@ -53,6 +54,7 @@ const config = {
   adapter: UnstorageAdapter(storage),
   providers: [
     Apple,
+    Atlassian,
     Auth0,
     AzureB2C({
       clientId: process.env.AUTH_AZURE_AD_B2C_ID,

--- a/apps/proxy/api/[auth].ts
+++ b/apps/proxy/api/[auth].ts
@@ -1,5 +1,6 @@
 import { Auth, setEnvDefaults, type AuthConfig } from "@auth/core"
 import Apple from "@auth/core/providers/apple"
+import Atlassian from "@auth/core/providers/atlassian"
 import Auth0 from "@auth/core/providers/auth0"
 import AzureB2C from "@auth/core/providers/azure-ad-b2c"
 import BankId from "@auth/core/providers/bankid-no"
@@ -33,6 +34,7 @@ import Zoom from "@auth/core/providers/zoom"
 const authConfig: AuthConfig = {
   providers: [
     Apple,
+    Atlassian,
     Auth0,
     AzureB2C({
       clientId: process.env.AUTH_AZURE_AD_B2C_ID,

--- a/packages/core/src/providers/atlassian.ts
+++ b/packages/core/src/providers/atlassian.ts
@@ -1,0 +1,104 @@
+/**
+ * <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+ * <span style={{fontSize: "1.35rem" }}>
+ *  Built-in sign in with <b>Atlassian</b> integration.
+ * </span>
+ * <a href="https://www.atlassian.com/" style={{backgroundColor: "black", padding: "12px", borderRadius: "100%" }}>
+ *   <img style={{display: "block"}} src="https://authjs.dev/img/providers/atlassian.svg" width="24" style={{ marginTop: "-3px"}} />
+ * </a>
+ * </div>
+ *
+ * @module providers/atlassian
+ */
+import type { OAuthConfig, OAuthUserConfig } from "./index.js"
+
+/** The returned user profile from Atlassian when using the profile callback. */
+export interface AtlassianProfile extends Record<string, any> {
+  /**
+   * The user's atlassian account ID
+   */
+  account_id: string
+  /**
+   * The user name
+   */
+  name: string
+  /**
+   * The user's email
+   */
+  email: string
+  /**
+   * The user's profile picture
+   */
+  picture: string
+}
+
+/**
+ * ### Setup
+ *
+ * #### Callback URL
+ * ```
+ * https://example.com/api/auth/callback/atlassian
+ * ```
+ *
+ * #### Configuration
+ *
+ * Import the provider and configure it in your **Auth.js** initialization file:
+ *
+ * ```ts title="pages/api/auth/[...nextauth].ts"
+ * import NextAuth from "next-auth"
+ * import AtlassianProvider from "next-auth/providers/atlassian"
+ *
+ * export default NextAuth({
+ *   providers: [
+ *     AtlassianProvider({
+ *       clientId: process.env.ATLASSIAN_ID,
+ *       clientSecret: process.env.ATLASSIAN_SECRET,
+ *     }),
+ *   ],
+ * })
+ * ```
+ *
+ * ### Resources
+ *
+ * - [Atlassian docs](https://developer.atlassian.com/server/jira/platform/oauth/)
+ *
+ * ### Notes
+ *
+ * The Atlassian provider comes with a [default configuration](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/atlassian.ts). To override the defaults for your use case, check out [customizing a built-in OAuth provider](https://authjs.dev/guides/providers/custom-provider#override-default-options).
+ *
+ * ## Help
+ *
+ * If you think you found a bug in the default configuration, you can [open an issue](https://authjs.dev/new/provider-issue).
+ *
+ * Auth.js strictly adheres to the specification and it cannot take responsibility for any deviation from
+ * the spec by the provider. You can open an issue, but if the problem is non-compliance with the spec,
+ * we might not pursue a resolution. You can ask for more help in [Discussions](https://authjs.dev/new/github-discussions).
+ */
+export default function Atlassian<P extends AtlassianProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
+  return {
+    id: "atlassian",
+    name: "Atlassian",
+    type: "oauth",
+    authorization: {
+      url: "https://auth.atlassian.com/authorize",
+      params: {
+        audience: "api.atlassian.com",
+        prompt: "consent",
+      },
+    },
+    token: "https://auth.atlassian.com/oauth/token",
+    userinfo: "https://api.atlassian.com/me",
+    profile(profile) {
+      return {
+        id: profile.account_id,
+        name: profile.name,
+        email: profile.email,
+        image: profile.picture,
+      }
+    },
+    style: { bg: "#fff", text: "#0052cc" },
+    options,
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

This PR brings back the `Atlassian` provider which was removed in [`cb1a260`](https://github.com/nextauthjs/next-auth/commit/cb1a260523d7b5c6a5af59b63f1e911a60a9edb1), but still exists in the documentation, and was re-requested in #11613 .


## 🧢 Checklist

- [x] Documentation
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

Fixes: #11613 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
