### PR TITLE
add missing step for credntials provider

### DIFF
--- a/docs/pages/getting-started/authentication/credentials.mdx
+++ b/docs/pages/getting-started/authentication/credentials.mdx
@@ -40,8 +40,9 @@ To use the `Credentials Provider`, you’ll first need to import and configure i
 Here’s how to set it up:
 
 1. Import the provider.
-2. Add it to the `providers` array in your `Auth.js` config.
-3. Define the `credentials` and `authorize` fields.
+2. Set the session strategy
+3. Add it to the `providers` array in your `Auth.js` config.
+4. Define the `credentials` and `authorize` fields.
 
 #### `credentials`
 
@@ -93,6 +94,9 @@ import Credentials from "next-auth/providers/credentials"
 import { saltAndHashPassword } from "@/utils/password"
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+   session: {
+    strategy: "jwt",
+  },
   providers: [
     Credentials({
       // You can specify which fields should be submitted, by adding keys to the `credentials` object.


### PR DESCRIPTION
- [x ] Documentation
- [ ] Tests
- [ ] Ready to be merged

Credntials provider needs the `strategy` inside the `session` parameter to be set to `jwt', however this is not mentioned in the docs.