### PR TITLE
Improve error validation for Microsoft EntraID provider errors before decoding token

### DIFF
--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -190,20 +190,23 @@ export async function handleOAuth(
       case "microsoft-entra-id":
       case "azure-ad": {
         /**
-         * These providers return errors in the response body and 
+         * These providers return errors in the response body and
          * need the authorization server metadata to be re-processed
          * based on the `id_token`'s `tid` claim.
          * @see: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#error-response-1
          */
-        const responseJson = await codeGrantResponse.clone().json();
+        const responseJson = await codeGrantResponse.clone().json()
         if (responseJson.error) {
-            const cause = {
-                providerId: provider.id,
-                ...responseJson,
-            };
-            throw new OAuthCallbackError(`OAuth Provider returned an error: ${responseJson.error}`, cause);
+          const cause = {
+            providerId: provider.id,
+            ...responseJson,
+          }
+          throw new OAuthCallbackError(
+            `OAuth Provider returned an error: ${responseJson.error}`,
+            cause
+          )
         }
-        const { tid } = decodeJwt(responseJson.id_token);
+        const { tid } = decodeJwt(responseJson.id_token)
         if (typeof tid === "string") {
           const tenantRe = /microsoftonline\.com\/(\w+)\/v2\.0/
           const tenantId = as.issuer?.match(tenantRe)?.[1] ?? "common"

--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -201,7 +201,7 @@ export async function handleOAuth(
                 providerId: provider.id,
                 ...responseJson,
             };
-            throw new OAuthCallbackError("OAuth Provider returned an error", cause);
+            throw new OAuthCallbackError(`OAuth Provider returned an error: ${responseJson.error}`, cause);
         }
         const { tid } = decodeJwt(responseJson.id_token);
         if (typeof tid === "string") {

--- a/packages/core/src/lib/actions/callback/oauth/callback.ts
+++ b/packages/core/src/lib/actions/callback/oauth/callback.ts
@@ -190,13 +190,20 @@ export async function handleOAuth(
       case "microsoft-entra-id":
       case "azure-ad": {
         /**
-         * These providers need the authorization server metadata to be re-processed
-         * based on the `id_token`'s `tid` claim
-         * @see https://github.com/MicrosoftDocs/azure-docs/issues/113944
+         * These providers return errors in the response body and 
+         * need the authorization server metadata to be re-processed
+         * based on the `id_token`'s `tid` claim.
+         * @see: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#error-response-1
          */
-        const { tid } = decodeJwt(
-          (await codeGrantResponse.clone().json()).id_token
-        )
+        const responseJson = await codeGrantResponse.clone().json();
+        if (responseJson.error) {
+            const cause = {
+                providerId: provider.id,
+                ...responseJson,
+            };
+            throw new OAuthCallbackError("OAuth Provider returned an error", cause);
+        }
+        const { tid } = decodeJwt(responseJson.id_token);
         if (typeof tid === "string") {
           const tenantRe = /microsoftonline\.com\/(\w+)\/v2\.0/
           const tenantId = as.issuer?.match(tenantRe)?.[1] ?? "common"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

Microsoft Entra ID & Entra External ID are returning OAuth errors in the response body for token requests. 
See: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#error-response-1

The change made in this PR will allow developers to at least know what is the real source of the issue instead of misguiding to the incorrect JWT token.

### Before:
![image](https://github.com/user-attachments/assets/2adfe17f-28ea-443f-9413-e66b4dafb92f)

### After:
![image](https://github.com/user-attachments/assets/1c23f3e3-b720-4d64-a66e-9fb37506ac10)

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->
Not fixed, but related due to increased difficulty to review errors:

#12702 
#12186
#12187
#12560
#12400

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
