### PR TITLE
docs: rm unused import statement from refresh token rotation page example code

### DIFF
--- a/docs/pages/guides/refresh-token-rotation.mdx
+++ b/docs/pages/guides/refresh-token-rotation.mdx
@@ -241,7 +241,6 @@ If the token refresh was unsuccesful, we can force a re-authentication.
 <Code.Next>
 
 ```tsx filename="app/dashboard/page.tsx"
-import { useEffect } from "react"
 import { auth, signIn } from "@/auth"
 
 export default async function Page() {


### PR DESCRIPTION
COMMIT MESSAGE: `chore(docs/refresh-token-rotation): deleted unused/out-of-place import statement`

## ☕️ Reasoning

For Next.js, there was a leftover import statement in the server-side code from the client-side code. I deleted the leftover import statement because useEffect is out of place in the server side, and thus the statement was left unused in the server-side code.

## 🧢 Checklist

- [x ] Documentation

## 🎫 Affected issues

None because this is a non-invasive documentation error.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
