### PR TITLE
fix(docs): broken link for Postmark API key

### DIFF
--- a/docs/pages/getting-started/providers/postmark.mdx
+++ b/docs/pages/getting-started/providers/postmark.mdx
@@ -27,9 +27,9 @@ If someone provides the email address of an _existing account_ when signing in, 
 
 ## Configuration
 
-1. First, you'll need to [add your domain](https://postmark.com/domains) to your Postmark account. This is required by Postmark and this domain of the address you use in the `from` provider option.
+1. First, you'll need to [add your domain](https://account.postmarkapp.com/sign_up) to your Postmark account. This is required by Postmark and this domain of the address you use in the `from` provider option.
 
-2. Next, you will have to generate an API key in the [Postmark Dashboard](https://postmark.com/api-keys). You can save this API key as the `AUTH_POSTMARK_KEY` environment variable.
+2. Next, you will have to generate an API key in the [Postmark Dashboard](https://account.postmarkapp.com/api_tokens). You can save this API key as the `AUTH_POSTMARK_KEY` environment variable.
 
 ```sh
 AUTH_POSTMARK_KEY=abc


### PR DESCRIPTION

Fixed : #12442

What I'm Changed  ?

Update the Links in the File : [C:\Users\ajeya\OneDrive\Desktop\OpenRepos\next-auth\docs\pages\getting-started\providers\postmark.mdx](url)  

