### PR TITLE
fix(next-auth): add missing middleware wrapper type to auth function

### DIFF
--- a/packages/next-auth/src/index.ts
+++ b/packages/next-auth/src/index.ts
@@ -84,8 +84,12 @@ import type {
   AppRouteHandlerFnContext,
 } from "./lib/types.js"
 // @ts-expect-error Next.js does not yet correctly use the `package.json#exports` field
-import type { NextRequest } from "next/server"
-import type { NextAuthConfig, NextAuthRequest } from "./lib/index.js"
+import type { NextRequest, NextMiddleware } from "next/server"
+import type {
+  NextAuthConfig,
+  NextAuthRequest,
+  NextAuthMiddleware,
+} from "./lib/index.js"
 export { AuthError, CredentialsSignin } from "@auth/core/errors"
 
 export { customFetch }
@@ -245,7 +249,8 @@ export interface NextAuthResult {
           ctx: AppRouteHandlerFnContext
         ) => ReturnType<AppRouteHandlerFn>,
       ]
-    ) => AppRouteHandlerFn)
+    ) => AppRouteHandlerFn) &
+    ((...args: [NextAuthMiddleware]) => NextMiddleware)
   /**
    * Sign in with a provider. If no provider is specified, the user will be redirected to the sign in page.
    *


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

This PR adds a missing TypeScript type overload for the `auth` function when used as a middleware wrapper pattern

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
