### PR TITLE
Description of error when using 'Credentials' Provider

### DIFF
--- a/docs/pages/getting-started/providers/credentials.mdx
+++ b/docs/pages/getting-started/providers/credentials.mdx
@@ -110,6 +110,18 @@ app.use("/auth/*", ExpressAuth({
   ],
 });
 ```
+    <Callout type="warning">
+      If you use 'Credentials' Provider, you will get an error due to the security policy of auth.js. You must set the 'strategy' option, which is a sub-option of the 'session' option, to 'jwt'.
+```ts
+ExpressAuth({
+  session: {
+    strategy: "jwt"
+  },
+  providers: [...]
+})
+```
+      Reference link: [Auth.js | Core - ?session](https://authjs.dev/reference/core#session-2)
+    </Callout>
 
   </Code.Express>
 </Code>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
If you use 'Credentials' Provider, you will get an error due to the security policy of auth.js. You must set the 'strategy' option, which is a sub-option of the 'session' option, to 'jwt'.

```ts
ExpressAuth({
  session: {
    strategy: "jwt"
  },
  providers: [...]
})
```

I wasted 5 hours due to the unfriendly error description and the Docs not describing the information in detail.

I thought it would be good to report this error at the stage of using Credentials, so I decided to make a Pull Request.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
