### PR TITLE
fix(core): AuthError.type should not be internal

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -41,9 +41,6 @@ type ErrorType =
  * @noInheritDoc
  */
 export class AuthError extends Error {
-  /** The error type. Used to identify the error in the logs.
-   * @internal
-   */
   type: ErrorType
   /**
    * Determines on which page an error should be handled. Typically `signIn` errors can be handled in-page.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -49,7 +49,6 @@ export class AuthError extends Error {
    */
   kind?: "signIn" | "error"
 
-  /** @internal */
   cause?: Record<string, unknown> & { err?: Error }
 
   /** @internal */
@@ -105,7 +104,6 @@ export class SignInError extends AuthError {
  * @noInheritDoc
  */
 export class AdapterError extends AuthError {
-  /** @internal */
   static type = "AdapterError"
 }
 
@@ -115,7 +113,6 @@ export class AdapterError extends AuthError {
  * @noInheritDoc
  */
 export class AccessDenied extends AuthError {
-  /** @internal */
   static type = "AccessDenied"
 }
 
@@ -160,7 +157,6 @@ export class AccessDenied extends AuthError {
  * @noInheritDoc
  */
 export class CallbackRouteError extends AuthError {
-  /** @internal */
   static type = "CallbackRouteError"
 }
 
@@ -174,7 +170,6 @@ export class CallbackRouteError extends AuthError {
  * @noInheritDoc
  */
 export class ErrorPageLoop extends AuthError {
-  /** @internal */
   static type = "ErrorPageLoop"
 }
 
@@ -188,7 +183,6 @@ export class ErrorPageLoop extends AuthError {
  * @noInheritDoc
  */
 export class EventError extends AuthError {
-  /** @internal */
   static type = "EventError"
 }
 
@@ -204,7 +198,6 @@ export class EventError extends AuthError {
  * @noInheritDoc
  */
 export class InvalidCallbackUrl extends AuthError {
-  /** @internal */
   static type = "InvalidCallbackUrl"
 }
 
@@ -216,7 +209,6 @@ export class InvalidCallbackUrl extends AuthError {
  * @noInheritDoc
  */
 export class CredentialsSignin extends SignInError {
-  /** @internal */
   static type = "CredentialsSignin"
   /**
    * The error code that is set in the `code` query parameter of the redirect URL.
@@ -240,7 +232,6 @@ export class CredentialsSignin extends SignInError {
  * @noInheritDoc
  */
 export class InvalidEndpoints extends AuthError {
-  /** @internal */
   static type = "InvalidEndpoints"
 }
 
@@ -252,7 +243,6 @@ export class InvalidEndpoints extends AuthError {
  * @noInheritDoc
  */
 export class InvalidCheck extends AuthError {
-  /** @internal */
   static type = "InvalidCheck"
 }
 
@@ -269,7 +259,6 @@ export class InvalidCheck extends AuthError {
  * @noInheritDoc
  */
 export class JWTSessionError extends AuthError {
-  /** @internal */
   static type = "JWTSessionError"
 }
 
@@ -282,7 +271,6 @@ export class JWTSessionError extends AuthError {
  * @noInheritDoc
  */
 export class MissingAdapter extends AuthError {
-  /** @internal */
   static type = "MissingAdapter"
 }
 
@@ -295,7 +283,6 @@ export class MissingAdapter extends AuthError {
  * @noInheritDoc
  */
 export class MissingAdapterMethods extends AuthError {
-  /** @internal */
   static type = "MissingAdapterMethods"
 }
 
@@ -307,7 +294,6 @@ export class MissingAdapterMethods extends AuthError {
  * @noInheritDoc
  */
 export class MissingAuthorize extends AuthError {
-  /** @internal */
   static type = "MissingAuthorize"
 }
 
@@ -326,7 +312,6 @@ export class MissingAuthorize extends AuthError {
  * @noInheritDoc
  */
 export class MissingSecret extends AuthError {
-  /** @internal */
   static type = "MissingSecret"
 }
 
@@ -344,7 +329,6 @@ export class MissingSecret extends AuthError {
  * @noInheritDoc
  */
 export class OAuthAccountNotLinked extends SignInError {
-  /** @internal */
   static type = "OAuthAccountNotLinked"
 }
 
@@ -356,7 +340,6 @@ export class OAuthAccountNotLinked extends SignInError {
  * @noInheritDoc
  */
 export class OAuthCallbackError extends SignInError {
-  /** @internal */
   static type = "OAuthCallbackError"
 }
 
@@ -367,7 +350,6 @@ export class OAuthCallbackError extends SignInError {
  * @noInheritDoc
  */
 export class OAuthProfileParseError extends AuthError {
-  /** @internal */
   static type = "OAuthProfileParseError"
 }
 
@@ -380,7 +362,6 @@ export class OAuthProfileParseError extends AuthError {
  * @noInheritDoc
  */
 export class SessionTokenError extends AuthError {
-  /** @internal */
   static type = "SessionTokenError"
 }
 
@@ -401,7 +382,6 @@ export class SessionTokenError extends AuthError {
  * @noInheritDoc
  */
 export class OAuthSignInError extends SignInError {
-  /** @internal */
   static type = "OAuthSignInError"
 }
 
@@ -417,7 +397,6 @@ export class OAuthSignInError extends SignInError {
  * @noInheritDoc
  */
 export class EmailSignInError extends SignInError {
-  /** @internal */
   static type = "EmailSignInError"
 }
 
@@ -432,7 +411,6 @@ export class EmailSignInError extends SignInError {
  * @noInheritDoc
  */
 export class SignOutError extends AuthError {
-  /** @internal */
   static type = "SignOutError"
 }
 
@@ -443,7 +421,6 @@ export class SignOutError extends AuthError {
  * @noInheritDoc
  */
 export class UnknownAction extends AuthError {
-  /** @internal */
   static type = "UnknownAction"
 }
 
@@ -454,7 +431,6 @@ export class UnknownAction extends AuthError {
  * @noInheritDoc
  */
 export class UnsupportedStrategy extends AuthError {
-  /** @internal */
   static type = "UnsupportedStrategy"
 }
 
@@ -463,7 +439,6 @@ export class UnsupportedStrategy extends AuthError {
  * @noInheritDoc
  */
 export class InvalidProvider extends AuthError {
-  /** @internal */
   static type = "InvalidProvider"
 }
 
@@ -480,7 +455,6 @@ export class InvalidProvider extends AuthError {
  * @noInheritDoc
  */
 export class UntrustedHost extends AuthError {
-  /** @internal */
   static type = "UntrustedHost"
 }
 
@@ -491,7 +465,6 @@ export class UntrustedHost extends AuthError {
  * @noInheritDoc
  */
 export class Verification extends AuthError {
-  /** @internal */
   static type = "Verification"
 }
 
@@ -507,7 +480,6 @@ export class Verification extends AuthError {
  * @noInheritDoc
  */
 export class MissingCSRF extends SignInError {
-  /** @internal */
   static type = "MissingCSRF"
 }
 
@@ -538,7 +510,6 @@ export function isClientError(error: Error): error is AuthError {
  * @noInheritDoc
  */
 export class DuplicateConditionalUI extends AuthError {
-  /** @internal */
   static type = "DuplicateConditionalUI"
 }
 
@@ -549,7 +520,6 @@ export class DuplicateConditionalUI extends AuthError {
  * @noInheritDoc
  */
 export class MissingWebAuthnAutocomplete extends AuthError {
-  /** @internal */
   static type = "MissingWebAuthnAutocomplete"
 }
 
@@ -558,7 +528,6 @@ export class MissingWebAuthnAutocomplete extends AuthError {
  * @noInheritDoc
  */
 export class WebAuthnVerificationError extends AuthError {
-  /** @internal */
   static type = "WebAuthnVerificationError"
 }
 
@@ -570,7 +539,6 @@ export class WebAuthnVerificationError extends AuthError {
  * @noInheritDoc
  */
 export class AccountNotLinked extends SignInError {
-  /** @internal */
   static type = "AccountNotLinked"
 }
 
@@ -579,6 +547,5 @@ export class AccountNotLinked extends SignInError {
  * @noInheritDoc
  */
 export class ExperimentalFeatureNotEnabled extends AuthError {
-  /** @internal */
   static type = "ExperimentalFeatureNotEnabled"
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The property was marked as internal during the doc change PR #12690 

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

Fixes #12912

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
