### PR TITLE
fix(core): adds 'none' token endpoint auth method for oauth and oidc

### DIFF
--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -118,6 +118,9 @@ export async function handleOAuth(
         },
       })
       break
+    case "none":
+      clientAuth = o.None()
+      break
     default:
       throw new Error("unsupported client authentication method")
   }


### PR DESCRIPTION
https://github.com/nextauthjs/next-auth/pull/11994 introduced an undocumented breaking change by removing support for OAuth Token Endpoint Authentication Methods ```"none"```.

``` ts
{
  type: 'oidc',
  client: {
    token_endpoint_auth_method: 'none',
  }
}
```

This restores compatibility.