### PR TITLE
fix(providers): Ease authorization and scope override for Discord provider

### DIFF
--- a/packages/core/src/providers/discord.ts
+++ b/packages/core/src/providers/discord.ts
@@ -146,8 +146,10 @@ export default function Discord<P extends DiscordProfile>(
     id: "discord",
     name: "Discord",
     type: "oauth",
-    authorization:
-      "https://discord.com/api/oauth2/authorize?scope=identify+email",
+    authorization: {
+      url: "https://discord.com/api/oauth2/authorize",
+      params: { scope: "identify email"},
+    },
     token: "https://discord.com/api/oauth2/token",
     userinfo: "https://discord.com/api/users/@me",
     profile(profile) {


### PR DESCRIPTION
## ☕️ Reasoning

You have to give the discord url with your scope url-encoded to add any scope to Discord provider, like `https://discord.com/api/oauth2/authorize?scope=identify+email+guilds`. I'm just using other providers default `authorization` object to enable providing only a custom `scope`.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
