### PR TITLE
feat(core): Use AdapterSession retruned from updateSession function

### DIFF
--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -360,6 +360,10 @@ export interface Adapter {
   /**
    * Updates a session in the database and returns it.
    *
+   * :::tip
+   * If an `AdapterSession` is returned, it will be used in place of the original session.
+   * :::
+   *
    * See also [Database Session management](https://authjs.dev/guides/creating-a-database-adapter#database-session-management)
    */
   updateSession?(

--- a/packages/core/src/lib/actions/session.ts
+++ b/packages/core/src/lib/actions/session.ts
@@ -154,7 +154,7 @@ export async function session(
           : sessionToken,
         options: {
           ...options.cookies.sessionToken.options,
-          expires: newExpires,
+          expires: newAdapterSession ? newAdapterSession.expires : newExpires,
         },
       })
 

--- a/packages/core/test/actions/session.test.ts
+++ b/packages/core/test/actions/session.test.ts
@@ -273,5 +273,80 @@ describe("assert GET session action", () => {
 
       assertNoCacheResponseHeaders(response)
     })
+
+    it("should return a new session if returned from the adapter", async () => {
+      vi.spyOn(callbacks, "jwt")
+      vi.spyOn(callbacks, "session")
+      const updatedExpires = getExpires()
+      const currentExpires = getExpires(24 * 60 * 60 * 1000) // 1 day from now
+
+      const expectedSessionToken = randomString(32)
+      const expectedNewSessionToken = randomString(32)
+      const expectedUserId = randomString(32)
+      const expectedUser = {
+        id: expectedUserId,
+        name: "test",
+        email: "test@test.com",
+        image: "https://test.com/test.png",
+        emailVerified: null,
+      } satisfies AdapterUser
+
+      // const expectedUserId = randomString(32)
+      const memory = initMemory()
+      memory.users.set(expectedUserId, expectedUser)
+      memory.sessions.set(expectedSessionToken, {
+        sessionToken: expectedSessionToken,
+        userId: expectedUserId,
+        expires: currentExpires,
+      })
+
+      const adapter = MemoryAdapter(memory, expectedNewSessionToken)
+
+      const { response } = await makeAuthRequest({
+        action: "session",
+        cookies: {
+          [SESSION_COOKIE_NAME]: expectedSessionToken,
+        },
+        config: {
+          adapter,
+        },
+      })
+
+      const actualBodySession = await response.json()
+
+      let cookies = response.headers.getSetCookie().reduce((acc, cookie) => {
+        return { ...acc, ...parseCookie(cookie) }
+      }, {})
+      const actualSessionToken = cookies[SESSION_COOKIE_NAME]
+
+      expect(memory.users.get(expectedUserId)).toEqual(expectedUser)
+      expect(memory.sessions.get(expectedSessionToken)).toEqual({
+        sessionToken: expectedNewSessionToken,
+        userId: expectedUserId,
+        expires: updatedExpires,
+      })
+
+      expect(callbacks.session).toHaveBeenCalledWith({
+        newSession: undefined,
+        session: {
+          user: expectedUser,
+          expires: currentExpires,
+          sessionToken: expectedNewSessionToken,
+          userId: expectedUserId,
+        },
+        user: expectedUser,
+      })
+      expect(callbacks.jwt).not.toHaveBeenCalled()
+
+      expect(actualSessionToken).toEqual(expectedNewSessionToken)
+      expect(actualBodySession.user).toEqual({
+        image: expectedUser.image,
+        name: expectedUser.name,
+        email: expectedUser.email,
+      })
+      expect(actualBodySession.expires).toEqual(currentExpires.toISOString())
+
+      assertNoCacheResponseHeaders(response)
+    })
   })
 })

--- a/packages/core/test/memory-adapter.ts
+++ b/packages/core/test/memory-adapter.ts
@@ -33,7 +33,10 @@ export function initMemory(): Memory {
   }
 }
 
-export function MemoryAdapter(memory?: Memory): Adapter {
+export function MemoryAdapter(
+  memory?: Memory,
+  newSessionToken: string | null = null
+): Adapter {
   const { users, accounts, sessions, verificationTokens } =
     memory ?? initMemory()
 
@@ -169,6 +172,16 @@ export function MemoryAdapter(memory?: Memory): Adapter {
       if (!currentSession) throw new Error("Session not found")
 
       const updatedSession = { ...currentSession, ...session }
+      if (newSessionToken) {
+        // Delete old session token if a new one is provided
+        sessions.delete(session.sessionToken)
+        // Create a new session with the new session token
+        updatedSession.sessionToken = newSessionToken
+        sessions.set(newSessionToken, updatedSession)
+
+        return updatedSession
+      }
+
       sessions.set(session.sessionToken, updatedSession)
 
       return updatedSession


### PR DESCRIPTION
☕️ Reasoning

Currently the `updateSession` function within Adapters has the option to return an `AdapterSession`, yet this session is just discarded. The ability to use this returned session allows for further customisation of business-specific logic within custom adapters without impacting existing available adapters.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

Note: I have updated session tests, how I am unable to run them as-is due to incorrect relative file paths. Updating the file paths by hand results in passing tests, but I have not committed these updates as I believe I like have local configuration incorrect.

Happy to discuss further if required.