### PR TITLE
chore(dev): added `no-floating-promises` rule and `projectService: true` to eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default tsEslint.config(
     languageOptions: {
       parser: tsEslint.parser,
       parserOptions: {
+        projectService: true,
         project: ["./packages/utils/tsconfig.eslint.json"],
       },
       globals: {
@@ -55,6 +56,7 @@ export default tsEslint.config(
     rules: {
       "prefer-const": ["error", { destructuring: "all" }],
       "no-empty": ["error", { allowEmptyCatch: true }],
+      "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/ban-ts-comment": "warn",
       "@typescript-eslint/no-empty-object-type": [

--- a/packages/adapter-typeorm/src/utils.ts
+++ b/packages/adapter-typeorm/src/utils.ts
@@ -98,7 +98,7 @@ export async function updateConnectionEntities(
   dataSource.entityMetadatas = entities
 
   // @ts-expect-error
-  dataSource.buildMetadatas()
+  await dataSource.buildMetadatas()
 
   if (dataSource.options.synchronize !== false) {
     console.warn(


### PR DESCRIPTION
## ☕️ Reasoning

Promises must be awaited, end with a call to `.catch`, end with a call to `.then` with a rejection handler or be explicitly marked as ignored with the `void` operator. So, added `no-floating-promises` rules to catch this cases.

Added `projectService: true` to fix issue with [huge memory consumption](https://github.com/typescript-eslint/typescript-eslint/issues/10516).

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

