### PR TITLE
Adding `pubkey` auth section alongside `/configuration/providers` pages in docs

### DIFF
--- a/docs/docs/configuration/providers/pubkey.md
+++ b/docs/docs/configuration/providers/pubkey.md
@@ -40,17 +40,17 @@ const config: NextAuthPubkeyConfig = {
   baseUrl: process.env.NEXTAUTH_URL,
   secret: process.env.NEXTAUTH_SECRET,
   storage: {
-    async set({ k1, session }) {
-      // save lnurl auth session data based on k1 id
+    async set({ k1, data }) {
+      // save pubkey data based on k1 id
     },
     async get({ k1 }) {
-      // lookup and return lnurl auth session data based on k1 id
+      // lookup and return pubkey data based on k1 id
     },
-    async update({ k1, session }) {
-      // update lnurl auth session data based on k1 id
+    async update({ k1, data }) {
+      // update pubkey data based on k1 id
     },
     async delete({ k1 }) {
-      // delete lnurl auth session data based on k1 id
+      // delete pubkey data based on k1 id
     },
   },
   generateQr,

--- a/docs/docs/configuration/providers/pubkey.md
+++ b/docs/docs/configuration/providers/pubkey.md
@@ -1,0 +1,109 @@
+---
+id: pubkey
+title: Pubkey
+---
+
+NextAuth.js has an active community of developers building tools and plugins that extend NextAuth.js.
+
+`next-auth-pubkey` is a light-weight plugin for NextAuth.js that enables public-private key based authentication.
+
+It's entirely self-hosted, meaning no 3rd party API keys required, and it currently supports Lightning and Nostr pubkey auth.
+
+## Complete docs
+
+[https://www.npmjs.com/package/next-auth-pubkey](https://www.npmjs.com/package/next-auth-pubkey)
+
+
+## Getting started
+
+#### Install
+
+```bash
+npm i next-auth-pubkey
+```
+
+#### .env
+
+You'll need to setup a couple of env vars in your project's `.env` file. However, you may already have them defined as part of your `next-auth` configuration.
+
+---
+
+The `NEXTAUTH_URL` env var must be defined as the canonical URL of your site.
+
+```bash
+NEXTAUTH_URL="http://localhost:3000"
+```
+
+---
+
+The `NEXTAUTH_SECRET` env var must be defined as a securely generated random string.
+
+```bash
+NEXTAUTH_SECRET="<super-secret-random-string>"
+```
+
+You can quickly create a good value for `NEXTAUTH_SECRET` on the command line via this `openssl` command.
+
+```bash
+openssl rand -base64 32
+```
+
+#### API
+
+Create a new API route under `pages/api/pubkey/[...pubkey].ts`
+
+This API will handle all of the pubkey auth API requests, such as generating QRs, handling callbacks, polling and issuing JWT auth tokens.
+
+```typescript
+// @/pages/api/pubkey/[...pubkey].ts
+
+import NextAuthPubkey, { NextAuthPubkeyConfig } from "next-auth-pubkey";
+import generateQr from "next-auth-pubkey/generators/qr";
+
+const config: NextAuthPubkeyConfig = {
+  baseUrl: process.env.NEXTAUTH_URL,
+  secret: process.env.NEXTAUTH_SECRET,
+  storage: {
+    async set({ k1, session }) {
+      // save lnurl auth session data based on k1 id
+    },
+    async get({ k1 }) {
+      // lookup and return lnurl auth session data based on k1 id
+    },
+    async update({ k1, session }) {
+      // update lnurl auth session data based on k1 id
+    },
+    async delete({ k1 }) {
+      // delete lnurl auth session data based on k1 id
+    },
+  },
+  generateQr,
+};
+
+const { lightningProvider, nostrProvider, handler } = NextAuthPubkey(config);
+
+export { lightningProvider, nostrProvider };
+
+export default handler;
+```
+
+> ℹ️ The above example uses the Pages Router. If your app uses the App Router then take a look at the [examples/app-router/](https://github.com/jowo-io/next-auth-pubkey/tree/main/examples/app-router/) example app.
+
+#### Provider
+
+In your existing `pages/api/auth/[...nextauth].ts` config file, import and add the Lightning provider to the provider array.
+
+```typescript
+// @/pages/api/auth/[...nextauth].ts
+
+import { lightningProvider, nostrProvider } from "../pubkey/[...pubkey]"; // <--- import the providers from the pubkey API route
+
+export const authOptions: AuthOptions = {
+  providers: [
+    lightningProvider, // <--- and add the providers to the providers array
+    nostrProvider, //     <--- and add the providers to the providers array
+  ],
+};
+
+export default NextAuth(authOptions);
+```

--- a/docs/docs/configuration/providers/pubkey.md
+++ b/docs/docs/configuration/providers/pubkey.md
@@ -9,53 +9,29 @@ NextAuth.js has an active community of developers building tools and plugins tha
 
 It's entirely self-hosted, meaning no 3rd party API keys required, and it currently supports Lightning and Nostr pubkey auth.
 
-## Complete docs
-
-[https://www.npmjs.com/package/next-auth-pubkey](https://www.npmjs.com/package/next-auth-pubkey)
-
-
 ## Getting started
 
-#### Install
+### Install
 
-```bash
-npm i next-auth-pubkey
+```bash npm2yarn2pnpm
+npm install next-auth-pubkey
 ```
 
-#### .env
+### Adding .env vars
 
-You'll need to setup a couple of env vars in your project's `.env` file. However, you may already have them defined as part of your `next-auth` configuration.
+You'll need to setup a couple of env vars in your project's `.env` file. However, you may already have them defined as part of your NextAuth.js configuration.
 
----
+The [NEXTAUTH_URL](/configuration/options#nextauth_url) env var must be defined as the canonical URL of your site.
 
-The `NEXTAUTH_URL` env var must be defined as the canonical URL of your site.
+The [NEXTAUTH_SECRET](/configuration/options#nextauth_secret) env var must be defined as a securely generated random string.
 
-```bash
-NEXTAUTH_URL="http://localhost:3000"
-```
-
----
-
-The `NEXTAUTH_SECRET` env var must be defined as a securely generated random string.
-
-```bash
-NEXTAUTH_SECRET="<super-secret-random-string>"
-```
-
-You can quickly create a good value for `NEXTAUTH_SECRET` on the command line via this `openssl` command.
-
-```bash
-openssl rand -base64 32
-```
-
-#### API
+### Pubkey API
 
 Create a new API route under `pages/api/pubkey/[...pubkey].ts`
 
 This API will handle all of the pubkey auth API requests, such as generating QRs, handling callbacks, polling and issuing JWT auth tokens.
 
-```typescript
-// @/pages/api/pubkey/[...pubkey].ts
+```ts title="@/pages/api/pubkey/[...pubkey].ts"
 
 import NextAuthPubkey, { NextAuthPubkeyConfig } from "next-auth-pubkey";
 import generateQr from "next-auth-pubkey/generators/qr";
@@ -87,23 +63,28 @@ export { lightningProvider, nostrProvider };
 export default handler;
 ```
 
-> ℹ️ The above example uses the Pages Router. If your app uses the App Router then take a look at the [examples/app-router/](https://github.com/jowo-io/next-auth-pubkey/tree/main/examples/app-router/) example app.
+> ℹ️ The above example uses the Pages Router. If your app uses the App Router see:
+> [https://github.com/jowo-io/next-auth-pubkey/tree/main/examples/app-router/](https://github.com/jowo-io/next-auth-pubkey/tree/main/examples/app-router/)
 
-#### Provider
+### Configuring Providers
 
-In your existing `pages/api/auth/[...nextauth].ts` config file, import and add the Lightning provider to the provider array.
+In your existing `pages/api/auth/[...nextauth].ts` config file, import and add the pubkey providers to the providers array.
 
-```typescript
-// @/pages/api/auth/[...nextauth].ts
+```ts title="@/pages/api/pubkey/[...pubkey].ts"
 
 import { lightningProvider, nostrProvider } from "../pubkey/[...pubkey]"; // <--- import the providers from the pubkey API route
 
 export const authOptions: AuthOptions = {
   providers: [
-    lightningProvider, // <--- and add the providers to the providers array
-    nostrProvider, //     <--- and add the providers to the providers array
+    lightningProvider, // <--- add the provider to the providers array
+    nostrProvider, //     <--- add the provider to the providers array
   ],
 };
 
 export default NextAuth(authOptions);
 ```
+
+## Complete docs
+
+[https://www.npmjs.com/package/next-auth-pubkey](https://www.npmjs.com/package/next-auth-pubkey)
+

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
             "configuration/providers/oauth",
             "configuration/providers/email",
             "configuration/providers/credentials",
+            "configuration/providers/pubkey",
           ],
         },
         "configuration/databases",


### PR DESCRIPTION
## ☕️ Reasoning

A little while back [a discussion](https://github.com/nextauthjs/next-auth/discussions/9711) took place regarding adding support for public-private key authentication in NextAuth.js.

I dug into the issue and concluded that I would not attempt to add this functionality directly into the NextAuth.js codebase.

So, I've built a plugin, [next-auth-pubkey](https://github.com/jowo-io/next-auth-pubkey), which extends NextAuth.js and adds support for Lightning and Nostr pubkey auth.

If anyone is curious how `next-auth-pubkey` works, take a look at the README file's [diagram](https://github.com/jowo-io/next-auth-pubkey/raw/main/diagram.jpeg?raw=true) - if anything is unclear - just ask here and I'll go into details.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/7872
