### PR TITLE
Update authentik.mdx to specify that the trailing slash IS required

### DIFF
--- a/docs/pages/getting-started/providers/authentik.mdx
+++ b/docs/pages/getting-started/providers/authentik.mdx
@@ -119,6 +119,6 @@ app.use("/auth/*", ExpressAuth({
 </Code>
 
 <Callout>
-  issuer should include the slug without a trailing slash – e.g.,
-  https://my-authentik-domain.com/application/o/My_Slug
+  issuer should include the slug with the trailing slash – e.g.,
+  https://my-authentik-domain.com/application/o/My_Slug/
 </Callout>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Currently the documentation says that you add the URL with the slug without a trailing slash explicitly, but it is actually the exact opposite. Authentik will not work without the trailing slash. You will receive this error: 

`OperationProcessingError: "response" body "issuer" does not match "expectedIssuer"`

until you add that trailing slash. This is directly from my console.log I used for testing:

```
Configured issuer: https://auth.gibbyb.com/application/o/techtracker
Authentik returned issuer: https://auth.gibbyb.com/application/o/techtracker/
```

Once I added the trailing slash, Authentik worked perfectly. 

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

I haven't seen anyone else bring this up, probably due to how trivial the problem is.

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
