### PR TITLE
fix(providers): conform Apple

### DIFF
--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -206,9 +206,7 @@ export async function handleOAuth(
         break
       }
       default:
-        throw new TypeError(
-          `Unrecognized provider conformation (${provider.id}).`
-        )
+        break
     }
   }
   const processedCodeResponse = await o.processAuthorizationCodeResponse(
@@ -226,6 +224,14 @@ export async function handleOAuth(
   if (requireIdToken) {
     const idTokenClaims = o.getValidatedIdTokenClaims(processedCodeResponse)!
     profile = idTokenClaims
+
+    // Apple sends some of the user information in a `user` parameter as a stringified JSON.
+    // It also only does so the first time the user consents to share their information.
+    if (provider[conformInternal] && provider.id === "apple") {
+      try {
+        profile.user = JSON.parse(params?.user)
+      } catch {}
+    }
 
     if (provider.idToken === false) {
       const userinfoResponse = await o.userInfoRequest(

--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -68,6 +68,17 @@ export async function getAuthorizationUrl(
 
   const cookies: Cookie[] = []
 
+  if (
+    // Otherwise "POST /redirect_uri" wouldn't include the cookies
+    provider.authorization?.url.searchParams.get("response_mode") ===
+    "form_post"
+  ) {
+    options.cookies.state.options.sameSite = "none"
+    options.cookies.state.options.secure = true
+    options.cookies.nonce.options.sameSite = "none"
+    options.cookies.nonce.options.secure = true
+  }
+
   const state = await checks.state.create(options, data)
   if (state) {
     authParams.set("state", state.value)

--- a/packages/core/src/lib/utils/providers.ts
+++ b/packages/core/src/lib/utils/providers.ts
@@ -39,10 +39,20 @@ export default function parseProviders(params: {
     })
 
     if (provider.type === "oauth" || provider.type === "oidc") {
-      merged.redirectProxyUrl ??= config.redirectProxyUrl
+      merged.redirectProxyUrl ??=
+        userOptions?.redirectProxyUrl ?? config.redirectProxyUrl
+
       const normalized = normalizeOAuth(merged) as InternalProvider<
         "oauth" | "oidc"
       >
+      // We currently don't support redirect proxies for response_mode=form_post
+      if (
+        normalized.authorization?.url.searchParams.get("response_mode") ===
+        "form_post"
+      ) {
+        delete normalized.redirectProxyUrl
+      }
+
       // @ts-expect-error Symbols don't get merged by the `merge` function
       // so we need to do it manually.
       normalized[customFetch] ??= userOptions?.[customFetch]

--- a/packages/core/src/providers/apple.ts
+++ b/packages/core/src/providers/apple.ts
@@ -11,6 +11,7 @@
  * @module providers/apple
  */
 
+import { conformInternal, customFetch } from "../lib/symbols.js"
 import type { OAuthConfig, OAuthUserConfig } from "./index.js"
 
 /** The returned user profile from Apple when using the profile callback. */
@@ -94,6 +95,20 @@ export interface AppleProfile extends Record<string, any> {
   transfer_sub: string
   at_hash: string
   auth_time: number
+  user?: AppleNonConformUser
+}
+
+/**
+ * This is the shape of the `user` query parameter that Apple sends the first
+ * time the user consents to the app.
+ * @see https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server#4066168
+ */
+export interface AppleNonConformUser {
+  name: {
+    firstName: string
+    lastName: string
+  }
+  email: string
 }
 
 /**
@@ -101,42 +116,38 @@ export interface AppleProfile extends Record<string, any> {
  *
  * #### Callback URL
  * ```
- * https://example.com/api/auth/callback/apple
+ * https://example.com/auth/callback/apple
  * ```
  *
  * #### Configuration
  * ```ts
- * import { Auth } from "@auth/core"
  * import Apple from "@auth/core/providers/apple"
- *
- * const request = new Request(origin)
- * const response = await Auth(request, {
- *   providers: [
- *     Apple({
- *       clientId: APPLE_CLIENT_ID,
- *       clientSecret: APPLE_CLIENT_SECRET,
- *     }),
- *   ],
- * })
+ * ...
+ * providers: [
+ *   Apple({
+ *     clientId: env.AUTH_APPLE_ID,
+ *     clientSecret: env.AUTH_APPLE_SECRET,
+ *   })
+ * ]
+ * ...
  * ```
- * 
- * 
- * Apple requires the client secret to be a JWT. You can generate one using the following script:
- * https://bal.so/apple-gen-secret
- * 
- * Read more: [Creating the Client Secret
-](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3262048)
- * 
+ *
  * ### Resources
- * 
+ *
  * - Sign in with Apple [Overview](https://developer.apple.com/sign-in-with-apple/get-started/)
  * - Sign in with Apple [REST API](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api)
  * - [How to retrieve](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple#3383773) the user's information from Apple ID servers
  * - [Learn more about OAuth](https://authjs.dev/concepts/oauth)
-
+ * - [Creating the Client Secret](https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret)
+ *
  * ### Notes
- * 
- * The Apple provider comes with a [default configuration](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/apple.ts). To override the defaults for your use case, check out [customizing a built-in OAuth provider](https://authjs.dev/guides/configuring-oauth-providers).
+ *
+ * - Apple does not support localhost/http URLs. You can only use a live URL with HTTPS.
+ * - Apple requires the client secret to be a JWT. We provide a CLI command `npx auth add apple`, to help you generate one.
+ *   This will prompt you for the necessary information and at the end it will add the `AUTH_APPLE_ID` and `AUTH_APPLE_SECRET` to your `.env` file.
+ * - Apple provides minimal user information. It returns the user's email and name, but only the first time the user consents to the app.
+ * - The Apple provider does not support setting up the same client for multiple deployments (like [preview deployments](https://authjs.dev/getting-started/deployment#securing-a-preview-deployment)).
+ * - The Apple provider comes with a [default configuration](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/apple.ts). To override the defaults for your use case, check out [customizing a built-in OAuth provider](https://authjs.dev/guides/configuring-oauth-providers).
  *
  * ## Help
  *
@@ -146,26 +157,50 @@ export interface AppleProfile extends Record<string, any> {
  * the spec by the provider. You can open an issue, but if the problem is non-compliance with the spec,
  * we might not pursue a resolution. You can ask for more help in [Discussions](https://authjs.dev/new/github-discussions).
  */
-export default function Apple<P extends AppleProfile>(
-  options: OAuthUserConfig<P>
-): OAuthConfig<P> {
+export default function Apple(
+  config: OAuthUserConfig<AppleProfile>
+): OAuthConfig<AppleProfile> {
   return {
     id: "apple",
     name: "Apple",
     type: "oidc",
     issuer: "https://appleid.apple.com",
     authorization: {
-      params: { scope: "name email", response_mode: "form_post" },
+      params: {
+        scope: "name email", // https://developer.apple.com/documentation/sign_in_with_apple/clientconfigi/3230955-scope
+        response_mode: "form_post",
+      },
     },
-    client: {
-      token_endpoint_auth_method: "client_secret_post",
+    // We need to parse the special `user` parameter the first time the user consents to the app.
+    // It adds the `name` object to the `profile`, with `firstName` and `lastName` fields.
+    [conformInternal]: true,
+    profile(profile) {
+      const name = profile.user
+        ? `${profile.user.name.firstName} ${profile.user.name.lastName}`
+        : profile.email
+      return {
+        id: profile.sub,
+        name: name,
+        email: profile.email,
+        image: null,
+      }
     },
-    style: {
-      text: "#fff",
-      bg: "#000",
+    // Apple does not provide a userinfo endpoint.
+    async [customFetch](...args) {
+      const url = new URL(args[0] instanceof Request ? args[0].url : args[0])
+      if (url.pathname.endsWith(".well-known/openid-configuration")) {
+        const response = await fetch(...args)
+        const json = await response.clone().json()
+        return Response.json({
+          ...json,
+          userinfo_endpoint: "https://appleid.apple.com/fake_endpoint",
+        })
+      }
+      return fetch(...args)
     },
-    // https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server
+    client: { token_endpoint_auth_method: "client_secret_post" },
+    style: { text: "#fff", bg: "#000" },
     checks: ["nonce", "state"],
-    options,
+    options: config,
   }
 }

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -270,7 +270,10 @@ export type OAuthConfigInternal<Profile> = Omit<
     url: URL
     request?: TokenEndpointHandler["request"]
     clientPrivateKey?: CryptoKey | PrivateKey
-    /** @internal */
+    /**
+     * @internal
+     * @deprecated
+     */
     conform?: TokenEndpointHandler["conform"]
   }
   userinfo?: { url: URL; request?: UserinfoEndpointHandler["request"] }


### PR DESCRIPTION
## ☕️ Reasoning

"Sign in with Apple" is not the smoothest thing to implement. The DX for setting things up for development is subpar considering the UX they uphold themselves for their users. It requires extra hops on every corner.

But here it is. With some hacks in the core library - since Apple is unable to follow the OIDC spec -, it is now fully working again. I'm sorry for those who needed to implement hacks for it before.

As part of this work, we've also worked on a way to generate the client secret with a [community member](https://github.com/nextauthjs/cli/pull/10), since Apple expects it to be a JWT. You can run `npx auth add apple` in the root of your project, and it will give you a step-by-step on how to do it. At the end, it will add the `AUTH_APPLE_ID` and `AUTH_APPLE_SECRET` to your env file as well.

Feedback on it is appreciated!

Huge thanks to @ChrGrb for the preliminary work in #8428 and #8189.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Closes #8189
Closes #6788
Closes #4061
Closes #8188
Closes #9989

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
