### PR TITLE
feat: add next 16 support

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -91,9 +91,9 @@
   "peerDependencies": {
     "@simplewebauthn/browser": "^9.0.1",
     "@simplewebauthn/server": "^9.0.2",
-    "next": "^14.0.0-0 || ^15.0.0-0",
+    "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
     "nodemailer": "^7.0.7",
-    "react": "^18.2.0 || ^19.0.0-0"
+    "react": "^18.2.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@simplewebauthn/browser": {


### PR DESCRIPTION
## ☕️ Reasoning

This PR adds Next.js 16 to peerDependencies, so that it can be used with Next.js 16 projects without peer dependency any warnings.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
