### PR TITLE
chore(docs): fixes appearance for some logos in dark mode

### DIFF
--- a/docs/pages/global.css
+++ b/docs/pages/global.css
@@ -7,6 +7,24 @@ details > *:not(summary) {
   @apply p-4;
 }
 
+html[class~="dark"]
+  :is(
+    img[src$="42-school.svg"],
+    img[src$="apple.svg"],
+    img[src$="boxyhq-saml.svg"],
+    img[src$="eveonline.svg"],
+    img[src$="github.svg"],
+    img[src$="hasura.svg"],
+    img[src$="mailchimp.svg"],
+    img[src$="medium.svg"],
+    img[src$="okta.svg"],
+    img[src$="prisma.svg"],
+    img[src$="threads.svg"],
+    img[src$="wikimedia.svg"]
+  ) {
+  filter: invert(1);
+}
+
 :is(html[class~="dark"]) ::selection {
   @apply bg-purple-500/40;
 }

--- a/packages/core/src/lib/pages/styles.css
+++ b/packages/core/src/lib/pages/styles.css
@@ -64,6 +64,19 @@
       color: var(--provider-dark-bg) !important;
     }
   }
+
+  img[src$="42-school.svg"],
+  img[src$="apple.svg"],
+  img[src$="boxyhq-saml.svg"],
+  img[src$="eveonline.svg"],
+  img[src$="github.svg"],
+  img[src$="mailchimp.svg"],
+  img[src$="medium.svg"],
+  img[src$="okta.svg"],
+  img[src$="threads.svg"],
+  img[src$="wikimedia.svg"] {
+    filter: invert(1);
+  }
 }
 
 html {


### PR DESCRIPTION
## ☕️ Reasoning

This PR repairs the appearance of black provider logos (most notably Apple and Github) when presented in dark mode browser UI.  These logos currently are not visible to users of dark mode.

Fix is applied via CSS on both 

- Auth core default signin page, and
- the Docs

Auth core default signin page
![Screen_Recording_2024-12-13_at_19 35 40](https://github.com/user-attachments/assets/bc0430a8-65d3-4729-9315-b8ae5e164abc)

Docs: Before
<img width="900" alt="docs-before" src="https://github.com/user-attachments/assets/6369edd3-14eb-4e18-84c1-a7b4a368127d" />

Docs: After
<img width="823" alt="docs-after" src="https://github.com/user-attachments/assets/abe65111-39ae-42cd-a74b-8d9beac9b5fa" />


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues
This PR aims to resolve issues of #11232 .
Per @ndom91  's requirement, this solution does not require additional icons.
Rather, it inverts the color scale of specific black icons when in dark mode, with CSS. 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
