### PR TITLE
fix(ts): make User interface overridable using module augmentation

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -248,17 +248,19 @@ export interface DefaultSession {
 /** The active session of the logged in user. */
 export interface Session extends DefaultSession {}
 
-/**
- * The shape of the returned object in the OAuth providers' `profile` callback,
- * available in the `jwt` and `session` callbacks,
- * or the second parameter of the `session` callback, when using a database.
- */
-export interface User {
+export interface DefaultUser {
   id?: string
   name?: string | null
   email?: string | null
   image?: string | null
 }
+
+/**
+ * The shape of the returned object in the OAuth providers' `profile` callback,
+ * available in the `jwt` and `session` callbacks,
+ * or the second parameter of the `session` callback, when using a database.
+ */
+export interface User extends DefaultUser {}
 
 // Below are types that are only supposed be used by next-auth internally
 


### PR DESCRIPTION
## ☕️ Reasoning

It's not possible to use TS module augmentation to force defined properties as required (i.e., not undefined) for the User interface using next-auth v5.

Usage:

```ts
// file types/next-auth.d.ts

declare module "next-auth" {
  interface User {
    id: string;
  }
}
```


## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

- https://github.com/nextauthjs/next-auth/issues/9253
- https://github.com/nextauthjs/next-auth/issues/9571
- (possibly related) https://github.com/nextauthjs/next-auth/issues/9493


## 📌 Resources

- [Next-Auth TS Module Augmentation (doc)](https://next-auth.js.org/getting-started/typescript)

Related commits:
- https://github.com/nextauthjs/next-auth/commit/36286b1fae4f07fa8c204e88aefb0876479e8b03
