### PR TITLE
Add model association override to `@auth/sequelize-adapter`

### DIFF
--- a/packages/adapter-sequelize/src/index.ts
+++ b/packages/adapter-sequelize/src/index.ts
@@ -56,13 +56,31 @@ export interface SequelizeAdapterOptions {
     Session: ModelCtor<SessionInstance>
     VerificationToken: ModelCtor<VerificationTokenInstance>
   }>
+  /**
+   * Override the default model {@link https://sequelize.org/docs/v6/core-concepts/assocs/ associations}
+   *
+   * Default Associations:
+   * ```ts
+   * Account.belongsTo(User, { onDelete: "cascade" })
+   * Session.belongsTo(User, { onDelete: "cascade" })
+   * ```
+   *
+   * Example:
+   * ```ts
+   * (User, Account, Session) => {
+   *   Account.belongsTo(User, { onDelete: "cascade", foreignKey: "userId", as: 'user' });
+   *   Session.belongsTo(User, { onDelete: "cascade", foreignKey: "userId", as: 'user' });
+   * }
+   * ```
+   */
+  associations?: async (User: UserInstance, Account: AccountInstance, Session: SessionInstance, VerificationToken: VerificationTokenInstance) => void
 }
 
 export default function SequelizeAdapter(
   client: Sequelize,
   options?: SequelizeAdapterOptions
 ): Adapter {
-  const { models, synchronize = true } = options ?? {}
+  const { models, synchronize = true, associations } = options ?? {}
   const defaultModelOptions = { underscored: true, timestamps: false }
   const { User, Account, Session, VerificationToken } = {
     User:
@@ -111,8 +129,12 @@ export default function SequelizeAdapter(
     }
   }
 
-  Account.belongsTo(User, { onDelete: "cascade" })
-  Session.belongsTo(User, { onDelete: "cascade" })
+  if (associations) {
+    await associations();
+  } else {
+    Account.belongsTo(User, { onDelete: "cascade" })
+    Session.belongsTo(User, { onDelete: "cascade" })
+  }
 
   return {
     async createUser(user) {

--- a/packages/adapter-sequelize/src/index.ts
+++ b/packages/adapter-sequelize/src/index.ts
@@ -55,7 +55,7 @@ export interface SequelizeAdapterOptions {
     Account: ModelCtor<AccountInstance>
     Session: ModelCtor<SessionInstance>
     VerificationToken: ModelCtor<VerificationTokenInstance>
-  }>,
+  }>;
   /**
    * Override the default model {@link https://sequelize.org/docs/v6/core-concepts/assocs/ associations}
    *
@@ -73,7 +73,12 @@ export interface SequelizeAdapterOptions {
    * }
    * ```
    */
-  associations?: (User: UserInstance, Account: AccountInstance, Session: SessionInstance, VerificationToken: VerificationTokenInstance) => void
+  associations?: (
+    User: ModelCtor<UserInstance>,
+    Account: ModelCtor<AccountInstance>,
+    Session: ModelCtor<SessionInstance>,
+    VerificationToken: ModelCtor<VerificationTokenInstance>
+  ) => void;
 }
 
 export default function SequelizeAdapter(
@@ -130,10 +135,10 @@ export default function SequelizeAdapter(
   }
 
   if (associations) {
-    associations();
+    associations(User, Account, Session, VerificationToken);
   } else {
-    Account.belongsTo(User, { onDelete: "cascade" })
-    Session.belongsTo(User, { onDelete: "cascade" })
+    Account.belongsTo(User, { onDelete: 'cascade' });
+    Session.belongsTo(User, { onDelete: 'cascade' });
   }
 
   return {

--- a/packages/adapter-sequelize/src/index.ts
+++ b/packages/adapter-sequelize/src/index.ts
@@ -55,7 +55,7 @@ export interface SequelizeAdapterOptions {
     Account: ModelCtor<AccountInstance>
     Session: ModelCtor<SessionInstance>
     VerificationToken: ModelCtor<VerificationTokenInstance>
-  }>
+  }>,
   /**
    * Override the default model {@link https://sequelize.org/docs/v6/core-concepts/assocs/ associations}
    *
@@ -73,7 +73,7 @@ export interface SequelizeAdapterOptions {
    * }
    * ```
    */
-  associations?: async (User: UserInstance, Account: AccountInstance, Session: SessionInstance, VerificationToken: VerificationTokenInstance) => void
+  associations?: (User: UserInstance, Account: AccountInstance, Session: SessionInstance, VerificationToken: VerificationTokenInstance) => void
 }
 
 export default function SequelizeAdapter(
@@ -130,7 +130,7 @@ export default function SequelizeAdapter(
   }
 
   if (associations) {
-    await associations();
+    associations();
   } else {
     Account.belongsTo(User, { onDelete: "cascade" })
     Session.belongsTo(User, { onDelete: "cascade" })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

I want to be able to customize the associations that are set up between the models when using the `@auth/sequelize-adapter`. This PR adds an optional override to the SequelizeAdapter options:

```ts
new SequelizeAdapter(sequelize, {
  models: {
    ...
  },
  associations: (User, Account, Session) => {
    Account.belongsTo(User, { onDelete: "cascade", foreignKey: "userId", as: 'user' });
    Session.belongsTo(User, { onDelete: "cascade", foreignKey: "userId", as: 'user' });
  }
});
```

## 🧢 Checklist

- [x] Documentation
- [ ] Tests - There are no tests covering the associations.
- [x] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
