### PR TITLE
Update configuring-oauth-providers

### DIFF
--- a/docs/pages/guides/configuring-oauth-providers.mdx
+++ b/docs/pages/guides/configuring-oauth-providers.mdx
@@ -59,6 +59,36 @@ export { handle } from "./auth"
 ```
 
 </Code.Svelte>
+<Code.Express>
+```ts filename="./auth.ts"
+import { Auth } from "@auth/core"
+import Auth0 from "@auth/core/providers/auth0"
+import express, { Request, Response } from "express"
+
+const app = express()
+
+app.use("/auth", async (req: Request, res: Response) => {
+  const request = new Request(`http://localhost:3000${req.url}`, {
+    headers: req.headers as HeadersInit,
+    method: req.method,
+    body: req.method === "POST" ? req.body : undefined,
+  })
+
+  const response = await Auth(request, {
+    providers: [
+      Auth0({
+        authorization: {
+          params: { scope: "openid custom_scope" }
+        }
+      })
+    ],
+  })
+
+  response.headers.forEach((value, key) => res.setHeader(key, value))
+  res.status(response.status).send(await response.text())
+})
+```
+</Code.Express>
 </Code>
 
 Another example, the `profile` callback will return `name`, `email` and `picture` by default, but you might want to return more information from the provider. What you return will be used to create the user object in the database.
@@ -124,6 +154,45 @@ export { handle } from "./auth"
 ```
 
 </Code.Svelte>
+<Code.Express>
+
+```ts filename="./auth.ts"
+import { Auth } from "@auth/core"
+import Auth0 from "@auth/core/providers/auth0"
+import express, { Request, Response } from "express"
+
+const app = express()
+
+app.use("/auth", async (req: Request, res: Response) => {
+  const request = new Request(`http://localhost:3000${req.url}`, {
+    headers: req.headers as HeadersInit,
+    method: req.method,
+    body: req.method === "POST" ? req.body : undefined,
+  })
+
+  const response = await Auth(request, {
+    providers: [
+      Auth0({
+        async profile(profile) {
+          return {
+            id: profile.sub,
+            name: profile.name,
+            email: profile.email,
+            image: profile.picture,
+          }
+        }
+      })
+    ],
+  })
+
+  response.headers.forEach((value, key) => res.setHeader(key, value))
+  res.status(response.status).send(await response.text())
+})
+```
+</Code.Express>
+
+
+
 </Code>
 
 ## Use your own provider
@@ -194,6 +263,38 @@ export { handle } from "./auth"
 ```
 
 </Code.Svelte>
+<Code.Express>
+
+```ts filename="./auth.ts"
+import { Auth } from "@auth/core"
+import express, { Request, Response } from "express"
+
+const app = express()
+
+app.use("/auth", async (req: Request, res: Response) => {
+  const request = new Request(`http://localhost:3000${req.url}`, {
+    headers: req.headers as HeadersInit,
+    method: req.method,
+    body: req.method === "POST" ? req.body : undefined,
+  })
+
+  const response = await Auth(request, {
+    providers: [{
+      id: "my-provider",
+      name: "My Provider",
+      type: "oidc",
+      issuer: "https://my.oidc-provider.com",
+      clientId: process.env.AUTH_CLIENT_ID!,
+      clientSecret: process.env.AUTH_CLIENT_SECRET!,
+    }]
+  })
+
+  response.headers.forEach((value, key) => res.setHeader(key, value))
+  res.status(response.status).send(await response.text())
+})```
+```
+</Code.Express>
+
 </Code>
 
 Then, set the [callback URL](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-07.html#name-client-redirection-endpoint) in your provider's dashboard to `https://app.com/{basePath}/callback/{id}`.


### PR DESCRIPTION
Added Express integration examples to the "Configuring an OAuth provider" guide.
This fills a documentation gap for users implementing @auth/core in an Express.js app.


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The official NextAuth.js documentation already provides examples for Next.js, SvelteKit, and Qwik integrations. However, despite @auth/core supporting a framework-agnostic usage, there were no concrete examples for Express.js.

This PR adds TypeScript-based usage examples for Express in:

 - Overriding default provider options

 - Customizing the profile callback

 - Setting up a custom OAuth provider


## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->
N/A 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
