### PR TITLE
docs: add missing "key" prop for form element in providerMap iterator

### DIFF
--- a/docs/pages/guides/pages/signin.mdx
+++ b/docs/pages/guides/pages/signin.mdx
@@ -165,6 +165,7 @@ export default async function SignInPage(props: {
       </form>
       {Object.values(providerMap).map((provider) => (
         <form
+          key={provider.id}
           action={async () => {
             "use server"
             try {


### PR DESCRIPTION
## ☕️ Reasoning

add missing "key" prop for form element in providerMap iterator to fix "Missing "key" prop for element in iterator" from `react/jsx-key` eslint rule.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

## 📌 Resources
- [Disallow missing key props in iterators/collection literals (react/jsx-key)](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)
- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
