### PR TITLE
fix(prisma): replace select with include for user relation query

### DIFF
--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -36,7 +36,7 @@ export function PrismaAdapter(
     async getUserByAccount(provider_providerAccountId) {
       const account = await p.account.findUnique({
         where: { provider_providerAccountId },
-        select: { user: true },
+        include: { user: true },
       })
       return (account?.user as AdapterUser) ?? null
     },


### PR DESCRIPTION
This PR fixes an issue where Prisma's `select` statement was incorrectly used to query the `user` relation in the `Account` model. Since `select` is only applicable for scalar fields, this caused Prisma to throw an error:  
`Unknown field 'user' for select statement on model 'Account'`. 

The fix replaces `select: { user: true }` with `include: { user: true }`, which correctly fetches the `user` relation and resolves the issue.