### PR TITLE
chore(examples): remove unnecessary 'as any' on route return

### DIFF
--- a/apps/examples/nextjs/app/api/protected/route.ts
+++ b/apps/examples/nextjs/app/api/protected/route.ts
@@ -6,4 +6,4 @@ export const GET = auth((req) => {
   }
 
   return Response.json({ message: "Not authenticated" }, { status: 401 })
-}) as any // TODO: Fix `auth()` return type
+})


### PR DESCRIPTION
Remove unnecessary as any on route return, the typing does not error anymore on this assignment.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
Unnecessary any on the route, this was not causing any issues but it was also not providing any additional functionality

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

No associated issue with this change

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
