### PR TITLE
fix: conditionally assign basePath in frameworks-sveltekit

### DIFF
--- a/packages/frameworks-sveltekit/src/lib/env.ts
+++ b/packages/frameworks-sveltekit/src/lib/env.ts
@@ -8,8 +8,10 @@ export function setEnvDefaults(
   config: SvelteKitAuthConfig
 ) {
   config.trustHost ??= dev
-  config.basePath ??= envObject.AUTH_URL ? undefined : `${base}/auth`
+  if (!config.basePath && !envObject.AUTH_URL) {
+    config.basePath = `${base}/auth`
+  }
   config.skipCSRFCheck = skipCSRFCheck
   if (building) return
-  coreSetEnvDefaults(envObject, config)
+  coreSetEnvDefaults(envObject, config, true)
 }

--- a/packages/frameworks-sveltekit/src/lib/env.ts
+++ b/packages/frameworks-sveltekit/src/lib/env.ts
@@ -8,7 +8,7 @@ export function setEnvDefaults(
   config: SvelteKitAuthConfig
 ) {
   config.trustHost ??= dev
-  config.basePath = `${base}/auth`
+  config.basePath ??= envObject.AUTH_URL ? undefined : `${base}/auth`
   config.skipCSRFCheck = skipCSRFCheck
   if (building) return
   coreSetEnvDefaults(envObject, config)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

This PR fixes the incorrect assignment statement to the `basePath` setting in the frameworks-sveltekit package. It used to ignore the value set by the user and didn’t recognize the possible presence of the `AUTH_URL` environment variable, which, when set, caused the env-url-basepath-redundant warning to be spammed in the logs. In this PR, I moved the assignment statement into an if condition that checks if neither user-defined `basePath` nor the `AUTH_URL` is present, which is supposed to be the only case where `basePath` should be assigned a fallback value.

Also, due to inappropriate implementation of the `coreSetEnvDefaults` function, it is unclear if it is supposed to be run once or multiple times - the `env-url-basepath-redundant` warning is logged each time it finds both `basePath` and `AUTH_URL` are present, but following this check in the function it immediately assigns `basePath` to ensure it always has an value, causing all subsequent invocations of this function to annoyingly spam that warning in the console, as long as `AUTH_URL` is defined. Therefore, `suppressBasePathWarning` is now set to true when calling `coreSetEnvDefaults` to completely prevent that warning from being logged.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/12795

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
