### PR TITLE
fix(nextjs): Update params type with Promise as expected in Next.js 15

### DIFF
--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -1,12 +1,13 @@
 // @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
 import type { NextRequest } from "next/server"
+import type { Awaitable } from "@auth/core/types"
 
 /**
  * AppRouteHandlerFnContext is the context that is passed to the handler as the
  * second argument.
  */
 export type AppRouteHandlerFnContext = {
-  params?: Promise<Record<string, string | string[]>>
+  params?: Awaitable<Record<string, string | string[]>>
 }
 /**
  * Handler function for app routes. If a non-Response value is returned, an error

--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -6,7 +6,7 @@ import type { NextRequest } from "next/server"
  * second argument.
  */
 export type AppRouteHandlerFnContext = {
-  params?: Record<string, string | string[]>
+  params?: Promise<Record<string, string | string[]>>
 }
 /**
  * Handler function for app routes. If a non-Response value is returned, an error

--- a/packages/next-auth/src/lib/types.ts
+++ b/packages/next-auth/src/lib/types.ts
@@ -7,7 +7,7 @@ import type { Awaitable } from "@auth/core/types"
  * second argument.
  */
 export type AppRouteHandlerFnContext = {
-  params?: Awaitable<Record<string, string | string[]>>
+  params: Awaitable<Record<string, string | string[]>>
 }
 /**
  * Handler function for app routes. If a non-Response value is returned, an error


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Follow #12002, fix type error with auth() wapprer,  update params type with Promise in handler.
Ref: [Next.js Doc](https://nextjs.org/docs/canary/app/api-reference/file-conventions/route#context-optional)

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
