### PR TITLE
chore(deps): remove @panva/hkdf in favor of Web Cryptography API

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@panva/hkdf": "^1.2.1",
     "jose": "^6.0.6",
     "oauth4webapi": "^3.3.0",
     "preact": "10.24.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,9 +676,6 @@ importers:
 
   packages/core:
     dependencies:
-      '@panva/hkdf':
-        specifier: ^1.2.1
-        version: 1.2.1
       jose:
         specifier: ^6.0.6
         version: 6.0.6
@@ -4067,9 +4064,6 @@ packages:
 
   '@pandacss/types@0.22.1':
     resolution: {integrity: sha512-WZCQrTa5wlenBStlu0gntKGi4dWA96LCft1oEqdh2u6VPK0sEfqk0wjyJGps/YN3pNjNKiQW3b4p1Wx+RshlYA==}
-
-  '@panva/hkdf@1.2.1':
-    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@parcel/watcher-android-arm64@2.4.1':
     resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
@@ -18056,8 +18050,6 @@ snapshots:
       ts-pattern: 5.0.5
 
   '@pandacss/types@0.22.1': {}
-
-  '@panva/hkdf@1.2.1': {}
 
   '@parcel/watcher-android-arm64@2.4.1':
     optional: true


### PR DESCRIPTION
## ☕️ Reasoning

The https://github.com/panva/hkdf repository has been archived with the following notice in the readme:

> This project is now archived. The functionality provided here is no longer necessary, as the Web Cryptography API is now widely supported across all major and modern JavaScript runtimes and you may just use the following `...`

So this PR replaces the dependency to @panva/hkdf with the proposed alternative using the Cryptography API. We had issues with jest and next-auth regarding ESM-imports from this package (which was fixed by mocking the surrounding methods, but that issue will not happen to others with this change).

I didn't create an issue for this, as the change was quickly made, so if any discussion is needed, it can be done here, or feel free to close the PR if there are other factors I am not aware of that would make this change problematic.

## 🧢 Checklist

- [ ] Documentation (only implementation detail)
- [x] Tests (jwt tests are already in place and still green)
- [x] Ready to be merged

## 🎫 Affected issues

n.a.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
