### PR TITLE
Fix: Supporting Database Strategies with Credentials Provider

### DIFF
--- a/packages/core/src/lib/actions/callback/index.ts
+++ b/packages/core/src/lib/actions/callback/index.ts
@@ -358,31 +358,54 @@ export async function callback(
         sub: user.id,
       }
 
-      const token = await callbacks.jwt({
-        token: defaultToken,
-        user,
-        account,
-        isNewUser: false,
-        trigger: "signIn",
-      })
-
-      // Clear cookies if token is null
-      if (token === null) {
-        cookies.push(...sessionStore.clean())
-      } else {
-        const salt = options.cookies.sessionToken.name
-        // Encode token
-        const newToken = await jwt.encode({ ...jwt, token, salt })
-
-        // Set cookie expiry date
-        const cookieExpires = new Date()
-        cookieExpires.setTime(cookieExpires.getTime() + sessionMaxAge * 1000)
-
-        const sessionCookies = sessionStore.chunk(newToken, {
-          expires: cookieExpires,
+      // If using JWT sessions, run the jwt callback and set JWT cookies
+      if (useJwtSession) {
+        const token = await callbacks.jwt({
+          token: defaultToken,
+          user,
+          account,
+          isNewUser: false,
+          trigger: "signIn",
         })
 
-        cookies.push(...sessionCookies)
+        // Clear cookies if token is null
+        if (token === null) {
+          cookies.push(...sessionStore.clean())
+        } else {
+          const salt = options.cookies.sessionToken.name
+          // Encode token
+          const newToken = await jwt.encode({ ...jwt, token, salt })
+
+          // Set cookie expiry date
+          const cookieExpires = new Date()
+          cookieExpires.setTime(cookieExpires.getTime() + sessionMaxAge * 1000)
+
+          const sessionCookies = sessionStore.chunk(newToken, {
+            expires: cookieExpires,
+          })
+
+          cookies.push(...sessionCookies)
+        }
+      } else {
+        // Non-JWT (database) sessions: create a session in the adapter and set session cookie
+        if (!adapter) {
+          throw new AuthError("Adapter is required for database sessions")
+        }
+
+        const createdSession = await adapter.createSession({
+          sessionToken: options.session.generateSessionToken(),
+          userId: user.id,
+          expires: new Date(Date.now() + sessionMaxAge * 1000),
+        })
+
+        cookies.push({
+          name: options.cookies.sessionToken.name,
+          value: createdSession.sessionToken,
+          options: {
+            ...options.cookies.sessionToken.options,
+            expires: createdSession.expires,
+          },
+        })
       }
 
       await events.signIn?.({ user, account })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

# Fix: Supporting Database Strategies with Credentials Provider

## ☕️ Reasoning
### EN
When using the Credentials Provider with a database strategy, sessions were not being persisted and authentication did not work as expected.
This change updates the logic to properly store sessions in the database.

(I'm a Japanese student so I can't speak English well... Sorry...)

### JA
> Credentials Providerでは、Databaseを使うように指定している際に、セッションが保存されず、動作しませんでした。  
> そのため、DBにセッションを保存するように変更しました。

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Resolves: #11088  
Resolves: #10280  

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
