### PR TITLE
Add missing issuer to discord provider config

### DIFF
--- a/packages/core/src/providers/discord.ts
+++ b/packages/core/src/providers/discord.ts
@@ -145,6 +145,7 @@ export default function Discord<P extends DiscordProfile>(
   return {
     id: "discord",
     name: "Discord",
+    issuer: "https://discord.com",
     type: "oauth",
     authorization: {
       url: "https://discord.com/api/oauth2/authorize",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The discord provider currently doesn't work out of the box and needs the issuer to be manually added like so:

```ts
    Discord({
      issuer: "https://discord.com",
    }),
```
I believe this should be in the provider config by default as the provider does not work at all without adding this right now.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #12687 
<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
