### PR TITLE
docs(search-params): clarify async usage in app router server components

### DIFF
--- a/docs/pages/guides/pages/signin.mdx
+++ b/docs/pages/guides/pages/signin.mdx
@@ -136,8 +136,11 @@ import { AuthError } from "next-auth"
 const SIGNIN_ERROR_URL = "/error"
 
 export default async function SignInPage(props: {
-  searchParams: { callbackUrl: string | undefined }
+  searchParams: Promise<{ callbackUrl: string | undefined }>
 }) {
+
+const { callbackUrl } = await props.searchParams;
+
   return (
     <div className="flex flex-col gap-2">
       <form
@@ -170,7 +173,7 @@ export default async function SignInPage(props: {
             "use server"
             try {
               await signIn(provider.id, {
-                redirectTo: props.searchParams?.callbackUrl ?? "",
+                redirectTo: callbackUrl ?? "",
               })
             } catch (error) {
               // Signin can fail for a number of reasons, such as the user


### PR DESCRIPTION
## ☕️ Reasoning

This pull request updates the documentation for the searchParams prop in App Router Server Components, clarifying its new behavior as a Promise that must be awaited. This change fixes runtime errors from synchronous access and eliminates "await has no effect" TypeScript warnings.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

issue: https://github.com/nextauthjs/next-auth/issues/12697

#12697 
