### PR TITLE
Correct the type signature of `account` in callbacks.

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -324,7 +324,7 @@ export interface AuthConfig {
      */
     signIn?: (params: {
       user: User | AdapterUser
-      account: Account | null | undefined
+      account?: Account | null
       /**
        * If OAuth provider is used, it contains the full
        * OAuth profile returned by your provider.
@@ -452,7 +452,7 @@ export interface AuthConfig {
        * Also includes {@link TokenSet}
        * @note available when `trigger` is `"signIn"` or `"signUp"`
        */
-      account: Account | null | undefined
+      account?: Account | null
       /**
        * The OAuth profile returned from your provider.
        * (In case of OIDC it will be the decoded ID Token or /userinfo response)
@@ -497,7 +497,7 @@ export interface AuthConfig {
      */
     signIn?: (message: {
       user: User
-      account: Account | null | undefined
+      account?: Account | null
       profile?: Profile
       isNewUser?: boolean
     }) => Awaitable<void>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -324,7 +324,7 @@ export interface AuthConfig {
      */
     signIn?: (params: {
       user: User | AdapterUser
-      account: Account | null
+      account: Account | null | undefined
       /**
        * If OAuth provider is used, it contains the full
        * OAuth profile returned by your provider.
@@ -452,7 +452,7 @@ export interface AuthConfig {
        * Also includes {@link TokenSet}
        * @note available when `trigger` is `"signIn"` or `"signUp"`
        */
-      account: Account | null
+      account: Account | null | undefined
       /**
        * The OAuth profile returned from your provider.
        * (In case of OIDC it will be the decoded ID Token or /userinfo response)
@@ -497,7 +497,7 @@ export interface AuthConfig {
      */
     signIn?: (message: {
       user: User
-      account: Account | null
+      account: Account | null | undefined
       profile?: Profile
       isNewUser?: boolean
     }) => Awaitable<void>


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The `account` argument can be `undefined` if it's not immediately after a sign-in. The current type signature does not reflect that.

## 🧢 Checklist

- [x] Documentation (Not applicable)
- [x] Tests
- [x] Ready to be merged
