### PR TITLE
fix: EmailProvider maxAge property into account correctly

### DIFF
--- a/packages/core/src/lib/actions/signin/send-token.ts
+++ b/packages/core/src/lib/actions/signin/send-token.ts
@@ -53,9 +53,9 @@ export async function sendToken(
     (await provider.generateVerificationToken?.()) ?? randomString(32)
 
   const ONE_DAY_IN_SECONDS = 86400
-  const expires = new Date(
-    Date.now() + (provider.maxAge ?? ONE_DAY_IN_SECONDS) * 1000
-  )
+  const maxAge =
+    provider.options?.maxAge ?? provider.maxAge ?? ONE_DAY_IN_SECONDS
+  const expires = new Date(Date.now() + maxAge * 1000)
 
   const secret = provider.secret ?? options.secret
 

--- a/packages/core/src/providers/email.ts
+++ b/packages/core/src/providers/email.ts
@@ -42,6 +42,7 @@ export interface EmailConfig extends CommonProviderOptions {
   type: "email"
   name: string
   from?: string
+  /** In seconds */
   maxAge?: number
   sendVerificationRequest: (
     params: EmailProviderSendVerificationRequestParams


### PR DESCRIPTION
## ☕️ Reasoning

`maxAge` that was passed to the 

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: #7434

