### PR TITLE
(Fix): broken link of middleware setup

### DIFF
--- a/docs/pages/getting-started/migrate-to-better-auth.mdx
+++ b/docs/pages/getting-started/migrate-to-better-auth.mdx
@@ -155,7 +155,7 @@ export const protectedAction = async () => {
 
 ### Middleware
 
-To protect routes with middleware, refer to the [Next.js middleware guide](/docs/integrations/next#middleware).
+To protect routes with middleware, refer to the [Next.js middleware guide](https://www.better-auth.com/docs/integrations/next#middleware).
 
 ## Wrapping Up
 


### PR DESCRIPTION
This pull request makes a small documentation update to the Next.js middleware guide link in the migration guide. The change ensures that the link points to the correct external URL.

* Updated the Next.js middleware guide link in `migrate-to-better-auth.mdx` to correct the url.