### PR TITLE
DOCS FIX: update next.js docs link to matcher

### DIFF
--- a/docs/pages/getting-started/session-management/protecting.mdx
+++ b/docs/pages/getting-started/session-management/protecting.mdx
@@ -284,7 +284,7 @@ export const config = {
 }
 ```
 
-Middleware will protect pages as defined by the `matcher` config export. For more details about the matcher, check out the [Next.js docs](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matching-paths).
+Middleware will protect pages as defined by the `matcher` config export. For more details about the matcher, check out the [Next.js docs](https://nextjs.org/docs/app/api-reference/file-conventions/middleware#matcher).
 
 <Callout>
   You should not rely on middleware exclusively for authorization. Always ensure


### PR DESCRIPTION
[The current link in the docs](https://authjs.dev/getting-started/session-management/protecting#:~:text=Middleware%20will%20protect%20pages%20as%20defined%20by%20the%20matcher%20config%20export.%20For%20more%20details%20about%20the%20matcher%2C%20check%20out%20the%20Next.js%20docs.) leads to a 404. This edits the link to lead to the current Matcher section in the Next.js Middleware docs. https://nextjs.org/docs/app/api-reference/file-conventions/middleware#matcher
