### PR TITLE
fix(adapters): handle P2025 errors without importing Prisma namespace

### DIFF
--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -15,7 +15,7 @@
  *
  * @module @auth/prisma-adapter
  */
-import { Prisma, type PrismaClient } from "@prisma/client"
+import type { PrismaClient } from "@prisma/client"
 import type {
   Adapter,
   AdapterAccount,
@@ -89,7 +89,9 @@ export function PrismaAdapter(
         // If token already used/deleted, just return null
         // https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
         if (
-          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error &&
+          typeof error === "object" &&
+          "code" in error &&
           error.code === "P2025"
         )
           return null


### PR DESCRIPTION
## ☕️ Reasoning

A bug relating to importing Prisma from a custom `output` raised in #13060 seems to be caused by previous PR #12755 where functionality was changed to import the error class `PrismaClientKnownRequestError` from the `Prisma` namespace.

As we are only looking for code `P2025` [(defined here)](https://www.prisma.io/docs/orm/reference/error-reference#p2025) we do not need to import the full client. 

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #13060 #13035 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
