### PR TITLE
feat: Add ability to customize client-side fetch calls

### DIFF
--- a/packages/next-auth/src/lib/client.ts
+++ b/packages/next-auth/src/lib/client.ts
@@ -16,6 +16,7 @@ export interface AuthClientConfig {
   basePath: string
   baseUrlServer: string
   basePathServer: string
+  fetchOptions: RequestInit
   /** Stores last session response */
   _session?: Session | null | undefined
   /** Used for timestamp since last sycned (in seconds) */
@@ -117,6 +118,10 @@ export interface SessionProviderProps {
   baseUrl?: string
   basePath?: string
   /**
+   *  Allows for customizing underlying fetch calls made to next-auth APIs
+   */
+  fetchOptions: RequestInit
+  /**
    * A time interval (in seconds) after which the session will be re-fetched.
    * If set to `0` (default), the session is not polled.
    */
@@ -153,7 +158,9 @@ export async function fetchData<T = any>(
   const url = `${apiBaseUrl(__NEXTAUTH)}/${path}`
   try {
     const options: RequestInit = {
+      ...__NEXTAUTH.fetchOptions,
       headers: {
+        ...(__NEXTAUTH.fetchOptions || {}),
         "Content-Type": "application/json",
         ...(req?.headers?.cookie ? { cookie: req.headers.cookie } : {}),
       },

--- a/packages/next-auth/src/lib/client.ts
+++ b/packages/next-auth/src/lib/client.ts
@@ -160,7 +160,7 @@ export async function fetchData<T = any>(
     const options: RequestInit = {
       ...__NEXTAUTH.fetchOptions,
       headers: {
-        ...(__NEXTAUTH.fetchOptions || {}),
+        ...(__NEXTAUTH.fetchOptions.headers || {}),
         "Content-Type": "application/json",
         ...(req?.headers?.cookie ? { cookie: req.headers.cookie } : {}),
       },

--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -67,6 +67,7 @@ export const __NEXTAUTH: AuthClientConfig = {
   basePathServer: parseUrl(
     process.env.NEXTAUTH_URL_INTERNAL ?? process.env.NEXTAUTH_URL
   ).path,
+  fetchOptions: {},
   _lastSync: 0,
   _session: undefined,
   _getSession: () => {},
@@ -270,8 +271,10 @@ export async function signIn<
   const res = await fetch(
     `${signInUrl}?${new URLSearchParams(authorizationParams)}`,
     {
+      ...__NEXTAUTH.fetchOptions,
       method: "post",
       headers: {
+        ...(__NEXTAUTH.fetchOptions.headers || {}),
         "Content-Type": "application/x-www-form-urlencoded",
         "X-Auth-Return-Redirect": "1",
       },
@@ -323,8 +326,10 @@ export async function signOut<R extends boolean = true>(
   const baseUrl = apiBaseUrl(__NEXTAUTH)
   const csrfToken = await getCsrfToken()
   const res = await fetch(`${baseUrl}/signout`, {
+    ...__NEXTAUTH.fetchOptions,
     method: "post",
     headers: {
+      ...(__NEXTAUTH.fetchOptions.headers || {}),
       "Content-Type": "application/x-www-form-urlencoded",
       "X-Auth-Return-Redirect": "1",
     },

--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -368,9 +368,16 @@ export function SessionProvider(props: SessionProviderProps) {
     throw new Error("React Context is unavailable in Server Components")
   }
 
-  const { children, basePath, refetchInterval, refetchWhenOffline } = props
+  const {
+    children,
+    basePath,
+    fetchOptions,
+    refetchInterval,
+    refetchWhenOffline,
+  } = props
 
   if (basePath) __NEXTAUTH.basePath = basePath
+  if (fetchOptions) __NEXTAUTH.fetchOptions = fetchOptions
 
   /**
    * If session was `null`, there was an attempt to fetch it,


### PR DESCRIPTION
## ☕️ Reasoning

Currently, if you have your next-auth `SessionProvider` is configured to point to a separate domain from the next.js app, next-auth related cookies will not be sent in your requests. In order to send cookies on cross-origin request, you have to use `{ credentials: 'include' }` when you make your fetch request. This approach allows users to pass custom fetch options that will be passed to the underlying `fetch` calls.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests - I'm having trouble running tests locally, I guess I'm missing some env vars needed for local but I'm not sure what they all are.
- [ ] Ready to be merged

## 🎫 Affected issues

(These are discussions, not issues):

Fixes: https://github.com/nextauthjs/next-auth/discussions/12203
Fixes: https://github.com/nextauthjs/next-auth/discussions/8799

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
