### PR TITLE
Enable secret manager integrations.

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,6 @@ import {
   isClientError,
 } from "./errors.js"
 import { AuthInternal, raw, skipCSRFCheck } from "./lib/index.js"
-import { setEnvDefaults, createActionURL } from "./lib/utils/env.js"
 import renderPage from "./lib/pages/index.js"
 import { setLogger, type LoggerInstance } from "./lib/utils/logger.js"
 import { toInternalRequest, toResponse } from "./lib/utils/web.js"
@@ -68,7 +67,14 @@ import { JWT, JWTOptions } from "./jwt.js"
 import { isAuthAction } from "./lib/utils/actions.js"
 
 export { customFetch } from "./lib/symbols.js"
-export { skipCSRFCheck, raw, setEnvDefaults, createActionURL, isAuthAction }
+export {
+  setEnvDefaults,
+  collectEnvSecrets,
+  applyEnvSecrets,
+  applyEnvSettings,
+  createActionURL,
+} from "./lib/utils/env.js"
+export { skipCSRFCheck, raw, isAuthAction }
 
 export async function Auth(
   request: Request,


### PR DESCRIPTION
This seperates the logic that scans the environment for secrets from the logic that applies those secrets to the config. This will allow frameworks / plugins to process any secrets found.

As an example, using [Cloudflare Secrets Store](https://developers.cloudflare.com/secrets-store/), a framework implementor could use the `collectEnvSecrets` function to scan for secrets relevant to the provider (using the same naming convention used for `string` secrets), and then `await` the `secret.get()` callback before calling `applyEnvSecrets`.

The behavior used by the default implementation `setEnvDefaults` should be completely unchanged.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
