### PR TITLE
Downgrade requested OAuth scope of TikTok provider

### DIFF
--- a/packages/core/src/providers/tiktok.ts
+++ b/packages/core/src/providers/tiktok.ts
@@ -293,7 +293,7 @@ export default function TikTok(
       url: "https://www.tiktok.com/v2/auth/authorize",
       params: {
         client_key: options.clientId,
-        scope: "user.info.profile",
+        scope: "user.info.basic",
       },
     },
 

--- a/packages/core/src/providers/tiktok.ts
+++ b/packages/core/src/providers/tiktok.ts
@@ -299,14 +299,15 @@ export default function TikTok(
 
     token: "https://open.tiktokapis.com/v2/oauth/token/",
     userinfo:
-      "https://open.tiktokapis.com/v2/user/info/?fields=open_id,avatar_url,display_name,username",
+      "https://open.tiktokapis.com/v2/user/info/?fields=open_id,avatar_url,display_name",
 
     profile(profile) {
       return {
         id: profile.data.user.open_id,
         name: profile.data.user.display_name,
         image: profile.data.user.avatar_url,
-        email: profile.data.user.email || profile.data.user.username || null,
+         // Email address is not supported by TikTok.
+        email: null,
       }
     },
     style: {


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

The provider is currently requesting a token with `user.info.profile` scope, which is more restrictive than `user.info.basic`. The latter is the one provided by default by the TikTok Login kit and as such, should be the one used for authentication purposes with TikTok. The user info requested by the provider is also covered by the `user.info.basic` scope. For this reason, this PR changes the requested scope to `user.info.basic`.

See [TikTok's documentation on scopes needed for user info](https://developers.tiktok.com/doc/tiktok-api-v2-get-user-info)
## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
