### PR TITLE
Fix undefined providerId

### DIFF
--- a/packages/core/src/lib/utils/web.ts
+++ b/packages/core/src/lib/utils/web.ts
@@ -144,5 +144,8 @@ export function parseActionAndProviderId(
   )
     throw new UnknownAction(`Cannot parse action at ${pathname}`)
 
-  return { action, providerId }
+  return { 
+    action, 
+    providerId: providerId == "undefined" ? undefined : providerId 
+  }
 }

--- a/packages/core/src/lib/utils/web.ts
+++ b/packages/core/src/lib/utils/web.ts
@@ -144,8 +144,8 @@ export function parseActionAndProviderId(
   )
     throw new UnknownAction(`Cannot parse action at ${pathname}`)
 
-  return { 
-    action, 
-    providerId: providerId == "undefined" ? undefined : providerId 
+  return {
+    action,
+    providerId: providerId == "undefined" ? undefined : providerId,
   }
 }

--- a/packages/core/test/url-parsing.test.ts
+++ b/packages/core/test/url-parsing.test.ts
@@ -82,3 +82,11 @@ describe("parse the action and provider id", () => {
     }
   })
 })
+
+it("should return undefined for providerId if it is empty", () => {
+  const path = "/auth/signin/undefined";
+  const basePath = "/auth";
+  const parsed = parseActionAndProviderId(path, basePath);
+  expect(parsed.action).toBe("signin");
+  expect(parsed.providerId).toBeUndefined();
+});

--- a/packages/core/test/url-parsing.test.ts
+++ b/packages/core/test/url-parsing.test.ts
@@ -70,6 +70,12 @@ describe("parse the action and provider id", () => {
       providerId: "auth0",
       basePath: "/auth",
     },
+    {
+      path: "/auth/signin/undefined",
+      action: "signin",
+      providerId: undefined,
+      basePath: "/auth",
+    },
   ])("$path", ({ path, error, basePath, action, providerId }) => {
     if (action || providerId) {
       const parsed = parseActionAndProviderId(path, basePath)
@@ -82,11 +88,3 @@ describe("parse the action and provider id", () => {
     }
   })
 })
-
-it("should return undefined for providerId if it is empty", () => {
-  const path = "/auth/signin/undefined";
-  const basePath = "/auth";
-  const parsed = parseActionAndProviderId(path, basePath);
-  expect(parsed.action).toBe("signin");
-  expect(parsed.providerId).toBeUndefined();
-});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Client-side auth with no `providerId` param results in error. Sample code: 
```js
import { signIn, signOut } from "@auth/sveltekit/client"
<button onclick={() => signIn()}>Sign In</button>
```

It's caused by [parseActionAndProviderId](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/lib/utils/web.ts#L136) function which returns providerId = "undefined" (as a string). This breaks the following check [auth/core/src/lib/utils/providers.ts](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/lib/utils/providers.ts#L66)
```js
export default function parseProviders(params) {
...
    if (providerId && !provider) {
        const availableProviders = providers.map((p) => p.id).join(", ");
        throw new Error(`Provider with id "${providerId}" not found. Available providers: [${availableProviders}].`);
    }
    return { providers, provider };
}
```

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [X] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
