### PR TITLE
fix(sveltekit) - client functions not working in latest patch

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/client.ts
+++ b/packages/frameworks-sveltekit/src/lib/client.ts
@@ -84,7 +84,7 @@ export async function signIn<Redirect extends boolean = true>(
     ...signInParams
   } = rest
 
-  const baseUrl = base ?? ""
+  const baseUrl = `${base}/auth`
 
   const signInUrl = `${baseUrl}/${
     provider === "credentials" ? "callback" : "signin"
@@ -150,7 +150,7 @@ export async function signOut<R extends boolean = true>(
     redirectTo = options?.callbackUrl ?? window.location.href,
   } = options ?? {}
 
-  const baseUrl = base ?? ""
+  const baseUrl = `${base}/auth`
   const res = await fetch(`${baseUrl}/signout`, {
     method: "post",
     headers: {

--- a/packages/frameworks-sveltekit/src/lib/webauthn.ts
+++ b/packages/frameworks-sveltekit/src/lib/webauthn.ts
@@ -24,7 +24,7 @@ async function webAuthnOptions(
   providerID: ProviderId,
   options?: Omit<SignInOptions, "redirect">
 ) {
-  const baseUrl = base ?? ""
+  const baseUrl = `${base}/auth`
 
   // @ts-expect-error
   const params = new URLSearchParams(options)
@@ -72,7 +72,7 @@ export async function signIn<Redirect extends boolean = true>(
     ...signInParams
   } = rest
 
-  const baseUrl = base ?? ""
+  const baseUrl = `${base}/auth`
 
   if (!provider || provider !== "webauthn") {
     // TODO: Add docs link with explanation


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The latest sveltekit changes broke the logging in and out of users when developers attempt to use the client functions.

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

For tests, I did not know what tooling I could add to update the test cases. I was thinking of using testing-framework jsdom but since they were not in the list of approved packages I did not add any. If there is a link to tools that we can use I will work them into the process.

I am also open to changing it if there is a way to get the baseURL from the server config to the front end. I do not believe this should be hard coded to /auth and should allow the user to change it if necessary. If there is a way we would like to see this implemented I will make any changes required. 

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

Fixes: https://github.com/nextauthjs/next-auth/issues/12719

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
