### PR TITLE
handle notion refresh_token

### DIFF
--- a/docs/pages/getting-started/providers/notion.mdx
+++ b/docs/pages/getting-started/providers/notion.mdx
@@ -138,3 +138,4 @@ app.use(
 
 - You need to select "Public Integration" on the configuration page to get an `oauth_id` and `oauth_secret`. Private integrations do not provide these details.
 - You must provide a `clientId` and `clientSecret` to use this provider, as-well as a redirect URI (due to this being required by Notion endpoint to fetch tokens).
+- The Notion OAuth API doesn’t support refreshing tokens, and so doesn’t return a refresh token. The access token never expires.

--- a/packages/core/src/providers/notion.ts
+++ b/packages/core/src/providers/notion.ts
@@ -120,11 +120,11 @@ export default function NotionProvider<P extends NotionProfile>(
       url: `${NOTION_HOST}/v1/oauth/token`,
       async conform(response) {
         const body = await response.json()
-        if (!body.refresh_token || typeof body.refresh_token !== "string") {
-          delete body.refresh_token;
+        if (body?.refresh_token === null) {
+          delete body.refresh_token
         }
-        return new Response(JSON.stringify(body), response);
-      }
+        return new Response(JSON.stringify(body), response)
+      },
     },
     userinfo: {
       url: `${NOTION_HOST}/v1/users`,

--- a/packages/core/src/providers/notion.ts
+++ b/packages/core/src/providers/notion.ts
@@ -118,6 +118,13 @@ export default function NotionProvider<P extends NotionProfile>(
     type: "oauth",
     token: {
       url: `${NOTION_HOST}/v1/oauth/token`,
+      async conform(response) {
+        const body = await response.json()
+        if (!body.refresh_token || typeof body.refresh_token !== "string") {
+          delete body.refresh_token;
+        }
+        return new Response(JSON.stringify(body), response);
+      }
     },
     userinfo: {
       url: `${NOTION_HOST}/v1/users`,


### PR DESCRIPTION
## ☕️ Reasoning

Adds a `token.conform` to the Notion provider to normalize the OAuth token response. Notion returns `"refresh_token": null` by default. This can break downstream logic that expects refresh_token to always be a string.

## 🧢 Checklist
- [x]  Documentation
- [x]  Tests
- [x]  Ready to be merged

## 🎫 Affected issues

Fixes: #13109 

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
