### PR TITLE
fix: invalid value provided on hubspot

### DIFF
--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -318,7 +318,7 @@ export async function getUserAndAccount(
         ...tokens,
         provider: provider.id,
         type: provider.type,
-        providerAccountId: userFromProfile.id ?? crypto.randomUUID(),
+        providerAccountId: String(userFromProfile.id ?? crypto.randomUUID()),
       },
     }
   } catch (e) {

--- a/packages/core/test/jwt.test.ts
+++ b/packages/core/test/jwt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { encode, decode } from "../jwt"
+import { encode, decode } from "../src/jwt"
 
 describe("supports secret rotation", () => {
   const token = { foo: "bar" }

--- a/packages/core/test/memory-adapter.ts
+++ b/packages/core/test/memory-adapter.ts
@@ -8,7 +8,7 @@ import {
   AdapterSession,
   AdapterUser,
   VerificationToken,
-} from "../adapters.js"
+} from "../src/adapters"
 
 /**
  * Represents the in-memory data structure for the adapter.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
I've been using HubSpot provider and i get this error when HubSpot redirects to callback:
```
  4295 async getUserByAccount (provider_providerAccountId) {
→ 4296     const account = await p.account.findUnique({
             where: {
               provider_providerAccountId: {
                 providerAccountId: 12345678,
                                    ~~~~~~~~
                 provider: "hubspot"
               }
             },
             select: {
               user: true
             }
           })


Argument 'providerAccountId': Invalid value provided. Expected String, provided Int.
```

Probably because the API is returning a integer and is not parsing to string.

This PR just parse `userFromProfile.id` to String to avoid this error.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
