### PR TITLE
docs: add support for yarn, pnpm, and bun in setup environment section

### DIFF
--- a/docs/pages/getting-started/installation.mdx
+++ b/docs/pages/getting-started/installation.mdx
@@ -46,8 +46,41 @@ Start by installing the appropriate package for your framework.
 The only environment variable that is mandatory is the `AUTH_SECRET`. This is a random value used by the library to encrypt tokens and email
 verification hashes. (See [Deployment](/getting-started/deployment) to learn more). You can generate one via the official [Auth.js CLI](https://cli.authjs.dev) running:
 
+<Code>
+  <Code.Next>
+    
+    ```bash npm2yarn
+    npx auth secret
+    ```
+
+  </Code.Next>
+  <Code.Qwik>
+
+    ```bash npm2yarn
+    npx auth secret
+    ```
+
+  </Code.Qwik>
+  <Code.Svelte>
+  
+    ```bash npm2yarn
+    npx auth secret
+    ```
+    
+  </Code.Svelte>
+  <Code.Express>
+  
+    ```bash npm2yarn
+    npx auth secret
+    ```
+  
+  </Code.Express>
+</Code>
+
+Alternatively, you can use bun:
+
 ```bash
-npx auth secret
+bunx auth secret
 ```
 
 This will also add it to your `.env` file, respecting the framework conventions (eg.: Next.js' `.env.local`).


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

## Changes
- Wrapped `npx auth secret` command in Code component with `npm2yarn` directive
- Added framework-specific tabs (Next, Qwik, Svelte, Express) for consistency
- Maintained consistency with the existing "Installing Auth.js" section pattern
- Kept bun alternative separate as it uses `bunx` instead of `npx`

## 🧢 Checklist

- [Yes ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
