### PR TITLE
fix(core): prevent multiple experimental warnings with webauthn

### DIFF
--- a/packages/core/src/lib/utils/assert.ts
+++ b/packages/core/src/lib/utils/assert.ts
@@ -228,7 +228,9 @@ export function assertConfig(
   if (hasWebAuthn) {
     // Log experimental warning
     if (options.experimental?.enableWebAuthn) {
-      warnings.push("experimental-webauthn")
+      if (!warned) {
+        warnings.push("experimental-webauthn")
+      }
     } else {
       return new ExperimentalFeatureNotEnabled(
         "WebAuthn is an experimental feature. To enable it, set `experimental.enableWebAuthn` to `true` in your config"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The #12598 issue reports a number of messages in the logs linked to the experimental webauthn feature. This PR limits the number of warnings by using the same procedure as for the `debug` option.

Tested with https://github.com/nextauthjs/next-auth-example and in `apps/dev/nextjs`

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fix https://github.com/nextauthjs/next-auth/issues/12598

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
