### PR TITLE
Fix(provider): Mailgun region selection

### DIFF
--- a/docs/pages/getting-started/providers/mailgun.mdx
+++ b/docs/pages/getting-started/providers/mailgun.mdx
@@ -41,6 +41,8 @@ AUTH_MAILGUN_KEY=abc
 
 If you name your environment variable `AUTH_MAILGUN_KEY`, the provider will pick it up automatically and your Auth.js configuration object can be simpler. If you'd like to rename it to something else, however, you'll have to manually pass it into the provider in your Auth.js configuration.
 
+3. If you are using the EU Mailgun server, you will need to include `region: "EU"` in the provider options. If you are using the US Mailgun server you can remove this option.
+
 <Code>
 <Code.Next>
 
@@ -53,8 +55,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
     Mailgun({
       // If your environment variable is named differently than default
-      apiKey: import.meta.env.AUTH_MAILGUN_KEY,
-      from: "no-reply@company.com"
+      apiKey: process.env.AUTH_MAILGUN_KEY,
+      from: "no-reply@company.com",
+      region: "EU",  // Optional
     }),
   ],
 })
@@ -74,6 +77,7 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
         // If your environment variable is named differently than default
         apiKey: import.meta.env.AUTH_MAILGUN_KEY,
         from: "no-reply@company.com",
+        region: "EU", // Optional
       }),
     ],
   })
@@ -95,6 +99,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
       // If your environment variable is named differently than default
       apiKey: env.AUTH_MAILGUN_KEY,
       from: "no-reply@company.com",
+      region: "EU",  // Optional
     }),
   ],
 })

--- a/packages/core/src/providers/mailgun.ts
+++ b/packages/core/src/providers/mailgun.ts
@@ -24,7 +24,10 @@ import { html, text } from "../lib/utils/email.js"
  * const request = new Request(origin)
  * const response = await Auth(request, {
  *   providers: [
- *     Mailgun({ from: MAILGUN_DOMAIN }),
+ *     Mailgun({
+ *       from: MAILGUN_DOMAIN,
+ *       region: "EU", // Optional
+ *     }),
  *   ],
  * })
  * ```
@@ -43,7 +46,23 @@ import { html, text } from "../lib/utils/email.js"
  *
  * :::
  */
-export default function MailGun(config: EmailUserConfig): EmailConfig {
+export default function MailGun(
+  config: EmailUserConfig & {
+    /**
+     * https://documentation.mailgun.com/docs/mailgun/api-reference/#base-url
+     *
+     * @default "US"
+     */
+    region?: "US" | "EU"
+  }
+): EmailConfig {
+  const { region = "US" } = config
+  const servers = {
+    US: "api.mailgun.net",
+    EU: "api.eu.mailgun.net",
+  }
+  const apiServer = servers[region]
+
   return {
     id: "mailgun",
     type: "email",
@@ -64,7 +83,7 @@ export default function MailGun(config: EmailUserConfig): EmailConfig {
       form.append("html", html({ host, url, theme }))
       form.append("text", text({ host, url }))
 
-      const res = await fetch(`https://api.mailgun.net/v3/${domain}/messages`, {
+      const res = await fetch(`https://${apiServer}/v3/${domain}/messages`, {
         method: "POST",
         headers: {
           Authorization: `Basic ${btoa(`api:${provider.apiKey}`)}`,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

This non-breaking PR adds the `region` option to the Mailgun provider. This option selects either the US or EU Mailgun API server. The `region` option is optional and if omitted will default to the US server.

**Example provider config**

```typescript
export const { handlers, auth, signIn, signOut } = NextAuth({
  providers: [
    Mailgun({
      region: "EU",  //  Optional
      apiKey: process.env.AUTH_MAILGUN_KEY,
      from: "no-reply@company.com"
    }),
  ],
})
```

## 🧢 Checklist

- [X] Documentation
- [ ] Tests
- [X] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:
-->

Fixes: #12925 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
