### PR TITLE
chore(docs): Qwik code example was using sveltekit code, corrected

### DIFF
--- a/docs/components/OAuthProviderInstructions/content/components/SetupCode.tsx
+++ b/docs/components/OAuthProviderInstructions/content/components/SetupCode.tsx
@@ -60,10 +60,10 @@ export const { GET, POST } = handlers
           icon={TSIcon}
           dangerouslySetInnerHTML={{
             __html: highlight(`
-import { SvelteKitAuth } from "@auth/sveltekit"
-import ${providerName} from "@auth/sveltekit/providers/${providerId}"
+import { QwikAuth$ } from "@auth/qwik"
+import ${providerName} from "@auth/qwik/providers/${providerId}"
 
-export const { handle, signIn, signOut } = SvelteKitAuth({
+export const { useSession, useSignIn, useSignOut } = QwikAuth$({
   providers: [${providerName}],
 }) `),
           }}

--- a/docs/components/OAuthProviderInstructions/content/components/SetupCode.tsx
+++ b/docs/components/OAuthProviderInstructions/content/components/SetupCode.tsx
@@ -63,7 +63,7 @@ export const { GET, POST } = handlers
 import { QwikAuth$ } from "@auth/qwik"
 import ${providerName} from "@auth/qwik/providers/${providerId}"
 
-export const { useSession, useSignIn, useSignOut } = QwikAuth$({
+export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$({
   providers: [${providerName}],
 }) `),
           }}


### PR DESCRIPTION
I noticed that in the current docs page for OAuth integration the Qwik tab uses sveltkit code so I thought I could make a simple fix and contribute in a small manner.

Link to [page](https://authjs.dev/getting-started/authentication/oauth)

<img width="846" alt="Screenshot 2024-10-21 at 10 52 20 AM" src="https://github.com/user-attachments/assets/63f7f768-7f97-47db-b2b3-73d67f42722a">



I did not create an issue for this because I felt it is a simple enough change, but happy to create a new issue if we feel that this needs to be discussed. My first PR so apologies in advance if I am not doing things correctly and appreciate any guidance.

## ☕️ Reasoning

The sample code for Qwik in the OAuth section of the docs was referencing some sveltekit code. I was hoping to update that so that it is correct.

## 🧢 Checklist

- [x] Documentation
- [NA] Tests
- [x] Ready to be merged

## 🎫 Affected issues

There are no affected issues by this. I was just hoping to make a minor update to the documentation.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
