### PR TITLE
fix: More descriptive error in case that discovery endpoint returns an invalid issuer

### DIFF
--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -33,8 +33,11 @@ export async function getAuthorizationUrl(
     const as = await o
       .processDiscoveryResponse(issuer, discoveryResponse)
       .catch((error) => {
-        if (!(error instanceof TypeError) || error.message !== "Invalid URL") throw error
-        throw new TypeError(`Discovery request responded with an invalid issuer. expected: ${issuer}`)
+        if (!(error instanceof TypeError) || error.message !== "Invalid URL")
+          throw error
+        throw new TypeError(
+          `Discovery request responded with an invalid issuer. expected: ${issuer}`
+        )
       })
 
     if (!as.authorization_endpoint) {

--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -33,15 +33,8 @@ export async function getAuthorizationUrl(
     const as = await o
       .processDiscoveryResponse(issuer, discoveryResponse)
       .catch((error) => {
-        if (error instanceof TypeError && error.message === "Invalid URL") {
-          throw new TypeError(
-            "Authorization server metadata discovery returned an invalid issuer." +
-              "expected: " +
-              issuer
-          )
-        } else {
-          throw error
-        }
+        if (!(error instanceof TypeError) || error.message !== "Invalid URL") throw error
+        throw new TypeError(`Discovery request responded with an invalid issuer. expected: ${issuer}`)
       })
 
     if (!as.authorization_endpoint) {

--- a/packages/core/src/lib/actions/signin/authorization-url.ts
+++ b/packages/core/src/lib/actions/signin/authorization-url.ts
@@ -30,7 +30,19 @@ export async function getAuthorizationUrl(
       // TODO: move away from allowing insecure HTTP requests
       [o.allowInsecureRequests]: true,
     })
-    const as = await o.processDiscoveryResponse(issuer, discoveryResponse)
+    const as = await o
+      .processDiscoveryResponse(issuer, discoveryResponse)
+      .catch((error) => {
+        if (error instanceof TypeError && error.message === "Invalid URL") {
+          throw new TypeError(
+            "Authorization server metadata discovery returned an invalid issuer." +
+              "expected: " +
+              issuer
+          )
+        } else {
+          throw error
+        }
+      })
 
     if (!as.authorization_endpoint) {
       throw new TypeError(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

From https://www.rfc-editor.org/rfc/rfc8414.html#section-2:

> issuer
      REQUIRED.  The authorization server's issuer identifier, which is
      a URL that uses the "https" scheme and has no query or fragment
      components. 
      
However, some providers like fusion-auth allow a non-conformant issuer, e.g. without the "https" scheme.
If such an issuer is configured on the authorization server, we see the cryptic "Invalid URL" error, that some people get [confused about](https://github.com/nextauthjs/next-auth/issues/9050). 

The solution is to throw a more descriptive error here. Alternatively, we could open a PR to oauth4webAPI to throw a more descriptive error [here](https://github.com/panva/oauth4webapi/blob/6caa822b9edb5374524c6c3c93b44ff16e70e2da/src/index.ts#L1328).

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
