### PR TITLE
docs: update corporate-proxy.mdx with https-proxy-agent example

### DIFF
--- a/docs/pages/guides/corporate-proxy.mdx
+++ b/docs/pages/guides/corporate-proxy.mdx
@@ -8,6 +8,8 @@ Auth.js libraries use the `fetch` API to communicate with OAuth providers. If yo
 
 You can provide a custom `fetch` function by passing it as an option to the provider.
 
+# Using Undici Library
+
 Here, we use the `undici` library to make requests through a proxy server, by passing a `dispatcher` to the `fetch` implementation by `undici`.
 
 <Code>
@@ -22,6 +24,35 @@ const dispatcher = new ProxyAgent("my.proxy.server")
 function proxy(...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {
   // @ts-expect-error `undici` has a `duplex` option
   return undici(args[0], { ...args[1], dispatcher })
+}
+
+export const { handlers, auth } = NextAuth({
+  providers: [GitHub({ [customFetch]: proxy })],
+})
+```
+
+  </Code.Next>
+</Code>
+
+# Using HttpsProxyAgent
+
+On Edge Runtimes or with proxy restrictions,  the `undici` library may not work. Using a simpler approach with HttpsProxyAgent by passing a `proxyAgent` to the `fetch` implementation.
+
+<Code>
+  <Code.Next>
+
+```tsx filename="auth.ts"
+import NextAuth, { customFetch } from "next-auth"
+import GitHub from "next-auth/providers/github"
+const { HttpsProxyAgent } = require('https-proxy-agent');
+
+const proxyAgent = new HttpsProxyAgent("my.proxy.server");
+async function proxy(url: string, options: any): Promise<Response> {
+  const response = (await fetch(url, {
+    ...options,
+    agent: proxyAgent,
+  })) as unknown as Response;
+  return response;
 }
 
 export const { handlers, auth } = NextAuth({


### PR DESCRIPTION
Added HttpsProxyAgent support to corporate proxies. Undici library fails behind certain firewalls and on edge runtime.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
