### PR TITLE
Fix: Prevent TypeError when config.providers is undefined

### DIFF
--- a/packages/core/src/lib/utils/env.ts
+++ b/packages/core/src/lib/utils/env.ts
@@ -48,7 +48,7 @@ export function setEnvDefaults(
     envObject.CF_PAGES ??
     envObject.NODE_ENV !== "production"
   )
-  config.providers = config.providers.map((provider) => {
+  config.providers = (config.providers ?? []).map((provider) => {
     const { id } = typeof provider === "function" ? provider({}) : provider
     const ID = id.toUpperCase().replace(/-/g, "_")
     const clientId = envObject[`AUTH_${ID}_ID`]


### PR DESCRIPTION
## What does this PR do?

This pull request addresses a runtime error encountered when using `@auth/express`, specifically:

```
TypeError: Cannot read properties of undefined (reading 'map')
    at setEnvDefaults (.../node_modules/@auth/core/lib/utils/env.js:45:41)
```

## Root Cause

The error is caused by the `config.providers` field being undefined when passed to `getSession`. The `setEnvDefaults` function in `@auth/core/lib/utils/env.js` expects `config.providers` to be an array and attempts to call `.map()` on it without null/undefined validation.

This happens when `providers: []` is forgotten in the auth configuration, causing the server to crash instead of gracefully handling the missing field.

## Fix

This PR adds defensive programming to handle cases where `config.providers` is undefined or omitted. The fix ensures that even when `providers` is forgotten in the auth configuration, the server won't crash:

```js
// Before: Would crash if providers was omitted
const authConfig = {
  secret: process.env.AUTH_SECRET,
  trustHost: true,
  // providers: [] // ❌ If forgotten, causes TypeError
};

// After: Safe even if providers is omitted
// The fix handles this scenario gracefully
```

## Why it matters

This change prevents server crashes when developers accidentally omit the `providers` field from their auth configuration. Instead of failing with a cryptic TypeError, the application continues to work, making the developer experience much more forgiving.

## Notes

This change does not modify provider behavior or add any new functionality — it simply ensures the default structure expected by the underlying library is respected.