### PR TITLE
Clarify `AUTH_URL` usage in documentation

### DIFF
--- a/docs/pages/getting-started/deployment.mdx
+++ b/docs/pages/getting-started/deployment.mdx
@@ -45,7 +45,11 @@ to `true`. This tells Auth.js to trust the `X-Forwarded-Host` header from the re
 
 ### `AUTH_URL`
 
-This environment variable is mostly unnecessary with v5 as the host is inferred from the request headers. However, if you are using a different base path, you can set this environment variable as well. For example, `AUTH_URL=http://localhost:3000/web/auth` or `AUTH_URL=https://company.com/app1/auth`
+Generally, this environment variable is inferred from the request headers in v5 and is not required. However, you should set AUTH_URL if:
+- Your application is behind a reverse proxy that does not sanitize headers
+- You are using a different base path, for example, AUTH_URL=http://localhost:3000/web/auth or AUTH_URL=https://company.com/app1/auth.
+
+If you experience issues with redirect URIs (e.g., being redirected to localhost instead of your domain), try setting the AUTH_URL environment variable to your desired base URL.
 
 ### `AUTH_REDIRECT_PROXY_URL`
 


### PR DESCRIPTION
This clarifies some confusion on the usage of `AUTH_URL`, including its usage in production settings behind a reverse proxy.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
