### PR TITLE
feat(provider): add ciam provider

### DIFF
--- a/packages/core/src/providers/ciam.ts
+++ b/packages/core/src/providers/ciam.ts
@@ -1,0 +1,65 @@
+import type { OAuthConfig, OAuthUserConfig } from "./oauth.js"
+
+/**
+ * ## CIAM Provider
+ *
+ * This provider is designed to integrate with a CIAM (Customer Identity and Access Management) service.
+ * It expects a set of endpoints to be configured for OAuth 2.0 authorization, token exchange, and user info retrieval.
+ *
+ * ### Configuration
+ *
+ * To use this provider, you must pass a configuration object with the following properties:
+ *
+ * - `clientId`: The client ID provided by your CIAM service.
+ * - `clientSecret`: The client secret provided by your CIAM service.
+ * - `authorizationUrl`: The authorization endpoint of your CIAM service.
+ * - `tokenUrl`: The token endpoint of your CIAM service.
+ * - `userinfoUrl`: The userinfo endpoint of your CIAM service.
+ * - `issuer`: The issuer URL of your CIAM service.
+ * - `jwksEndpoint`: The JWKS endpoint of your CIAM service.
+ *
+ * Additionally, you can override any of the default `OAuthConfig` properties.
+ *
+ * @param {Omit<OAuthUserConfig<Record<string, any>>, 'checks'> & {
+ *   authorizationUrl: string;
+ *   tokenUrl: string;
+ *   userinfoUrl: string;
+ *   issuer: string;
+ *   jwksEndpoint: string;
+ * }} options
+ * @returns {OAuthConfig<Record<string, any>>}
+ */
+export default function CiamProvider(
+  options: Omit<OAuthUserConfig<Record<string, any>>, "checks"> & {
+    authorizationUrl: string
+    tokenUrl: string
+    userinfoUrl: string
+    issuer: string
+    jwksEndpoint: string
+  }
+): OAuthConfig<Record<string, any>> {
+  return {
+    id: "ciam",
+    name: "CIAM",
+    type: "oauth",
+    checks: ["state"],
+    authorization: {
+      url: options.authorizationUrl,
+      params: {
+        scope: "openid profile",
+        response_type: "code",
+      },
+    },
+    token: options.tokenUrl,
+    jwks_endpoint: options.jwksEndpoint,
+    userinfo: options.userinfoUrl,
+    profile(profile: any) {
+      return {
+        id: profile.sub,
+        name: profile.sub,
+        authorities: profile.authorities,
+      }
+    },
+    ...options,
+  }
+}


### PR DESCRIPTION
***

### Summary

This pull request introduces a new, flexible OAuth provider for CIAM (Customer Identity and Access Management) services.

### Motivation

Many organizations use custom or self-hosted CIAM solutions for identity management. While many newer systems are OIDC-compliant, a significant number of them still operate as standard OAuth 2.0 servers that require the explicit configuration of endpoints.

This `CiamProvider` is designed to fill that gap, allowing developers to seamlessly integrate `next-auth` with any generic OAuth 2.0-based identity provider by manually specifying the required URLs.

### Implementation Details

*   **Provider Type**: `oauth`
*   **Configuration**: Requires manual setup of `authorizationUrl`, `tokenUrl`, and `userinfoUrl`.
*   **Profile Mapping**: The user's `id` and `name` are mapped from the `sub` claim returned by the userinfo endpoint, a standard convention.

### Example Usage

```javascript
import CiamProvider from "next-auth/providers/ciam";

//...
  providers: [
    CiamProvider({
      clientId: process.env.CIAM_CLIENT_ID,
      clientSecret: process.env.CIAM_CLIENT_SECRET,
      authorizationUrl: "https://my-ciam.com/auth",
      tokenUrl: "https://my-ciam.com/token",
      userinfoUrl: "https://my-ciam.com/userinfo",
      issuer: "https://my-ciam.com",
      jwksEndpoint: "https://my-ciam.com/jwks",
    }),
  ]
//...
```