### PR TITLE
feat: update Twitter provider to retrieve email

### DIFF
--- a/packages/core/src/providers/twitter.ts
+++ b/packages/core/src/providers/twitter.ts
@@ -22,8 +22,9 @@ export interface TwitterProfile {
     id: string
     /** The friendly name of this user, as shown on their profile. */
     name: string
-    /** @note Email is currently unsupported by Twitter.  */
     email?: string
+    /** @note Twitter (X) only returns the email if is has been confirmed under the "confirmed_email" property.  */
+    confirmed_email?: string
     /** The Twitter handle (screen name) of this user. */
     username: string
     /**
@@ -133,22 +134,12 @@ export interface TwitterProfile {
  * - [Twitter App documentation](https://developer.x.com/en/apps)
  *
  * ## OAuth 2
- * Twitter supports OAuth 2, which is currently opt-in. To enable it, simply add version: "2.0" to your Provider configuration:
  * ```ts
  * Twitter({
  *   clientId: process.env.TWITTER_ID,
  *   clientSecret: process.env.TWITTER_SECRET,
- *   version: "2.0", // opt-in to Twitter OAuth 2.0
  * })
  * ```
- * Keep in mind that although this change is easy, it changes how and with which of Twitter APIs you can interact with. Read the official Twitter OAuth 2 documentation for more details.
- *
- *
- * :::note
- *
- * Email is currently not supported by Twitter OAuth 2.0.
- *
- * :::
  *
  * ### Notes
  *
@@ -190,14 +181,14 @@ export default function Twitter(
     type: "oauth",
     checks: ["pkce", "state"],
     authorization:
-      "https://x.com/i/oauth2/authorize?scope=users.read tweet.read offline.access",
+      "https://x.com/i/oauth2/authorize?scope=users.read users.email tweet.read offline.access",
     token: "https://api.x.com/2/oauth2/token",
-    userinfo: "https://api.x.com/2/users/me?user.fields=profile_image_url",
+    userinfo: "https://api.x.com/2/users/me?user.fields=profile_image_url,confirmed_email",
     profile({ data }) {
       return {
         id: data.id,
         name: data.name,
-        email: data.email ?? null,
+        email: data.confirmed_email || data.email || null,
         image: data.profile_image_url,
       }
     },


### PR DESCRIPTION


## ☕️ Reasoning

Update the Twitter provider to include `email` scope in the new oauth 2.0 support.
## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

