### PR TITLE
Export NextAuthRequest  type from next-auth root

### DIFF
--- a/packages/next-auth/src/index.ts
+++ b/packages/next-auth/src/index.ts
@@ -91,10 +91,10 @@ export { AuthError, CredentialsSignin } from "@auth/core/errors"
 export { customFetch }
 
 export type {
-  Account,
-  DefaultSession,
-  Profile,
   Session,
+  Account,
+  Profile,
+  DefaultSession,
   User,
 } from "@auth/core/types"
 

--- a/packages/next-auth/src/index.ts
+++ b/packages/next-auth/src/index.ts
@@ -68,12 +68,12 @@
  */
 
 import { Auth, customFetch } from "@auth/core"
+import { signIn, signOut, update } from "./lib/actions.js"
 import { reqWithEnvURL, setEnvDefaults } from "./lib/env.js"
 import { initAuth } from "./lib/index.js"
-import { signIn, signOut, update } from "./lib/actions.js"
 
-import type { Awaitable, Session } from "@auth/core/types"
 import type { BuiltInProviderType } from "@auth/core/providers"
+import type { Awaitable, Session } from "@auth/core/types"
 import type {
   GetServerSidePropsContext,
   NextApiRequest,
@@ -91,10 +91,10 @@ export { AuthError, CredentialsSignin } from "@auth/core/errors"
 export { customFetch }
 
 export type {
-  Session,
   Account,
-  Profile,
   DefaultSession,
+  Profile,
+  Session,
   User,
 } from "@auth/core/types"
 
@@ -103,7 +103,7 @@ type AppRouteHandlers = Record<
   (req: NextRequest) => Promise<Response>
 >
 
-export type { NextAuthConfig }
+export type { NextAuthConfig, NextAuthRequest }
 
 /**
  * The result of invoking {@link NextAuth|NextAuth}, initialized with the {@link NextAuthConfig}.

--- a/packages/next-auth/src/index.ts
+++ b/packages/next-auth/src/index.ts
@@ -68,12 +68,12 @@
  */
 
 import { Auth, customFetch } from "@auth/core"
-import { signIn, signOut, update } from "./lib/actions.js"
 import { reqWithEnvURL, setEnvDefaults } from "./lib/env.js"
 import { initAuth } from "./lib/index.js"
+import { signIn, signOut, update } from "./lib/actions.js"
 
-import type { BuiltInProviderType } from "@auth/core/providers"
 import type { Awaitable, Session } from "@auth/core/types"
+import type { BuiltInProviderType } from "@auth/core/providers"
 import type {
   GetServerSidePropsContext,
   NextApiRequest,


### PR DESCRIPTION
## ☕️ Reasoning

Hello, 
the `NextAuthRequest` type is not exported from `next-auth`, but it is very useful to be able to import it in your code when working with next api route. 

There are many reason for it to be useful, but the most common, I think, is when you forward the  `req` params of `auth(req => {...})` in api  route.


```ts
export const POST = auth((req) => {
  try {
    const searchParams = req.nextUrl.searchParams;
    const query = searchParams.get("q");
    switch (query) {
      case "create-x":
        return createSomeStuff(req); // if you want this function typed
      case "create-y":
        return createSomeStuffss(req); // if you want this function typed;
      case "create-z":
        return createSomeStuffssxx(req); // if you want this function typed;
      default:
        break;
    }
  } catch (error) {
    // catch
  }
});

```

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
