### PR TITLE
fix: conditionally skipping of certain steps in `setup-fw-integration` script to avoid script error

### DIFF
--- a/packages/utils/scripts/setup-fw-integration.js
+++ b/packages/utils/scripts/setup-fw-integration.js
@@ -38,7 +38,19 @@ await fs.cp(sourceDir, destinationDir, { recursive: true })
 
 // Delete node_modules & providers
 await fs.rm(path.join(destinationDir, "node_modules"), { recursive: true })
-await fs.rm(path.join(destinationDir, "providers"), { recursive: true })
+
+try {
+  const folderPath = path.join(destinationDir, "providers")
+  // Check if the folder exists
+  await fs.access(folderPath)
+
+  // The folder exists, so delete it
+  await fs.rm(folderPath, { recursive: true })
+} catch (error) {
+  console.log(
+    "Skipping the deletion of `providers` folder as it does not exist"
+  )
+}
 
 // Replace placeholders in files
 const files = await fs.readdir(destinationDir, { withFileTypes: true })
@@ -63,7 +75,7 @@ await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2))
 const vercelJsonPath = path.join(__dirname, "../../..", "docs", "vercel.json")
 let vercelJson = JSON.parse(await fs.readFile(vercelJsonPath, "utf8"))
 vercelJson.redirects = [
-  ...vercelJson.redirects,
+  ...(vercelJson.redirects ? vercelJson.redirects : []),
   {
     source: "/",
     has: [{ type: "host", value: `${id}.authjs.dev` }],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning
### Summary of Changes  
1. **Handled missing `providers` folder gracefully**  
   - Previously, `fs.rm` was called directly, which could throw an error if the folder didn’t exist.  
   - Now, it first checks for folder existence using `fs.access` and only attempts deletion if the folder is found.  
   - If the folder doesn’t exist, a message is logged instead of throwing an error.  

2. **Fixed potential issue with `vercelJson.redirects` merging**  
   - Updated to ensure that `redirects` is properly merged by using a fallback to an empty array when `redirects` is undefined.  

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)