### PR TITLE
Fix file in Google example

### DIFF
--- a/docs/pages/getting-started/providers/google.mdx
+++ b/docs/pages/getting-started/providers/google.mdx
@@ -111,7 +111,7 @@ Alternatively, you can also pass options in the `params` object of `authorizatio
 
 If you need access to the RefreshToken or AccessToken for a Google account and you are not using a database to persist user accounts, this may be something you need to do.
 
-```ts filename="app/api/auth/[...nextauth]/route.ts"
+```ts filename="@/auth.ts"
 import Google from "next-auth/providers/google"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({

--- a/docs/pages/getting-started/providers/google.mdx
+++ b/docs/pages/getting-started/providers/google.mdx
@@ -111,7 +111,7 @@ Alternatively, you can also pass options in the `params` object of `authorizatio
 
 If you need access to the RefreshToken or AccessToken for a Google account and you are not using a database to persist user accounts, this may be something you need to do.
 
-```ts filename="@/auth.ts"
+```ts filename="./auth.ts"
 import Google from "next-auth/providers/google"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({


### PR DESCRIPTION
## ☕️ Reasoning

Within the providers doc for google:
https://authjs.dev/getting-started/providers/google

The changed file link references the APP route when the content of the example references the providers as in the `auth.ts` file.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged