### PR TITLE
Fix `user` type in `jwt` callback

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -447,7 +447,7 @@ export interface AuthConfig {
        * - [Credentials Provider](https://authjs.dev/getting-started/authentication/credentials)
        * - [User database model](https://authjs.dev/guides/creating-a-database-adapter#user-management)
        */
-      user: User | AdapterUser
+      user: User | AdapterUser | undefined
       /**
        * Contains information about the provider that was used to sign in.
        * Also includes {@link TokenSet}


### PR DESCRIPTION
## ☕️ Reasoning

After the first time the `jwt` callback is called, `user` is undefined, but this is not reflected in the type. This resulted in errors that were difficult to fix in my SvelteKit app using Auth.js. The same change may need to be made in the `session` callback. See further discussion here: https://github.com/nextauthjs/next-auth/discussions/9438

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
