### PR TITLE
fix: do not pass content-type to GET/HEAD requests

### DIFF
--- a/packages/next-auth/src/lib/client.ts
+++ b/packages/next-auth/src/lib/client.ts
@@ -146,12 +146,15 @@ export async function fetchData<T = any>(
   try {
     const options: RequestInit = {
       headers: {
-        "Content-Type": "application/json",
         ...(req?.headers?.cookie ? { cookie: req.headers.cookie } : {}),
       },
     }
 
     if (req?.body) {
+      options.headers = {
+        "Content-Type": "application/json",
+        ...options.headers
+      }
       options.body = JSON.stringify(req.body)
       options.method = "POST"
     }


### PR DESCRIPTION
Fixes issues with different WAFs in strict mode, since GET requests should not specify content-type header