### PR TITLE
docs: Fix composite primary key syntax in examples

### DIFF
--- a/docs/pages/getting-started/adapters/drizzle.mdx
+++ b/docs/pages/getting-started/adapters/drizzle.mdx
@@ -90,11 +90,10 @@ export const accounts = pgTable(
     session_state: text("session_state"),
   },
   (account) => [
-    {
-      compoundKey: primaryKey({
-        columns: [account.provider, account.providerAccountId],
-      }),
-    },
+    primaryKey({
+      name: "compoundKey",
+      columns: [account.provider, account.providerAccountId],
+    }),
   ]
 )
 
@@ -114,11 +113,10 @@ export const verificationTokens = pgTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (verificationToken) => [
-    {
-      compositePk: primaryKey({
-        columns: [verificationToken.identifier, verificationToken.token],
-      }),
-    },
+    primaryKey({
+      name: "compositePk",
+      columns: [verificationToken.identifier, verificationToken.token],
+    }),
   ]
 )
 
@@ -137,11 +135,10 @@ export const authenticators = pgTable(
     transports: text("transports"),
   },
   (authenticator) => [
-    {
-      compositePK: primaryKey({
-        columns: [authenticator.userId, authenticator.credentialID],
-      }),
-    },
+    primaryKey({
+      name: "compositePK",
+      columns: [authenticator.userId, authenticator.credentialID],
+    }),
   ]
 )
 ```


### PR DESCRIPTION
## ☕️ Reasoning

Fixing a bug within the PostgreSQL schema.ts example. 

In the previous example, drizzle would overlook the composite keys, therefore the constraints wouldn't be added within the generated SQL file.

## 🧢 Checklist

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
