### PR TITLE
fix(docs): code tabs behavior

### DIFF
--- a/docs/components/Code/index.tsx
+++ b/docs/components/Code/index.tsx
@@ -48,10 +48,10 @@ const parseParams = (url: string): string => {
 export function Code({ children }: ChildrenProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const childs = Children.toArray(children)
+  const childElements = Children.toArray(children)
   const { project } = useThemeConfig()
 
-  const withNextJsPages = childs.some(
+  const withNextJsPages = childElements.some(
     // @ts-expect-error: Hacky dynamic child wrangling
     (p) => p && p.type.name === NextClientCode.name
   )
@@ -93,7 +93,7 @@ export function Code({ children }: ChildrenProps) {
       >
         {Object.keys(renderedFrameworks).map((f) => {
           // @ts-expect-error: Hacky dynamic child wrangling
-          const child = childs.find((c) => c?.type?.name === f)
+          const child = childElements.find((c) => c?.type?.name === f)
 
           // @ts-expect-error: Hacky dynamic child wrangling
           return Object.keys(child?.props ?? {}).length ? (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

This PR addresses an issue in the documentation where navigating code snippets causes the page to scroll to the top when copying or switching between frameworks.

### Key fixes & improvements:
- **Prevents unintended scrolling** when interacting with code blocks.
- **Separates local storage states** for "all frameworks" and "base frameworks" to avoid conflicts.
- **Keeps code blocks in sync** by ensuring they display the same framework when possible.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
