### PR TITLE
fix: since express 5 parameters have to be named

### DIFF
--- a/packages/frameworks-express/src/index.ts
+++ b/packages/frameworks-express/src/index.ts
@@ -206,5 +206,6 @@ export async function getSession(
 }
 
 function getBasePath(req: e.Request) {
-  return req.baseUrl.split(req.params[0])[0].replace(/\/$/, "")
+  const params = req.params.splat ?? req.params[0];
+  return req.baseUrl.split(params)[0].replace(/\/$/, "")
 }


### PR DESCRIPTION
splat recommendation from migration https://expressjs.com/en/guide/migrating-5

## ☕️ Reasoning

Express 5 support

## 🧢 Checklist

- [ ] Documentation - don't have documentation for version 5
- [ ] Tests - no tests for version 5
- [x] Ready to be merged - yes

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
