### PR TITLE
Allow setting custom cookie name instead of "authjs"

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -583,6 +583,18 @@ export interface AuthConfig {
    */
   useSecureCookies?: boolean
   /**
+   * When set the cookie name will use this as it's name. For example, the session cookie will be 
+   * of the form `mycookiename.session-token` or `__Secure-mycookiename.session-token`.
+   * The exact full name of the cookie will change based on other cookie-related options.
+   *
+   * - ⚠ **This is an advanced option.** Advanced options are passed the same way as basic options,
+   * but **may have complex implications** or side effects.
+   * You should **try to avoid using advanced options** unless you are very comfortable using them.
+   *
+   * The default is `authjs`.
+   */
+  cookieName?: string
+  /**
    * You can override the default cookie names and options for any of the cookies used by Auth.js.
    * You can specify one or more cookies with custom properties
    * and missing options will use the default values defined by Auth.js.

--- a/packages/core/src/lib/init.ts
+++ b/packages/core/src/lib/init.ts
@@ -106,7 +106,8 @@ export async function init({
     provider,
     cookies: merge(
       cookie.defaultCookies(
-        config.useSecureCookies ?? url.protocol === "https:"
+        config.useSecureCookies ?? url.protocol === "https:",
+        config.cookieName ?? "authjs",
       ),
       config.cookies
     ),

--- a/packages/core/src/lib/utils/assert.ts
+++ b/packages/core/src/lib/utils/assert.ts
@@ -110,7 +110,8 @@ export function assertConfig(
   }
 
   const { callbackUrl: defaultCallbackUrl } = defaultCookies(
-    options.useSecureCookies ?? url.protocol === "https:"
+    options.useSecureCookies ?? url.protocol === "https:",
+    options.cookieName ?? "authjs",
   )
   const callbackUrlCookie =
     request.cookies?.[

--- a/packages/core/src/lib/utils/cookie.ts
+++ b/packages/core/src/lib/utils/cookie.ts
@@ -56,12 +56,12 @@ export type SessionToken<T extends "jwt" | "database" = "jwt"> = T extends "jwt"
  *
  * @TODO Review cookie settings (names, options)
  */
-export function defaultCookies(useSecureCookies: boolean) {
+export function defaultCookies(useSecureCookies: boolean, cookieName = "authjs") {
   const cookiePrefix = useSecureCookies ? "__Secure-" : ""
   return {
     // default cookie options
     sessionToken: {
-      name: `${cookiePrefix}authjs.session-token`,
+      name: `${cookiePrefix}${cookieName}.session-token`,
       options: {
         httpOnly: true,
         sameSite: "lax",
@@ -70,7 +70,7 @@ export function defaultCookies(useSecureCookies: boolean) {
       },
     },
     callbackUrl: {
-      name: `${cookiePrefix}authjs.callback-url`,
+      name: `${cookiePrefix}${cookieName}.callback-url`,
       options: {
         httpOnly: true,
         sameSite: "lax",
@@ -81,7 +81,7 @@ export function defaultCookies(useSecureCookies: boolean) {
     csrfToken: {
       // Default to __Host- for CSRF token for additional protection if using useSecureCookies
       // NB: The `__Host-` prefix is stricter than the `__Secure-` prefix.
-      name: `${useSecureCookies ? "__Host-" : ""}authjs.csrf-token`,
+      name: `${useSecureCookies ? "__Host-" : ""}${cookieName}.csrf-token`,
       options: {
         httpOnly: true,
         sameSite: "lax",
@@ -90,7 +90,7 @@ export function defaultCookies(useSecureCookies: boolean) {
       },
     },
     pkceCodeVerifier: {
-      name: `${cookiePrefix}authjs.pkce.code_verifier`,
+      name: `${cookiePrefix}${cookieName}.pkce.code_verifier`,
       options: {
         httpOnly: true,
         sameSite: "lax",
@@ -100,7 +100,7 @@ export function defaultCookies(useSecureCookies: boolean) {
       },
     },
     state: {
-      name: `${cookiePrefix}authjs.state`,
+      name: `${cookiePrefix}${cookieName}.state`,
       options: {
         httpOnly: true,
         sameSite: "lax",
@@ -110,7 +110,7 @@ export function defaultCookies(useSecureCookies: boolean) {
       },
     },
     nonce: {
-      name: `${cookiePrefix}authjs.nonce`,
+      name: `${cookiePrefix}${cookieName}.nonce`,
       options: {
         httpOnly: true,
         sameSite: "lax",
@@ -119,7 +119,7 @@ export function defaultCookies(useSecureCookies: boolean) {
       },
     },
     webauthnChallenge: {
-      name: `${cookiePrefix}authjs.challenge`,
+      name: `${cookiePrefix}${cookieName}.challenge`,
       options: {
         httpOnly: true,
         sameSite: "lax",


### PR DESCRIPTION
## ☕️ Reasoning

Currently the cookie is always `authjs` by default - this exposes the implementation detail of the cookie and advanced usecases should allow customising the name of the cookie to prevent malicious users from introspecting implementation details of the authentication mechanism used by a particular website.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
