### PR TITLE
fix(auth): preserve basePath in request URL reconstruction (#13034)

### DIFF
--- a/packages/next-auth/src/lib/env.ts
+++ b/packages/next-auth/src/lib/env.ts
@@ -3,13 +3,21 @@ import { NextRequest } from "next/server"
 import type { NextAuthConfig } from "./index.js"
 import { setEnvDefaults as coreSetEnvDefaults } from "@auth/core"
 
-/** If `NEXTAUTH_URL` or `AUTH_URL` is defined, override the request's URL. */
+/**
+ *  If `NEXTAUTH_URL` or `AUTH_URL` is defined, override the request's URL.
+ *  Reset the basePath onto the url as it checks the full url in nextauth api handlers
+ *  References:
+ * - Bug in Next.js affecting URL handling: https://github.com/vercel/next.js/issues/62756
+ * - Bug in NextAuth causing incorrect action, redirect URL behavior: https://github.com/nextauthjs/next-auth/issues/13034
+ */
 export function reqWithEnvURL(req: NextRequest): NextRequest {
   const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL
+  // nextjs basepath not auth config basepath
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
   if (!url) return req
   const { origin: envOrigin } = new URL(url)
   const { href, origin } = req.nextUrl
-  return new NextRequest(href.replace(origin, envOrigin), req)
+  return new NextRequest(href.replace(origin, envOrigin + basePath), req)
 }
 
 /**


### PR DESCRIPTION
Ensure that reqWithEnvURL can correctly restore the API call path when Next.js strips it from incoming requests.

Refs: https://github.com/nextauthjs/next-auth/issues/13034

## ☕️ Reasoning

After running into bug #13034 when having a basepath configured in the nextjs config. this variable is unfortunately not easilly exposed and therefor we see a convention in discussions and bug reports using env variable NEXT_PUBLIC_BASE_PATH as it can be available in both the server side and client side.

## 🧢 Checklist
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues
- Discussion about availabillity of basepath in nextjs on the server side and client sidehttps://github.com/vercel/next.js/discussions/16059
- Bug in Next.js affecting URL handling: https://github.com/vercel/next.js/issues/62756
- Bug in NextAuth causing incorrect action, redirect URL behavior: https://github.com/nextauthjs/next-auth/issues/13034
