### PR TITLE
Fix crash in azure-ad-b2c provider (v4)

### DIFF
--- a/packages/next-auth/src/providers/azure-ad-b2c.ts
+++ b/packages/next-auth/src/providers/azure-ad-b2c.ts
@@ -37,7 +37,7 @@ export default function AzureADB2C<P extends AzureB2CProfile>(
       return {
         id: profile.sub,
         name: profile.name,
-        email: profile.emails[0],
+        email: profile?.emails?.[0],
         // TODO: Find out how to retrieve the profile picture
         image: null,
       }


### PR DESCRIPTION
☕️ Reasoning
Not all b2c-setups return a list of emails for a profile. This fixes the resulting crash by using defensive access when reading/setting the profile email address field.

This is a copy of a merged PR from 2 years ago that is in the main branch but never made it to the v4 branch.
https://github.com/nextauthjs/next-auth/pull/8616

🧢 Checklist
 Documentation
 Tests
 Ready to be merged
🎫 Affected issues
None found.

📌 Resources
[Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
[Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
[Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
[Contributing to Open Source](https://kcd.im/pull-request)