### PR TITLE
feat(providers): add Heavstal provider

### DIFF
--- a/docs/pages/data/manifest.json
+++ b/docs/pages/data/manifest.json
@@ -78,6 +78,7 @@
     "freshbooks": "Freshbooks",
     "fusionauth": "FusionAuth",
     "gitlab": "GitLab",
+    "heavstal": "Heavstal",
     "hubspot": "HubSpot",
     "huggingface": "Hugging Face",
     "identity-server4": "IdentityServer4",

--- a/docs/pages/getting-started/providers/heavstal.mdx
+++ b/docs/pages/getting-started/providers/heavstal.mdx
@@ -1,0 +1,47 @@
+import { Callout } from "nextra/components"
+import { Code } from "@/components/Code"
+
+# Heavstal
+
+Heavstal is a developer infrastructure platform providing secure OAuth2 and OpenID Connect (OIDC) identity services.
+
+## Resources
+
+- [Heavstal Developer Console](https://heavstal-tech.vercel.app/oauth/apps)
+- [Heavstal Documentation](https://heavstal-tech.vercel.app/docs/api/oauth-guide)
+
+## Setup
+
+### Callback URL
+
+<Code>
+  <CopyButton />
+  <span className="code-block">https://example.com/api/auth/callback/heavstal</span>
+</Code>
+
+### Environment Variables
+
+<Callout type="info">
+  Heavstal supports OIDC discovery. You do not need to configure endpoints manually.
+</Callout>
+
+```env filename=".env"
+AUTH_HEAVSTAL_ID=ht_id_...
+AUTH_HEAVSTAL_SECRET=ht_secret_...
+```
+
+### Configuration
+
+<Code>
+  <CopyButton />
+  ```ts filename="auth.ts"
+  import NextAuth from "next-auth"
+  import Heavstal from "next-auth/providers/heavstal"
+
+  export const { handlers, auth, signIn, signOut } = NextAuth({
+    providers: [
+      Heavstal
+    ],
+  })
+  ```
+</Code>

--- a/docs/public/img/providers/heavstal.svg
+++ b/docs/public/img/providers/heavstal.svg
@@ -1,0 +1,5 @@
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="48" cy="48" r="42" fill="none" stroke="#2563EB" stroke-width="4.5"/>
+  <circle cx="48" cy="48" r="34" fill="none" stroke="#2563EB" stroke-opacity="0.25" stroke-width="2"/>
+  <path d="M32 26h11v44h-11ZM53 26h11v44h-11ZM32 44h32v8h-32Z" fill="#1E40AF"/>
+</svg>

--- a/packages/core/src/providers/heavstal.ts
+++ b/packages/core/src/providers/heavstal.ts
@@ -1,0 +1,71 @@
+import type { OAuthConfig, OAuthUserConfig } from "../types.js"
+
+/**
+ * The returned user profile from Heavstal Tech.
+ */
+export interface HeavstalProfile extends Record<string, any> {
+  /** The unique Heavstal User ID */
+  sub: string
+  /** The user's public display name */
+  name: string
+  /** The user's verified email address */
+  email: string
+  /** The user's profile picture URL */
+  picture: string
+}
+
+/**
+ * Add Heavstal login to your page.
+ *
+ * ### Setup
+ *
+ * #### Callback URL
+ * ```
+ * https://example.com/api/auth/callback/heavstal
+ * ```
+ *
+ * #### Configuration
+ *```ts
+ * import { Auth } from "@auth/core"
+ * import Heavstal from "@auth/core/providers/heavstal"
+ *
+ * const request = new Request("https://example.com")
+ * const response = await Auth(request, {
+ *   providers: [
+ *     Heavstal({
+ *       clientId: process.env.HEAVSTAL_CLIENT_ID,
+ *       clientSecret: process.env.HEAVSTAL_CLIENT_SECRET,
+ *     }),
+ *   ],
+ * })
+ * ```
+ *
+ * ### Resources
+ *
+ * - [Heavstal Developer Console](https://heavstal-tech.vercel.app/oauth/apps)
+ * - [Heavstal API Documentation](https://heavstal-tech.vercel.app/docs/api/oauth-guide)
+ */
+export default function Heavstal(
+  options: OAuthUserConfig<HeavstalProfile>
+): OAuthConfig<HeavstalProfile> {
+  return {
+    id: "heavstal",
+    name: "Heavstal",
+    type: "oidc",
+    issuer: "https://accounts-heavstal.vercel.app",
+    style: {
+      logo: "/providers/heavstal.svg",
+      bg: "#000",
+      text: "#fff",
+    },
+    profile(profile) {
+      return {
+        id: profile.sub,
+        name: profile.name,
+        email: profile.email,
+        image: profile.picture,
+      }
+    },
+    options,
+  }
+}


### PR DESCRIPTION
Adds the Heavstal OAuth2 provider to the library.

**Changes:**
- Added provider source: `packages/core/src/providers/heavstal.ts`
- Added documentation: `docs/pages/getting-started/providers/heavstal.mdx`
- Added logo: `docs/public/img/providers/heavstal.svg`
- Manually updated manifests (`docs/pages/data/manifest.json`) to register the provider.

**Note to Maintainers:**
I manually updated the internal manifest file because the `pnpm providers` generation script was failing in my environment. The implementation follows the standard OAuth2 pattern.

**Resources:**
- Docs: https://heavstal-tech.vercel.app/docs/api/oauth-guide