### PR TITLE
Fix @auth/core version discrepancies affecting nodemailer package resolution

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/core",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Authentication for the Web.",
   "keywords": [
     "authentication",

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-auth",
-  "version": "5.0.0-beta.30",
+  "version": "5.0.0-beta.31",
   "description": "Authentication for Next.js",
   "homepage": "https://nextjs.authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth.git",


### PR DESCRIPTION
`@auth/core` has two versions published on npm

-   [0.41.1](https://www.npmjs.com/package/@auth/core/v/0.41.1) (with nodemailer@7)
-   [0.41.0](https://www.npmjs.com/package/@auth/core/v/0.41.0) (with nodemailer@6)

However, this repository has only the latter 0.41.0, and with nodemailer@7 (different from the two published versions.)

The problem is that latest [next-auth@5.0.0-beta.30](https://www.npmjs.com/package/next-auth/v/5.0.0-beta.30?activeTab=code) depends on the published 0.41.0 (that has nodemailer@6) while itself (next-auth) needs nodemailer@7. This is causing issues with installing the latest next-auth because each sub package needs a different nodemailer version.