### PR TITLE
fix: do not swallow error in fetchData

### DIFF
--- a/packages/next-auth/src/lib/client.ts
+++ b/packages/next-auth/src/lib/client.ts
@@ -161,8 +161,12 @@ export async function fetchData<T = any>(
     if (!res.ok) throw data
     return data
   } catch (error) {
-    logger.error(new ClientFetchError((error as Error).message, error as any))
-    return null
+    const wrappedError = new ClientFetchError(
+      (error as Error).message,
+      error as any
+    )
+    logger.error(wrappedError)
+    throw wrappedError
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

`fetchData` currently swallows error, which makes network error returns `null` and is equivalent to a user becoming unauthenticated. I don't think that's ideal since a network blip can log a person out, especially in combination with `refetchInterval` this has unintentional side effects.
Downside is this makes session a bit stale.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
