### PR TITLE
docs: remove carbon developer ads widget from docs sidebar

### DIFF
--- a/docs/components/Footer/index.tsx
+++ b/docs/components/Footer/index.tsx
@@ -1,40 +1,25 @@
-import { useEffect } from "react"
-import { useRouter } from "next/router"
-import cx from "classnames"
+import { useEffect } from "react";
+import cx from "classnames";
 
 function kFormatter(num: number) {
-  return (Math.sign(num) * (Math.abs(num) / 1000)).toFixed(1) + "k"
+  return (Math.sign(num) * (Math.abs(num) / 1000)).toFixed(1) + "k";
 }
 
 export function Footer({ className = "" }) {
-  const router = useRouter()
-
   useEffect(() => {
     fetch("https://api.github.com/repos/nextauthjs/next-auth")
       .then((res) => res.json())
       .then((data) => {
-        const githubStat = document.querySelector(".github-counter")!
-        if (!githubStat) return
-        githubStat.innerHTML = kFormatter(data.stargazers_count ?? 21100)
-      })
-
-    // CarbonAds hydration error workaround hack
-    const carbonAdsEl =
-      document.querySelector<HTMLScriptElement>("#_carbonads_js")
-    if (carbonAdsEl) {
-      carbonAdsEl.src =
-        "https://cdn.carbonads.com/carbon.js?serve=CWYD42JY&placement=authjsdev&format=cover"
-
-      router.events.on("routeChangeComplete", () => {
-        window._carbonads?.refresh()
-      })
-    }
-  }, [])
+        const githubStat = document.querySelector(".github-counter")!;
+        if (!githubStat) return;
+        githubStat.innerHTML = kFormatter(data.stargazers_count ?? 21100);
+      });
+  }, []);
   return (
     <div
       className={cx(
         "mx-auto flex w-full flex-col items-center gap-4 px-12 pb-20 pt-24 text-gray-600 sm:gap-12 dark:text-gray-100",
-        className
+        className,
       )}
     >
       <div className="flex w-full max-w-[90rem] flex-col justify-between gap-6 sm:flex-row sm:gap-0">
@@ -90,7 +75,7 @@ export function Footer({ className = "" }) {
         Auth.js &copy; Better Auth Inc. - {new Date().getFullYear()}
       </div>
     </div>
-  )
+  );
 }
 
-export default Footer
+export default Footer;

--- a/docs/pages/global.css
+++ b/docs/pages/global.css
@@ -199,31 +199,6 @@ html[data-theme="dark"] .github-counter {
   animation: fadeOut 250ms ease-in;
 }
 
-#carbonads_bak {
-  @apply flex flex-col gap-1 rounded-md bg-neutral-100 p-3 text-xs text-neutral-500 dark:bg-neutral-800 dark:!text-neutral-400;
-
-  .carbon-text {
-    @apply dark:text-neutral-300;
-  }
-
-  .carbon-poweredby {
-    @apply dark:text-neutral-400;
-  }
-
-  #carbon-responsive .carbon-img {
-    flex: unset !important;
-  }
-  img {
-    @apply w-full !max-w-full rounded-[0.25rem];
-  }
-
-  #carbon-responsive .carbon-responsive-wrap {
-    border: none !important;
-    background-color: unset !important;
-    padding: 0 !important;
-  }
-}
-
 .sponsoredBadge {
   display: inline-block;
   width: max-content;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

- Removed the [Carbon ads](https://carbonads.net) widget from the docs page sidebar


## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
