### PR TITLE
doc: fix useSession() example

### DIFF
--- a/docs/pages/getting-started/migrating-to-v5.mdx
+++ b/docs/pages/getting-started/migrating-to-v5.mdx
@@ -132,7 +132,7 @@ Imports from `next-auth/react` are now marked with the [`"use client"`](https://
 import { useSession, SessionProvider } from 'next-auth/react';
 
 const ClientComponent = () => {
-  const session = useSession();
+  const { data: session } = useSession();
 
   return (
     <SessionProvider>


### PR DESCRIPTION
## ☕️ Reasoning

The example of the use of `useSession()` in the Migration Guide to v5 was not correct.

## 🧢 Checklist

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
