### PR TITLE
feat: export broadcast function from react module

### DIFF
--- a/packages/next-auth/src/react.tsx
+++ b/packages/next-auth/src/react.tsx
@@ -87,7 +87,7 @@ function getNewBroadcastChannel() {
   return new BroadcastChannel("next-auth")
 }
 
-function broadcast() {
+export function broadcast() {
   if (broadcastChannel === null) {
     broadcastChannel = getNewBroadcastChannel()
   }


### PR DESCRIPTION
Exporting the broadcast function to allow external usage of the BroadcastChannel functionality.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

This gives us the opportunity to directly listen to the broadcasted signout event to achieve reload on other tabs, while the tab that executes `signOut` won't receive the event itself.

```typescript
'use client';

import { broadcast, useSession } from 'next-auth/react';
import { useEffect } from 'react';

interface NextAuthBroadcastMessage {
  event: string;
  data?: {
    trigger?: string;
  };
}

export function SignOutListener() {
  const { data: session } = useSession();

  useEffect(() => {
    const channel = broadcast();

    const handler = (message: MessageEvent<NextAuthBroadcastMessage>) => {
      const { event, data } = message.data;

      // message format: { event: "session", data: { trigger: "signout" } }
      if (session && event === 'session' && data?.trigger === 'signout') {
        window.location.reload();
      }
    };

    channel.addEventListener('message', handler);

    return () => {
      channel.removeEventListener('message', handler);
    };
  }, [session]);

  return null;
}
```

## 🧢 Checklist

- [x] Ready to be merged
