### PR TITLE
fix(docs): Mark the GET function callback as async

### DIFF
--- a/docs/pages/getting-started/session-management/protecting.mdx
+++ b/docs/pages/getting-started/session-management/protecting.mdx
@@ -165,7 +165,7 @@ In Next.js, you can use the `auth` function to wrap an API route handler. The re
 import { auth } from "@/auth"
 import { NextResponse } from "next/server"
 
-export const GET = auth(function GET(req) {
+export const GET = auth(async function GET(req) {
   if (req.auth) return NextResponse.json(req.auth)
   return NextResponse.json({ message: "Not authenticated" }, { status: 401 })
 })


### PR DESCRIPTION
## ☕️ Reasoning

The issue was that Next.js expects route handlers to return a Promise (i.e., work asynchronously). Without marking the function as async, TypeScript detects a mismatch where the expected parameter type (which relies on a Promise) doesn't align with a synchronous return value. Adding async ensures the function returns a Promise, resolving the type error.

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: I[NSERT_ISSUE_LINK_HERE](https://github.com/nextauthjs/next-auth/issues/12749)
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
