### PR TITLE
feat(providers): support custom baseURL for Gitlab

### DIFF
--- a/docs/pages/getting-started/providers/gitlab.mdx
+++ b/docs/pages/getting-started/providers/gitlab.mdx
@@ -59,10 +59,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     GitLab,
     // Self-hosted example
     GitLab({
-      instance: {
-        baseUrl: "https://gitlab.example.com"
-      }
-    })
+      baseUrl: "https://gitlab.example.com",
+    }),
   ],
 })
 ```
@@ -99,10 +97,8 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
   providers: [
     GitLab,
     GitLab({
-      instance: {
-        baseUrl: "https://gitlab.example.com"
-      }
-    })
+      baseUrl: "https://gitlab.example.com",
+    }),
   ],
 })
 ```
@@ -114,14 +110,17 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 import { ExpressAuth } from "@auth/express"
 import GitLab from "@auth/express/providers/gitlab"
 
-app.use("/auth/*", ExpressAuth({ providers: [
-  GitLab,
-  GitLab({
-    instance: {
-      baseUrl: "https://gitlab.example.com"
-    }
+app.use(
+  "/auth/*",
+  ExpressAuth({
+    providers: [
+      GitLab,
+      GitLab({
+        baseUrl: "https://gitlab.example.com",
+      }),
+    ],
   })
-] }))
+)
 ```
 
   </Code.Express>

--- a/docs/pages/getting-started/providers/gitlab.mdx
+++ b/docs/pages/getting-started/providers/gitlab.mdx
@@ -54,7 +54,16 @@ import NextAuth from "next-auth"
 import GitLab from "next-auth/providers/gitlab"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  providers: [GitLab],
+  providers: [
+    // Default (gitlab.com)
+    GitLab,
+    // Self-hosted example
+    GitLab({
+      instance: {
+        baseUrl: "https://gitlab.example.com"
+      }
+    })
+  ],
 })
 ```
 
@@ -67,7 +76,14 @@ import GitLab from "@auth/qwik/providers/gitlab"
 
 export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
   () => ({
-    providers: [GitLab],
+    providers: [
+      GitLab,
+      GitLab({
+        instance: {
+          baseUrl: "https://gitlab.example.com"
+        }
+      })
+    ],
   })
 )
 ```
@@ -80,7 +96,14 @@ import { SvelteKitAuth } from "@auth/sveltekit"
 import GitLab from "@auth/sveltekit/providers/gitlab"
 
 export const { handle, signIn, signOut } = SvelteKitAuth({
-  providers: [GitLab],
+  providers: [
+    GitLab,
+    GitLab({
+      instance: {
+        baseUrl: "https://gitlab.example.com"
+      }
+    })
+  ],
 })
 ```
 
@@ -91,7 +114,14 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 import { ExpressAuth } from "@auth/express"
 import GitLab from "@auth/express/providers/gitlab"
 
-app.use("/auth/*", ExpressAuth({ providers: [GitLab] }))
+app.use("/auth/*", ExpressAuth({ providers: [
+  GitLab,
+  GitLab({
+    instance: {
+      baseUrl: "https://gitlab.example.com"
+    }
+  })
+] }))
 ```
 
   </Code.Express>

--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -118,21 +118,14 @@ export default function GitLab<P extends GitLabProfile>(
   }
 ): OAuthConfig<P> {
   const baseUrl = config?.instance?.baseUrl ?? "https://gitlab.com"
-  const apiBaseUrl = config?.instance?.baseUrl
-    ? `${config?.instance?.baseUrl}/api/v4`
-    : "https://gitlab.com/api/v4"
 
   return {
     id: "gitlab",
     name: "GitLab",
     type: "oauth",
-    authorization: {
-      url: `${baseUrl}/oauth/authorize?scope=read_user`,
-    },
+    authorization: `${baseUrl}/oauth/authorize?scope=read_user`,
     token: `${baseUrl}/oauth/token`,
-    userinfo: {
-      url: `${apiBaseUrl}/user`,
-    },
+    userinfo: `${baseUrl}/api/v4/user`,
     profile(profile) {
       return {
         id: profile.sub?.toString() ?? profile.id?.toString(),

--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -109,24 +109,39 @@ export interface GitLabProfile extends Record<string, any> {
  * :::
  */
 export default function GitLab<P extends GitLabProfile>(
-  options: OAuthUserConfig<P>
+  config: OAuthUserConfig<P> & {
+    /** Configuration for usage with self-hosted GitLab instances. */
+    instance?: {
+      /** The base URL of your GitLab instance. */
+      baseUrl?: string
+    }
+  }
 ): OAuthConfig<P> {
+  const baseUrl = config?.instance?.baseUrl ?? "https://gitlab.com"
+  const apiBaseUrl = config?.instance?.baseUrl
+    ? `${config?.instance?.baseUrl}/api/v4`
+    : "https://gitlab.com/api/v4"
+
   return {
     id: "gitlab",
     name: "GitLab",
     type: "oauth",
-    authorization: "https://gitlab.com/oauth/authorize?scope=read_user",
-    token: "https://gitlab.com/oauth/token",
-    userinfo: "https://gitlab.com/api/v4/user",
+    authorization: {
+      url: `${baseUrl}/oauth/authorize?scope=read_user`,
+    },
+    token: `${baseUrl}/oauth/token`,
+    userinfo: {
+      url: `${apiBaseUrl}/user`,
+    },
     profile(profile) {
       return {
-        id: profile.sub?.toString(),
+        id: profile.sub?.toString() ?? profile.id?.toString(),
         name: profile.name ?? profile.username,
         email: profile.email,
         image: profile.avatar_url,
       }
     },
     style: { bg: "#FC6D26", text: "#fff" },
-    options,
+    options: config,
   }
 }

--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -109,23 +109,23 @@ export interface GitLabProfile extends Record<string, any> {
  * :::
  */
 export default function GitLab<P extends GitLabProfile>(
-  config: OAuthUserConfig<P> & {
-    /** Configuration for usage with self-hosted GitLab instances. */
-    instance?: {
-      /** The base URL of your GitLab instance. */
-      baseUrl?: string
-    }
+  options: OAuthUserConfig<P> & {
+    /**
+     * @default "https://gitlab.com"
+     */
+    baseUrl?: URL | string
   }
 ): OAuthConfig<P> {
-  const baseUrl = config?.instance?.baseUrl ?? "https://gitlab.com"
+  const baseUrl = options.baseUrl ?? "https://gitlab.com"
+  const url = new URL(baseUrl.toString())
 
   return {
     id: "gitlab",
     name: "GitLab",
     type: "oauth",
-    authorization: `${baseUrl}/oauth/authorize?scope=read_user`,
-    token: `${baseUrl}/oauth/token`,
-    userinfo: `${baseUrl}/api/v4/user`,
+    authorization: `${url}oauth/authorize?scope=read_user`,
+    token: `${url}oauth/token`,
+    userinfo: `${url}api/v4/user`,
     profile(profile) {
       return {
         id: profile.sub?.toString() ?? profile.id?.toString(),
@@ -135,6 +135,6 @@ export default function GitLab<P extends GitLabProfile>(
       }
     },
     style: { bg: "#FC6D26", text: "#fff" },
-    options: config,
+    options,
   }
 }

--- a/packages/core/test/providers/gitlab.test.ts
+++ b/packages/core/test/providers/gitlab.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from "vitest"
+import GitLab from "../../src/providers/gitlab"
+
+it("GitLab should handle baseURL correctly", () => {
+  const config = GitLab({
+    baseUrl: "https://gitlab.example.com",
+  })
+  expect(config.id).toBe("gitlab")
+  expect(config.name).toBe("GitLab")
+  expect(config.type).toBe("oauth")
+  expect(config.authorization).toEqual(
+    "https://gitlab.example.com/oauth/authorize?scope=read_user"
+  )
+  expect(config.token).toEqual("https://gitlab.example.com/oauth/token")
+  expect(config.userinfo).toEqual("https://gitlab.example.com/api/v4/user")
+})


### PR DESCRIPTION
## ☕️ Reasoning

To support self-hosted Gitlab instanced this PR introduces a baseURL similar function to this PR: https://github.com/nextauthjs/next-auth/pull/9271


## 🧢 Checklist

- [x] Documentation
- [x] Ready to be merged

## 🎫 Affected issues

-

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
