### PR TITLE
docs: update drizzle commands due to deprecation

### DIFF
--- a/docs/pages/getting-started/adapters/drizzle.mdx
+++ b/docs/pages/getting-started/adapters/drizzle.mdx
@@ -34,8 +34,8 @@ To use this adapter, you must have setup Drizzle ORM and Drizzle Kit in your pro
 1. Create your schema file, based off of one of the ones below.
 2. Install a supported database driver to your project, like `@libsql/client`, `mysql2` or `postgres`.
 3. Create a `drizzle.config.ts` [file](https://orm.drizzle.team/kit-docs/conf).
-4. Generate the initial migration from your schema file with a command like, `drizzle-kit generate:pg`.
-5. Apply migrations by using `migrate()` function or push changes directly to your database with a command like, `drizzle-kit push:pg`.
+4. Generate the initial migration from your schema file with a command like, `drizzle-kit generate`.
+5. Apply migrations by using `migrate()` function or push changes directly to your database with a command like, `drizzle-kit push`.
 6. If your schemas differ from the default ones, pass them as the second parameter to the adapter.
 
 #### Schemas


### PR DESCRIPTION
## ☕️ Reasoning
Commands like `drizzle-kit push:pg` or `drizzle-kit generate:pg` are deprecated.
```
 ▲ ~/Developer/vexx/packages/db master* npx drizzle-kit push:pg
    This command is deprecated, please use updated 'push' command (see https://orm.drizzle.team/kit-docs/upgrade-21#how-to-migrate-to-0210)
```

## :billed_cap: Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## :pushpin: Resources

- [Drizzle Documentation](https://orm.drizzle.team/docs/kit-overview)