### PR TITLE
fix(core): handle an error inside `parseProviders()` when `providerId` not found in config

### DIFF
--- a/packages/core/src/lib/utils/providers.ts
+++ b/packages/core/src/lib/utils/providers.ts
@@ -62,10 +62,15 @@ export default function parseProviders(params: {
     return merged as InternalProvider
   })
 
-  return {
-    providers,
-    provider: providers.find(({ id }) => id === providerId),
+  const provider = providers.find(({ id }) => id === providerId)
+  if (providerId && !provider) {
+    const availableProviders = providers.map((p) => p.id).join(", ")
+    throw new Error(
+      `Provider with id "${providerId}" not found. Available providers: [${availableProviders}].`
+    )
   }
+
+  return { providers, provider }
 }
 
 // TODO: Also add discovery here, if some endpoints/config are missing.


### PR DESCRIPTION

## ☕️ Reasoning

Currently, if an invalid `providerId` is entered, the `parseProviders()` function will return an empty `provider`. I discovered this when I intentionally entered an incorrect `providerId` in the url `curl -iS http://0.0.0.0:3000/auth/callback/providerType -d ''` so that the error handler would tell me what to enter. Instead, it throws the following error:

```text
TypeError: Cannot read properties of undefined (reading 'type')
```

Error stack pointing to this row:

https://github.com/nextauthjs/next-auth/blob/6bd0f962f02cdbd7b64a50a658a25495cbd300bd/packages/core/src/lib/index.ts#L73

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

