### PR TITLE
fix(adapter-prisma): update error handling to Prisma's recommended approach

### DIFF
--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -15,8 +15,7 @@
  *
  * @module @auth/prisma-adapter
  */
-import { type PrismaClient } from "@prisma/client"
-import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library"
+import { type PrismaClient, Prisma } from "@prisma/client"
 import type {
   Adapter,
   AdapterAccount,
@@ -90,7 +89,7 @@ export function PrismaAdapter(
         // If token already used/deleted, just return null
         // https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
         if (
-          error instanceof PrismaClientKnownRequestError &&
+          error instanceof Prisma.PrismaClientKnownRequestError &&
           error.code === "P2025"
         )
           return null


### PR DESCRIPTION
## ☕️ Reasoning

In our Cloudflare Workers + Next.js + OpenNext + Next-Auth + Prisma web application, we encountered errors related to CommonJS and ESM compatibility. Upon investigation, it was discovered that in a CommonJS environment, the module "@prisma/client/runtime/library" was being interpreted and invoked as "@prisma/client/runtime/library.mjs", which caused the error. While explicitly importing "@prisma/client/runtime/library.js" could serve as a workaround, the recommended approach is to avoid importing the runtime library directly. Instead, we should import "Prisma" from "@prisma/client" (using `import { Prisma } from "@prisma/client"`) and reference `Prisma.PrismaClientKnownRequestError` for error handling, as suggested by Prisma's troubleshooting and error handling guidelines. 

For more details, please refer to the Prisma documentation on handling exceptions and errors:  
https://www.prisma.io/docs/orm/prisma-client/debugging-and-troubleshooting/handling-exceptions-and-errors

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
