### PR TITLE
fix(providers): dropbox authorization params should contain token_access_type

### DIFF
--- a/packages/core/src/providers/dropbox.ts
+++ b/packages/core/src/providers/dropbox.ts
@@ -72,7 +72,7 @@ export default function Dropbox(
     authorization: {
       url: "https://www.dropbox.com/oauth2/authorize",
       params: {
-        access_type: "offline",
+        token_access_type: "offline",
         scope: "account_info.read",
       },
     },


### PR DESCRIPTION
## ☕️ Reasoning

Based on [Dropbox OAuth Guide](https://developers.dropbox.com/oauth-guide) `Using Refresh Tokens` section:

`you’ll need to include token_access_type=offline as a parameter on your Authorization URL in order to return a refresh_token inside your access token payload.`

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged


## 📌 Resources

- [Dropbox OAuth Guide](https://developers.dropbox.com/oauth-guide)
