### PR TITLE
Ensure trigger is set in JWT callback when update() is called

### DIFF
--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -507,13 +507,16 @@ export function SessionProvider(props: SessionProviderProps) {
       async update(data: any) {
         if (loading) return
         setLoading(true)
+        const csrfToken = await getCsrfToken()
+        // If the body property is not defined, a GET request will be sent instead of a POST. 
+        // As a result, the trigger property in the JWT callback won't be set, 
+        // making it impossible to know if the user data should be re-fetched
+        // (when the session data updates are handled inside the JWT callback)
         const newSession = await fetchData<Session>(
           "session",
           __NEXTAUTH,
           logger,
-          typeof data === "undefined"
-            ? undefined
-            : { body: { csrfToken: await getCsrfToken(), data } }
+          { body: { csrfToken, data: typeof data === "undefined" ? undefined : data } }
         )
         setLoading(false)
         if (newSession) {


### PR DESCRIPTION
## ☕️ Reasoning
When update() from the useSession() hook is called without any parameters, a GET request is sent (making its behavior similar to getSession()), instead of a POST request.
This prevents the trigger property (in JWT callback) from being set and used to determine whether the user session data needs to be re-fetched.

This is important when session data updates are handled inside the JWT callback and rely on the trigger value to determine whether user data should be re-fetched.