### PR TITLE
docs: replace tenantId with issuer for Entra ID documentation

### DIFF
--- a/docs/pages/getting-started/providers/microsoft-entra-id.mdx
+++ b/docs/pages/getting-started/providers/microsoft-entra-id.mdx
@@ -54,7 +54,7 @@ https://example.com/auth/callback/microsoft-entra-id
 ```
 AUTH_MICROSOFT_ENTRA_ID_ID
 AUTH_MICROSOFT_ENTRA_ID_SECRET
-AUTH_MICROSOFT_ENTRA_ID_TENANT_ID
+AUTH_MICROSOFT_ENTRA_ID_ISSUER
 ```
 
 ### Configuration
@@ -71,7 +71,7 @@ const { handlers, auth, signIn, signOut } = NextAuth({
     MicrosoftEntraID({
       clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
       clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-      issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+      issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_ISSUER,
     }),
   ],
 })
@@ -90,7 +90,7 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
       Entra({
         clientId: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_ID,
         clientSecret: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-        issuer: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+        issuer: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_ISSUER,
       }),
     ],
   })
@@ -110,7 +110,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
     Entra({
       clientId: env.AUTH_MICROSOFT_ENTRA_ID_ID,
       clientSecret: env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-      issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+      issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_ISSUER,
     }),
   ],
 })
@@ -130,7 +130,7 @@ app.use(
       Entra({
         clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
         clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-        issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+        issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_ISSUER,
       }),
     ],
   })
@@ -153,15 +153,15 @@ app.use(
 - After your App Registration is created, under "Client Credential" create your Client secret.
 - Now copy your:
   - Application (client) ID
-  - Directory (tenant) ID
   - Client secret (value)
+  - Issuer
 
 In `.env.local` create the following entries:
 
 ```
 AUTH_MICROSOFT_ENTRA_ID_ID=<copy Application (client) ID here>
 AUTH_MICROSOFT_ENTRA_ID_SECRET=<copy generated client secret value here>
-AUTH_MICROSOFT_ENTRA_ID_TENANT_ID=<copy the tenant id here>
+AUTH_MICROSOFT_ENTRA_ID_ISSUER=<copy the issuer here>
 ```
 
 That will default the tenant to use the `common` authorization endpoint. [For more details see here](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols#endpoints).

--- a/docs/pages/getting-started/providers/microsoft-entra-id.mdx
+++ b/docs/pages/getting-started/providers/microsoft-entra-id.mdx
@@ -71,7 +71,7 @@ const { handlers, auth, signIn, signOut } = NextAuth({
     MicrosoftEntraID({
       clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
       clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-      tenantId: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+      issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
     }),
   ],
 })
@@ -90,7 +90,7 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
       Entra({
         clientId: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_ID,
         clientSecret: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-        tenantId: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+        issuer: import.meta.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
       }),
     ],
   })
@@ -110,7 +110,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
     Entra({
       clientId: env.AUTH_MICROSOFT_ENTRA_ID_ID,
       clientSecret: env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-      tenantId: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+      issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
     }),
   ],
 })
@@ -130,7 +130,7 @@ app.use(
       Entra({
         clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
         clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
-        tenantId: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
+        issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID,
       }),
     ],
   })


### PR DESCRIPTION
As per  https://github.com/nextauthjs/next-auth/blob/fac6bd93063089e0f3d1725519e627dfeb5ad1a7/packages/core/src/providers/microsoft-entra-id.ts#L67 and the object OIDCConfig the provider expects an `issuer` parameter.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The documentation doesn't align with the code. VSCode was giving errors when the code from the website is copy-pasted since the object itself doesn't contain the property `tenantId`, instead it expects the `issuer` which is documented right in the code.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

#12072 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
