### PR TITLE
fix(core): carry-over request params for custom verifyRequest page

### DIFF
--- a/packages/core/src/lib/pages/index.ts
+++ b/packages/core/src/lib/pages/index.ts
@@ -144,7 +144,11 @@ export default function renderPage(params: RenderPageParams) {
     },
     verifyRequest(props?: any) {
       if (pages?.verifyRequest)
-        return { redirect: pages.verifyRequest, cookies }
+        return {
+          redirect: `${pages.verifyRequest}${url?.search ? url?.search : ""}`,
+          cookies,
+        }
+      //return { redirect: pages.verifyRequest + (url?.search? url?.search : ''), cookies }
       return send({
         cookies,
         theme,

--- a/packages/core/src/lib/pages/index.ts
+++ b/packages/core/src/lib/pages/index.ts
@@ -145,7 +145,7 @@ export default function renderPage(params: RenderPageParams) {
     verifyRequest(props?: any) {
       if (pages?.verifyRequest)
         return {
-          redirect: `${pages.verifyRequest}${url?.search ? url?.search : ""}`,
+          redirect: `${pages.verifyRequest}${url?.search ?? ""}`,
           cookies,
         }
       return send({

--- a/packages/core/src/lib/pages/index.ts
+++ b/packages/core/src/lib/pages/index.ts
@@ -148,7 +148,6 @@ export default function renderPage(params: RenderPageParams) {
           redirect: `${pages.verifyRequest}${url?.search ? url?.search : ""}`,
           cookies,
         }
-      //return { redirect: pages.verifyRequest + (url?.search? url?.search : ''), cookies }
       return send({
         cookies,
         theme,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Default Email Verification page accepts query params like this
```
http://localhost/api/auth/verify-request?provider=nodemailer&type=email"
```
In case we use custom request verification page we want those parameters to be carried over.
e.g.
```
  pages: {
    verifyRequest: '/verify',
  },
```
then we want `/api/auth/verify-request?provider=nodemailer&type=email` to be redirected to `/verify?provider=nodemailer&type=email`

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
