### PR TITLE
Fix: Selected framework in Code component

### DIFF
--- a/docs/components/Code/index.tsx
+++ b/docs/components/Code/index.tsx
@@ -64,7 +64,7 @@ export function Code({ children }: ChildrenProps) {
 
   const updateFrameworkStorage = (value: string): void => {
     const params = new URLSearchParams(searchParams?.toString())
-    params.set("framework", value)
+    params.set("framework", parseParams(value))
     router.push(`${router.pathname}?${params.toString()}`)
   }
 
@@ -76,13 +76,16 @@ export function Code({ children }: ChildrenProps) {
         newValue: framework,
       })
     )
-    updateFrameworkStorage(parseParams(framework))
+    updateFrameworkStorage(framework)
   }
 
   const handleClickFramework = (event: MouseEvent<HTMLDivElement>) => {
     if (!(event.target instanceof HTMLButtonElement)) return
     const { textContent } = event.target as unknown as HTMLDivElement
-    if (textContent) {
+    if (
+      textContent &&
+      Object.values(renderedFrameworks).includes(textContent)
+    ) {
       handleFrameworkChange(textContent)
     }
   }
@@ -106,12 +109,12 @@ export function Code({ children }: ChildrenProps) {
   useEffect(() => {
     const getFrameworkStorage = window.localStorage.getItem(AUTHJS_TAB_KEY)
     if (!getFrameworkStorage) {
-      handleFrameworkChange(Object.values(renderedFrameworks)[0])
+      handleFrameworkChange(selectedFramework)
     } else if (
       Object.values(renderedFrameworks).includes(getFrameworkStorage)
     ) {
       setSelectedFramework(getFrameworkStorage)
-      updateFrameworkStorage(parseParams(getFrameworkStorage))
+      updateFrameworkStorage(getFrameworkStorage)
     }
   }, [router.pathname, renderedFrameworks])
 


### PR DESCRIPTION
## ☕️ Reasoning

The `Code` component currently uses the `Tabs` component from the Nextra UI library to display different code examples for various frameworks. The `Tabs` component achieves synchronization across all instances by storing the selected tab's index in local storage. However, relying on an index introduces limitations when the tabs differ in content or order between components. 

This PR refactors the `Code` component to handle tab synchronization and local storage management directly, decoupling this logic from the `Tabs` component. Instead of storing an index, the name of the framework is stored in local storage. This implementation:

1. Stores the framework name in local storage instead of the index.
2. Checks whether the stored framework name is valid for the current context.
3. Displays the valid framework's tab or defaults to the first tab if no valid value is found.
4. Synchronizes tabs across components using a StorageEvent, ensuring updates are propagated immediately.


## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
Fixes: https://github.com/nextauthjs/next-auth/issues/12451

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
