### PR TITLE
chore(docs): update refresh-token-rotation.mdx

### DIFF
--- a/docs/pages/guides/refresh-token-rotation.mdx
+++ b/docs/pages/guides/refresh-token-rotation.mdx
@@ -244,7 +244,7 @@ import { useEffect } from "react"
 import { auth, signIn } from "@/auth"
 
 export default async function Page() {
-  const session = await useSession()
+  const session = await auth()
   if (session?.error === "RefreshTokenError") {
     await signIn("google") // Force sign in to obtain a new set of access and refresh tokens
   }
@@ -262,7 +262,7 @@ import { useEffect } from "react"
 import { signIn, useSession } from "next-auth/react"
 
 export default function Page() {
-  const { data: session } = useSession()
+  const { data: session } = useSession() // For this to work, the Page should be wrapped inside the SessionProvider component in Layout
   useEffect(() => {
     if (session?.error !== "RefreshTokenError") return
     signIn("google") // Force sign in to obtain a new set of access and refresh tokens


### PR DESCRIPTION
- Rectify the typo in the example code for Next.js for error handling if the token refresh is unsuccessful.

-  Add a comment about wrapping the client component inside the SessionProvider component when using the useSession hook inside it for the same error handling example.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

A simple change in example code rectifying the typo. `useSession()` is used instead of `auth()` in Next.js example code in the guide related to handling the error when token refresh is unsuccessful.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
