### PR TITLE
chore(docs): fix clickup id

### DIFF
--- a/docs/pages/data/manifest.json
+++ b/docs/pages/data/manifest.json
@@ -62,7 +62,7 @@
     "box": "Box",
     "boxyhq-saml": "BoxyHQ SAML",
     "bungie": "Bungie",
-    "clickup": "ClickUp",
+    "click-up": "ClickUp",
     "cognito": "Cognito",
     "coinbase": "Coinbase",
     "descope": "Descope",


### PR DESCRIPTION
Fixed Click Up provider ID.

## ☕️ Reasoning

Visiting Click Up from Getting Started > Introduction/Official Providers returns 404.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
