### PR TITLE
chore: bump to oauth4webapi@3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
     "@types/cookie": "0.6.0",
     "cookie": "0.7.1",
     "jose": "^5.9.3",
-    "oauth4webapi": "^2.17.0",
+    "oauth4webapi": "^3.0.0",
     "preact": "10.11.3",
     "preact-render-to-string": "5.2.3"
   },

--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -25,10 +25,11 @@ export async function getAuthorizationUrl(
     // We check this in assert.ts
 
     const issuer = new URL(provider.issuer!)
-    const discoveryResponse = await o.discoveryRequest(
-      issuer,
-      fetchOpt(options.provider)
-    )
+    // TODO: move away from allowing insecure HTTP requests
+    const discoveryResponse = await o.discoveryRequest(issuer, {
+      ...fetchOpt(options.provider),
+      [o.allowInsecureRequests]: true,
+    })
     const as = await o.processDiscoveryResponse(issuer, discoveryResponse)
 
     if (!as.authorization_endpoint) {

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -205,7 +205,7 @@ export interface OAuth2Config<Profile>
    * Pass overrides to the underlying OAuth library.
    * See [`oauth4webapi` client](https://github.com/panva/oauth4webapi/blob/main/docs/interfaces/Client.md) for details.
    */
-  client?: Partial<Client>
+  client?: Partial<Client & { token_endpoint_auth_method: string }>
   style?: OAuthProviderButtonStyles
   /**
    * Normally, when you sign in with an OAuth provider and another account

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,10 +52,7 @@
  */
 
 import type { CookieSerializeOptions } from "cookie"
-import type {
-  OAuth2TokenEndpointResponse,
-  OpenIDTokenEndpointResponse,
-} from "oauth4webapi"
+import type { TokenEndpointResponse } from "oauth4webapi"
 import type { Adapter } from "./adapters.js"
 import { AuthConfig } from "./index.js"
 import type { JWTOptions } from "./jwt.js"
@@ -102,9 +99,7 @@ export interface Theme {
  * Some of them are available with different casing,
  * but they refer to the same value.
  */
-export type TokenSet = Partial<
-  OAuth2TokenEndpointResponse | OpenIDTokenEndpointResponse
-> & {
+export type TokenSet = Partial<TokenEndpointResponse> & {
   /**
    * Date of when the `access_token` expires in seconds.
    * This value is calculated from the `expires_in` value.
@@ -118,7 +113,7 @@ export type TokenSet = Partial<
  * Usually contains information about the provider being used
  * and also extends `TokenSet`, which is different tokens returned by OAuth Providers.
  */
-export interface Account extends Partial<OpenIDTokenEndpointResponse> {
+export interface Account extends Partial<TokenEndpointResponse> {
   /** Provider's id for this account. E.g. "google". See the full list at https://authjs.dev/reference/core/providers */
   provider: string
   /**
@@ -137,11 +132,11 @@ export interface Account extends Partial<OpenIDTokenEndpointResponse> {
    */
   userId?: string
   /**
-   * Calculated value based on {@link OAuth2TokenEndpointResponse.expires_in}.
+   * Calculated value based on {@link TokenEndpointResponse.expires_in}.
    *
-   * It is the absolute timestamp (in seconds) when the {@link OAuth2TokenEndpointResponse.access_token} expires.
+   * It is the absolute timestamp (in seconds) when the {@link TokenEndpointResponse.access_token} expires.
    *
-   * This value can be used for implementing token rotation together with {@link OAuth2TokenEndpointResponse.refresh_token}.
+   * This value can be used for implementing token rotation together with {@link TokenEndpointResponse.refresh_token}.
    *
    * @see https://authjs.dev/guides/refresh-token-rotation#database-strategy
    * @see https://www.rfc-editor.org/rfc/rfc6749#section-5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,8 +676,8 @@ importers:
         specifier: ^6.8.0
         version: 6.9.8
       oauth4webapi:
-        specifier: ^2.17.0
-        version: 2.17.0
+        specifier: ^3.0.0
+        version: 3.0.0
       preact:
         specifier: 10.11.3
         version: 10.11.3
@@ -10467,8 +10467,8 @@ packages:
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
 
-  oauth4webapi@2.17.0:
-    resolution: {integrity: sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==}
+  oauth4webapi@3.0.0:
+    resolution: {integrity: sha512-Rw9SxQYuQX9J41VgM4rVNGtm1ng0Qcd8ndv7JmhmwqQ3hHBokX+WjV379IJhKk7bVPHefgvrDgHoO/rB2dY7YA==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -26462,7 +26462,7 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  oauth4webapi@2.17.0: {}
+  oauth4webapi@3.0.0: {}
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
Bumps the oauth4webapi dependency to [v3.x](https://github.com/panva/oauth4webapi/releases/tag/v3.0.0) while 

- maintaining support for insecure HTTP requests (marking TODOs where applicable)
- keeping client_secret_basic as the default client auth method with the incomplete charset encoding of oauth4webapi@2 (marking TODOs where applicable)
- keeping multi-audience on private_key_jwt assertions (marking TODOs where applicable)