### PR TITLE
fix(core): respect forwarded headers for base URL detection

### DIFF
--- a/packages/core/src/lib/utils/web.ts
+++ b/packages/core/src/lib/utils/web.ts
@@ -35,7 +35,17 @@ export async function toInternalRequest(
     // Defaults are usually set in the `init` function, but this is needed below
     config.basePath ??= "/auth"
 
-    const url = new URL(req.url)
+    let url = new URL(req.url)
+    if (config.trustHost) {
+      const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host")
+      const protocol =
+        req.headers.get("x-forwarded-proto") ??
+        (url.protocol === "https:" ? "https" : "http")
+      if (host) {
+        const _protocol = protocol.endsWith(":") ? protocol : protocol + ":"
+        url = new URL(`${_protocol}//${host}${url.pathname}${url.search}`)
+      }
+    }
 
     const { action, providerId } = parseActionAndProviderId(
       url.pathname,


### PR DESCRIPTION
## ☕️ Reasoning

In containerized environments (like Docker) or multi-tenant setups behind a reverse proxy, `Request.url` often reflects the internal network address (e.g., http://0.0.0.0:3000) rather than the public-facing domain.

When `trustHost` is enabled, the library should prioritize X-Forwarded-Host and X-Forwarded-Proto headers to reconstruct the application's base URL. Without this, callbackUrl validation fails because the incoming URL behaves as a mismatch against the detected internal base URL, leading to incorrect redirects

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Potential issue fixes: https://github.com/nextauthjs/next-auth/discussions/8154

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
