### PR TITLE
fix: check if emails exist in userInfo callback of GitHub provider

### DIFF
--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -166,7 +166,9 @@ export default function GitHub(
 
           if (res.ok) {
             const emails: GitHubEmail[] = await res.json()
-            profile.email = (emails.find((e) => e.primary) ?? emails[0]).email
+            if (emails.length) {
+              profile.email = (emails.find((e) => e.primary) ?? emails[0]).email
+            }
           }
         }
 


### PR DESCRIPTION
This PR adds a JS check for whether the request to GitHub's `/public_emails` actually returns any public emails. Before the change, the code would fail if GitHub API did not return any public emails. Any error thrown in the userInfo callback would abort the OAuth login flow.

The user does not have to have a public email set. All registered emails could be hidden in `Settings` -> `Emails` -> `Keep my email addresses private`.