### PR TITLE
fix(next-auth): provide request context in lazy initialization for `auth()` calls in RSCs

### DIFF
--- a/packages/next-auth/src/index.ts
+++ b/packages/next-auth/src/index.ts
@@ -46,7 +46,7 @@
  * If you need to override the default values for a provider, you can still call it as a function `GitHub({...})` as before.
  *
  * ## Lazy initialization
- * You can also initialize NextAuth.js lazily (previously known as advanced intialization), which allows you to access the request context in the configuration in some cases, like Route Handlers, Middleware, API Routes or `getServerSideProps`.
+ * You can also initialize NextAuth.js lazily (previously known as advanced intialization), which allows you to access the request context in the configuration in some cases, like Route Handlers, React Server Components, Middleware, API Routes or `getServerSideProps`.
  * The above example becomes:
  *
  * ```ts title="auth.ts"

--- a/packages/next-auth/src/lib/index.ts
+++ b/packages/next-auth/src/lib/index.ts
@@ -2,7 +2,7 @@ import { Auth, createActionURL, type AuthConfig } from "@auth/core"
 // @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
 import { headers } from "next/headers"
 // @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
 import { reqWithEnvURL } from "./env.js"
 
 import type { AuthAction, Awaitable, Session } from "@auth/core/types"
@@ -13,7 +13,7 @@ import type {
 } from "next"
 import type { AppRouteHandlerFn } from "./types.js"
 // @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
-import type { NextFetchEvent, NextMiddleware, NextRequest } from "next/server"
+import type { NextFetchEvent, NextMiddleware } from "next/server"
 
 /** Configure NextAuth.js. */
 export interface NextAuthConfig extends Omit<AuthConfig, "raw"> {
@@ -121,11 +121,12 @@ function isReqWrapper(arg: any): arg is NextAuthMiddleware | AppRouteHandlerFn {
  * Creates a Request object from Headers, primarily for server-side contexts
  * where we need to reconstruct request information.
  */
-function createRequestFromHeaders(headers: Headers): Request {
+function createRequestFromHeaders(headers: Headers): NextRequest {
   const url = headers.get("x-url") ||
     `${headers.get("x-forwarded-proto") || "http"}://${headers.get("host")}`;
 
-  return new Request(url, {
+  // this constructor will properly parse and set cookies field from given headers
+  return new NextRequest(url, {
     headers: new Headers(headers)
   })
 }


### PR DESCRIPTION
- add createRequestFromHeaders utility for consistent request creation
- pass constructed Request to config function instead of undefined
- enable request-based config customization and runtime modifications for `auth()` calls in RSCs, matching other contexts
- support documented use cases like env-specific provider configuration
- allow header/request access during server-side `auth()` calls

## ☕️ Reasoning

Lazy initialization is documented to provide request context access for customizing configuration, with examples like:
- Accessing request data during server-side auth() calls
- Adding different providers based on staging/dev environments
- Customizing configuration and runtime modifications based on request headers 

However, RSCs were receiving undefined instead of the request context, making these customizations impossible in RSC contexts. This fix makes `auth()` call in RSCs work consistently with other contexts (middleware, route handlers) and enables the documented use cases.

Example use case that was broken but now works:
```typescript
const { auth } = NextAuth(
  async (req) => {
    if (req) {
      // This now works for `auth()` calls in RSCs too
      const headers = req?.headers
      const isStaging = headers?.get('host')?.includes('staging')
    }
  
    return {
      providers: [
        isStaging 
          ? StagingProvider() 
          : ProductionProvider()
      ]
    }
})
```

### Previous Behavior

```typescript
// RSCs received undefined
const _config = await config(undefined)
```

### New Behavior

```typescript
// RSCs now receive a proper Request object
const _request = createRequestFromHeaders(_headers)
const _config = await config(_request)
```

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
