### PR TITLE
fix(providers): enable OIDC capabilities for Keycloak

### DIFF
--- a/packages/core/src/providers/keycloak.ts
+++ b/packages/core/src/providers/keycloak.ts
@@ -8,7 +8,7 @@
  *
  * @module providers/keycloak
  */
-import type { OAuthConfig, OAuthUserConfig } from "./index.js"
+import type { OIDCConfig, OIDCUserConfig } from "./index.js"
 
 export interface KeycloakProfile extends Record<string, any> {
   exp: number
@@ -99,8 +99,8 @@ export interface KeycloakProfile extends Record<string, any> {
  * :::
  */
 export default function Keycloak<P extends KeycloakProfile>(
-  options: OAuthUserConfig<P>
-): OAuthConfig<P> {
+  options: OIDCUserConfig<P>
+): OIDCConfig<P> {
   return {
     id: "keycloak",
     name: "Keycloak",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Keycloak is an OpenID Connect provider, but it is only defined as an OAuth provider. Because of this OpenID capabilities such as using user data from the userinfo endpoint via the `idToken` configuration parameter are not available to users although keycloak could support them.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
