### PR TITLE
Fix environment variable names and SvelteKit example

### DIFF
--- a/docs/pages/getting-started/providers/authentik.mdx
+++ b/docs/pages/getting-started/providers/authentik.mdx
@@ -40,8 +40,8 @@ https://example.com/auth/callback/authentik
 ### Environment Variables
 
 ```
-AUTH_AUTHENTIK_ID
-AUTH_AUTHENTIK_SECRET
+AUTH_AUTHENTIK_CLIENT_ID
+AUTH_AUTHENTIK_CLIENT_SECRET
 AUTH_AUTHENTIK_ISSUER
 ```
 
@@ -89,6 +89,11 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
 ```ts filename="/src/auth.ts"
 import { SvelteKitAuth } from "@auth/sveltekit";
 import Authentik from "@auth/sveltekit/providers/authentik";
+import {
+	AUTH_AUTHENTIK_CLIENT_ID,
+	AUTH_AUTHENTIK_CLIENT_SECRET,
+	AUTH_AUTHENTIK_ISSUER
+} from '$env/static/private';
 
 export const { handle, signIn, signOut } = SvelteKitAuth({
   providers: [Authentik({


### PR DESCRIPTION
I was implementing Auth.js with authentik when I came accross this.

1. The environment variable names at the beginning of the help doc don't correspond with the code samples (in any framework) > fixed
2. The SvelteKit example was not working because it didn't import the env variables. Updated the code snippet to include the import statement.