### PR TITLE
Changed npm execution command to fix pnpm translation. Fixes #12331

### DIFF
--- a/docs/pages/getting-started/deployment.mdx
+++ b/docs/pages/getting-started/deployment.mdx
@@ -14,7 +14,7 @@ import { Accordion, Accordions } from "@/components/Accordion"
 Auth.js libraries require you to set an `AUTH_SECRET` environment variable. This is used to encrypt cookies and tokens. It should be a cryptographically secure random string of at least 32 characters:
 
 ```bash npm2yarn
-npm exec auth secret
+npx auth secret
 ```
 
 If you are using an [OAuth Provider](/concepts/oauth), your provider will provide you with a **Client ID** and **Client Secret** that you will need to set as environment variables as well (in the case of an OIDC provider, like Auth0, a third `issuer` value might be also required, refer to the provider's specific documentation).

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -39,7 +39,7 @@ AUTH_SECRET="This is an example"
 `AUTH_SECRET` is a random token used by the library to encrypt tokens and email verification hashes, and it's mandatory to keep things secure (See [Deployment](/getting-started/deployment) to learn more). You can use the CLI to generate an auth secret:
 
 ```bash npm2yarn
-npm exec auth secret
+npx auth secret
 ```
 
 ## Environment Variable Inference


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Deployment guide translates `npm exec auth secret` to a nonfunctional `pnpm exec auth secret` instead of `pnpm dlx auth secret` due to downstream package. Because the command does not use any double-hyphen `--` flags, `npm exec` is equivalent to the shorthand `npx` (see [npm documentation](https://docs.npmjs.com/cli/v8/commands/npx#npx-vs-npm-exec)). The package handles the `npx` to `pnpx` translation without any issues and calling `pnpx auth secret` executes perfectly.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/12331


## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
