### PR TITLE
Update/passkey 01

### DIFF
--- a/docs/pages/getting-started/authentication/webauthn.mdx
+++ b/docs/pages/getting-started/authentication/webauthn.mdx
@@ -25,10 +25,10 @@ Support for more frameworks and adapters are coming soon.
 ### Install peer dependencies
 
 ```bash npm2yarn
-npm install @simplewebauthn/server@9.0.3 @simplewebauthn/browser@9.0.1
+npm install @simplewebauthn/server@^13.2.2 @simplewebauthn/browser@^13.2.2
 ```
 
-The `@simplewebauthn/browser` peer dependency **is only required for custom signin pages**. If you're using the Auth.js default pages, you can skip installing that peer dependency.
+Auth.js uses [SimpleWebAuthn v13](https://simplewebauthn.dev/docs/packages/server). The `@simplewebauthn/browser` peer dependency **is only required for custom sign-in pages**. If you're using the Auth.js default pages, you can skip installing the browser package. As of v13, types come from the browser and server packages (no separate `@simplewebauthn/types`).
 
 ### Apply the required schema Migrations
 

--- a/docs/pages/getting-started/providers/passkey.mdx
+++ b/docs/pages/getting-started/providers/passkey.mdx
@@ -29,10 +29,10 @@ Passkeys are currently supported in the following adapters / framework packages.
 ### Install peer dependencies
 
 ```bash npm2yarn
-npm install @simplewebauthn/browser@9.0.1 @simplewebauthn/server@9.0.3
+npm install @simplewebauthn/browser@^13.2.2 @simplewebauthn/server@^13.2.2
 ```
 
-The `@simplewebauthn/browser` peer dependency is only required for custom signin pages. If you're using the Auth.js default pages, you can skip installing that peer dependency.
+Auth.js uses [SimpleWebAuthn v13](https://simplewebauthn.dev/docs/packages/server). Both packages are optional peer dependencies: the server package is used for generating and verifying options; the browser package is only required for custom sign-in pages (you can skip it if using the default Auth.js pages). As of v13, types are exported from the browser and server packages (no separate `@simplewebauthn/types`).
 
 ### Database Setup
 
@@ -184,7 +184,7 @@ If you're using the built-in Auth.js pages, then you are good to go now! Navigat
 
 ### Custom Pages
 
-If you're building a custom signin page, you can leverage the `next-auth/webauthn` `signIn` function to initiate both WebAuthn registration and authentication. Remember, when using the WebAuthn `signIn` function, you'll also need the `@simplewebauth/browser` peer dependency installed.
+If you're building a custom sign-in page, you can leverage the `next-auth/webauthn` `signIn` function to initiate both WebAuthn registration and authentication. Remember, when using the WebAuthn `signIn` function, you'll also need the `@simplewebauthn/browser` peer dependency installed.
 
 ```ts filename="app/login/page.tsx" {4} /webauthn/
 "use client"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,8 +74,8 @@
     "preact-render-to-string": "6.5.11"
   },
   "peerDependencies": {
-    "@simplewebauthn/browser": "^9.0.1",
-    "@simplewebauthn/server": "^9.0.2",
+    "@simplewebauthn/browser": "^13.2.2",
+    "@simplewebauthn/server": "^13.2.2",
     "nodemailer": "^7.0.7"
   },
   "peerDependenciesMeta": {
@@ -99,9 +99,8 @@
     "providers": "node scripts/generate-providers"
   },
   "devDependencies": {
-    "@simplewebauthn/browser": "9.0.1",
-    "@simplewebauthn/server": "9.0.3",
-    "@simplewebauthn/types": "^9.0.1",
+    "@simplewebauthn/browser": "^13.2.2",
+    "@simplewebauthn/server": "^13.2.2",
     "@types/node": "18.11.10",
     "@types/nodemailer": "6.4.6",
     "@types/react": "18.0.37",

--- a/packages/core/src/lib/utils/webauthn-client.js
+++ b/packages/core/src/lib/utils/webauthn-client.js
@@ -8,9 +8,9 @@
 /**
  * @template {WebAuthnOptionsAction} T
  * @typedef {T extends WebAuthnAuthenticate ?
- *  { options: import("@simplewebauthn/types").PublicKeyCredentialRequestOptionsJSON; action: "authenticate" } :
+ *  { options: import("@simplewebauthn/server").PublicKeyCredentialRequestOptionsJSON; action: "authenticate" } :
  *  T extends WebAuthnRegister ?
- *  { options: import("@simplewebauthn/types").PublicKeyCredentialCreationOptionsJSON; action: "register" } :
+ *  { options: import("@simplewebauthn/server").PublicKeyCredentialCreationOptionsJSON; action: "register" } :
  * never
  * } WebAuthnOptionsReturn
  */
@@ -125,10 +125,10 @@ export async function webauthnScript(authURL, providerID) {
    */
   async function authenticationFlow(options, autofill) {
     // Start authentication
-    const authResp = await WebAuthnBrowser.startAuthentication(
-      options,
-      autofill
-    )
+    const authResp = await WebAuthnBrowser.startAuthentication({
+      optionsJSON: options,
+      useBrowserAutofill: autofill ?? false,
+    })
 
     // Submit authentication response to server
     return await submitForm("authenticate", authResp)
@@ -147,7 +147,9 @@ export async function webauthnScript(authURL, providerID) {
     })
 
     // Start registration
-    const regResp = await WebAuthnBrowser.startRegistration(options)
+    const regResp = await WebAuthnBrowser.startRegistration({
+      optionsJSON: options,
+    })
 
     // Submit registration response to server
     return await submitForm("register", regResp)

--- a/packages/core/src/lib/utils/webauthn-utils.ts
+++ b/packages/core/src/lib/utils/webauthn-utils.ts
@@ -17,12 +17,12 @@ import {
   WebAuthnVerificationError,
 } from "../../errors.js"
 import { webauthnChallenge } from "../actions/callback/oauth/checks.js"
-import {
-  type AuthenticationResponseJSON,
-  type PublicKeyCredentialCreationOptionsJSON,
-  type PublicKeyCredentialRequestOptionsJSON,
-  type RegistrationResponseJSON,
-} from "@simplewebauthn/types"
+import type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+} from "@simplewebauthn/server"
 import type {
   Adapter,
   AdapterAccount,
@@ -428,7 +428,7 @@ async function getAuthenticationOptions(
     ...provider.authenticationOptions,
     rpID: relayingParty.id,
     allowCredentials: authenticators?.map((a) => ({
-      id: fromBase64(a.credentialID),
+      id: a.credentialID,
       type: "public-key",
       transports: stringToTransports(a.transports),
     })),
@@ -459,7 +459,7 @@ async function getRegistrationOptions(
   // We can do this because we don't use this user ID to link the
   // credential to the user. Instead, we store actual userID in the
   // Authenticator object and fetch it via it's credential ID.
-  const userID = randomString(32)
+  const userID = new TextEncoder().encode(randomString(32))
 
   const relayingParty = provider.getRelayingParty(options, request)
 
@@ -472,7 +472,7 @@ async function getRegistrationOptions(
     rpID: relayingParty.id,
     rpName: relayingParty.name,
     excludeCredentials: authenticators?.map((a) => ({
-      id: fromBase64(a.credentialID),
+      id: a.credentialID,
       type: "public-key",
       transports: stringToTransports(a.transports),
     })),

--- a/packages/core/src/lib/utils/webauthn-utils.ts
+++ b/packages/core/src/lib/utils/webauthn-utils.ts
@@ -33,6 +33,7 @@ import { randomString } from "./web.js"
 import type {
   VerifiedAuthenticationResponse,
   VerifiedRegistrationResponse,
+  WebAuthnCredential,
 } from "@simplewebauthn/server"
 
 export type WebAuthnRegister = "register"
@@ -249,7 +250,7 @@ export async function verifyAuthenticate(
       ...provider.verifyAuthenticationOptions,
       expectedChallenge,
       response: data as AuthenticationResponseJSON,
-      authenticator: fromAdapterAuthenticator(authenticator),
+      credential: adapterAuthenticatorToWebAuthnCredential(authenticator),
       expectedOrigin: relayingParty.origin,
       expectedRPID: relayingParty.id,
     })
@@ -369,9 +370,12 @@ export async function verifyRegister(
     )
   }
 
+  const { credential, credentialDeviceType, credentialBackedUp } =
+    verification.registrationInfo
+
   // Build a new account
   const account = {
-    providerAccountId: toBase64(verification.registrationInfo.credentialID),
+    providerAccountId: credential.id,
     provider: options.provider.id,
     type: provider.type,
   }
@@ -379,13 +383,11 @@ export async function verifyRegister(
   // Build a new authenticator
   const authenticator = {
     providerAccountId: account.providerAccountId,
-    counter: verification.registrationInfo.counter,
-    credentialID: toBase64(verification.registrationInfo.credentialID),
-    credentialPublicKey: toBase64(
-      verification.registrationInfo.credentialPublicKey
-    ),
-    credentialBackedUp: verification.registrationInfo.credentialBackedUp,
-    credentialDeviceType: verification.registrationInfo.credentialDeviceType,
+    counter: credential.counter,
+    credentialID: credential.id,
+    credentialPublicKey: toBase64(credential.publicKey),
+    credentialBackedUp,
+    credentialDeviceType,
     transports: transportsToString(
       (data as RegistrationResponseJSON).response
         .transports as AuthenticatorTransport[]
@@ -495,16 +497,15 @@ export function assertInternalOptionsWebAuthn(
   return { ...options, provider, adapter }
 }
 
-function fromAdapterAuthenticator(
+function adapterAuthenticatorToWebAuthnCredential(
   authenticator: AdapterAuthenticator
-): InternalAuthenticator {
+): WebAuthnCredential {
+  const publicKeyBytes = fromBase64(authenticator.credentialPublicKey)
   return {
-    ...authenticator,
-    credentialDeviceType:
-      authenticator.credentialDeviceType as InternalAuthenticator["credentialDeviceType"],
+    id: authenticator.credentialID,
+    publicKey: new Uint8Array(publicKeyBytes),
+    counter: authenticator.counter,
     transports: stringToTransports(authenticator.transports),
-    credentialID: fromBase64(authenticator.credentialID),
-    credentialPublicKey: fromBase64(authenticator.credentialPublicKey),
   }
 }
 

--- a/packages/core/src/providers/passkey.ts
+++ b/packages/core/src/providers/passkey.ts
@@ -19,11 +19,16 @@ import WebAuthn, {
  *
  * ### Setup
  *
- * Install the required peer dependency.
+ * Install the required peer dependencies (SimpleWebAuthn v13).
  *
  * ```bash npm2yarn
- * npm install @simplewebauthn/browser@13.2.2
+ * npm install @simplewebauthn/browser@^13.2.2 @simplewebauthn/server@^13.2.2
  * ```
+ *
+ * Both packages are optional peer dependencies; the server package is used for
+ * generating and verifying options, the browser package for the sign-in page script.
+ * As of v13, types are exported from the browser and server packages (no separate
+ * `@simplewebauthn/types` package).
  *
  * #### Configuration
  * ```ts
@@ -46,8 +51,14 @@ import WebAuthn, {
  * ### Notes
  *
  * This provider is an extension of the WebAuthn provider that defines some default values
- * associated with Passkey support. You may override these, but be aware that authenticators
- * may not recognize your credentials as Passkey credentials if you do.
+ * associated with Passkey support (e.g. resident key, user verification). You may override
+ * these, but be aware that authenticators may not recognize your credentials as Passkey
+ * credentials if you do.
+ *
+ * **SimpleWebAuthn v13:** Auth.js uses the v13 API: credential IDs in options are base64
+ * strings; `verifyAuthenticationResponse` expects a `credential` (id, publicKey, counter);
+ * `verifyRegistrationResponse` returns `registrationInfo.credential` with the same shape;
+ * and the browser helpers use a single options object (`optionsJSON`, `useBrowserAutofill`).
  *
  * :::tip
  *

--- a/packages/core/src/providers/passkey.ts
+++ b/packages/core/src/providers/passkey.ts
@@ -22,7 +22,7 @@ import WebAuthn, {
  * Install the required peer dependency.
  *
  * ```bash npm2yarn
- * npm install @simplewebauthn/browser@9.0.1
+ * npm install @simplewebauthn/browser@13.2.2
  * ```
  *
  * #### Configuration

--- a/packages/core/src/providers/webauthn.ts
+++ b/packages/core/src/providers/webauthn.ts
@@ -24,7 +24,7 @@ import type {
 export type WebAuthnProviderType = "webauthn"
 
 export const DEFAULT_WEBAUTHN_TIMEOUT = 5 * 60 * 1000 // 5 minutes
-export const DEFAULT_SIMPLEWEBAUTHN_BROWSER_VERSION: SemverString = "v9.0.1"
+export const DEFAULT_SIMPLEWEBAUTHN_BROWSER_VERSION: SemverString = "v13.2.2"
 
 export type RelayingParty = {
   /** Relaying Party ID. Use the website's domain name. */
@@ -105,7 +105,7 @@ export interface WebAuthnConfig extends CommonProviderOptions {
    * Version of SimpleWebAuthn browser script to load in the sign in page.
    *
    * This is only loaded if the provider has conditional UI enabled. If set to false, it won't load any script.
-   * Defaults to `v9.0.0`.
+   * Defaults to `v13.2.2`.
    */
   simpleWebAuthnBrowserVersion: SemverString | false
   /** Form fields displayed in the default Passkey sign in/up form.

--- a/packages/core/src/providers/webauthn.ts
+++ b/packages/core/src/providers/webauthn.ts
@@ -72,7 +72,7 @@ type ConfigurableVerifyAuthenticationOptions = Omit<
   | "expectedChallenge"
   | "expectedOrigin"
   | "expectedRPID"
-  | "authenticator"
+  | "credential"
   | "response"
 >
 type ConfigurableVerifyRegistrationOptions = Omit<
@@ -162,6 +162,16 @@ export interface WebAuthnConfig extends CommonProviderOptions {
  *
  * ### Setup
  *
+ * Install the optional peer dependencies (SimpleWebAuthn v13):
+ *
+ * ```bash npm2yarn
+ * npm install @simplewebauthn/browser@^13.2.2 @simplewebauthn/server@^13.2.2
+ * ```
+ *
+ * The browser package is used for the sign-in page script; the server package for
+ * generating and verifying options. As of v13, types come from those packages
+ * (no separate `@simplewebauthn/types`).
+ *
  * #### Configuration
  * ```ts
  * import { Auth } from "@auth/core"
@@ -177,6 +187,12 @@ export interface WebAuthnConfig extends CommonProviderOptions {
  * - [SimpleWebAuthn - Server side](https://simplewebauthn.dev/docs/packages/server)
  * - [SimpleWebAuthn - Client side](https://simplewebauthn.dev/docs/packages/client)
  * - [Source code](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/webauthn.ts)
+ *
+ * **SimpleWebAuthn v13:** This provider targets the v13 API: credential IDs in
+ * `allowCredentials`/`excludeCredentials` are base64 strings; authentication
+ * verification uses a `credential` object (id, publicKey, counter); registration
+ * verification returns `registrationInfo.credential`; and the default browser
+ * script uses the v13 options shape (`optionsJSON`, `useBrowserAutofill`).
  *
  * :::tip
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,14 +699,11 @@ importers:
         version: 6.5.11(preact@10.24.3)
     devDependencies:
       '@simplewebauthn/browser':
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 13.2.2
+        version: 13.2.2
       '@simplewebauthn/server':
-        specifier: 9.0.3
-        version: 9.0.3(encoding@0.1.13)
-      '@simplewebauthn/types':
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: 13.2.2
+        version: 13.2.2
       '@types/node':
         specifier: 18.11.10
         version: 18.11.10
@@ -4740,11 +4737,18 @@ packages:
   '@simplewebauthn/browser@13.2.0':
     resolution: {integrity: sha512-N3fuA1AAnTo5gCStYoIoiasPccC+xPLx2YU88Dv0GeAmPQTWHETlZQq5xZ0DgUq1H9loXMWQH5qqUjcI7BHJ1A==}
 
+  '@simplewebauthn/browser@13.2.2':
+    resolution: {integrity: sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==}
+
   '@simplewebauthn/browser@9.0.1':
     resolution: {integrity: sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==}
 
   '@simplewebauthn/server@13.2.1':
     resolution: {integrity: sha512-Inmfye5opZXe3HI0GaksqBnQiM7glcNySoG6DH1GgkO1Lh9dvuV4XSV9DK02DReUVX39HpcDob9nxHELjECoQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@simplewebauthn/server@13.2.2':
+    resolution: {integrity: sha512-HcWLW28yTMGXpwE9VLx9J+N2KEUaELadLrkPEEI9tpI5la70xNEVEsu/C+m3u7uoq4FulLqZQhgBCzR9IZhFpA==}
     engines: {node: '>=20.0.0'}
 
   '@simplewebauthn/server@9.0.3':
@@ -18921,6 +18925,8 @@ snapshots:
 
   '@simplewebauthn/browser@13.2.0': {}
 
+  '@simplewebauthn/browser@13.2.2': {}
+
   '@simplewebauthn/browser@9.0.1':
     dependencies:
       '@simplewebauthn/types': 9.0.1
@@ -18934,6 +18940,17 @@ snapshots:
       '@peculiar/asn1-rsa': 2.3.8
       '@peculiar/asn1-schema': 2.3.8
       '@peculiar/asn1-x509': 2.3.8
+      '@peculiar/x509': 1.14.0
+
+  '@simplewebauthn/server@13.2.2':
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.2
+      '@peculiar/asn1-android': 2.3.10
+      '@peculiar/asn1-ecc': 2.5.0
+      '@peculiar/asn1-rsa': 2.5.0
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
       '@peculiar/x509': 1.14.0
 
   '@simplewebauthn/server@9.0.3(encoding@0.1.13)':
@@ -30654,7 +30671,7 @@ snapshots:
 
   webcrypto-core@1.7.8:
     dependencies:
-      '@peculiar/asn1-schema': 2.3.8
+      '@peculiar/asn1-schema': 2.5.0
       '@peculiar/json-schema': 1.1.12
       asn1js: 3.0.5
       pvtsutils: 1.3.5


### PR DESCRIPTION
## ☕️ Reasoning

This PR upgrades **WebAuthn / Passkey** support to **SimpleWebAuthn v13** and keeps docs and tests in sync.

This will make it production ready instead of deprecated version.

### Package updates
- Bump **@simplewebauthn/browser** and **@simplewebauthn/server** from v9 to **^13.2.2** (peer and dev dependencies).
- Drop **@simplewebauthn/types** (deprecated in v13; types now come from browser and server packages).

### API and implementation changes (v13)
- **Registration options:** `userID` is now a `Uint8Array` (encoded via `TextEncoder`); credential IDs in `allowCredentials` / `excludeCredentials` are base64 **strings** (`a.credentialID`).
- **Authentication verification:** Use `credential` (WebAuthnCredential: `id`, `publicKey`, `counter`) instead of `authenticator`. Add `adapterAuthenticatorToWebAuthnCredential()` and ensure `publicKey` is an `ArrayBuffer`-backed `Uint8Array` for type compatibility.
- **Registration verification:** Use v13 `registrationInfo` shape: `credential` (id, publicKey, counter) and top-level `credentialDeviceType` / `credentialBackedUp`.
- **Client script (`webauthn-client.js`):** `startAuthentication` and `startRegistration` now take a single options object (`optionsJSON`, `useBrowserAutofill` / `useAutoRegister`).
- **Config type:** `ConfigurableVerifyAuthenticationOptions` omits `credential` instead of `authenticator`. Remove unused `fromAdapterAuthenticator`.

### Tests
- Adjust expectations and mocks for v13 (e.g. `registrationInfo.credential`, `credential` in auth verification, `CredentialDeviceType`, `Uint8Array` for `publicKey`).
- Add a **Passkey provider** test block: registration and authentication flows with Passkey defaults and `provider.id === "passkey"`.

### Documentation
- **Provider JSDoc** (`passkey.ts`, `webauthn.ts`): document both peer deps, v13.2.2 install, and a short “SimpleWebAuthn v13” note (credential IDs, `credential` usage, browser API shape).
- **Guides:** Update `docs/pages/getting-started/providers/passkey.mdx` and `docs/pages/getting-started/authentication/webauthn.mdx` to install `@^13.2.2`, mention v13 and that types live in browser/server. Fix typo `@simplewebauth/browser` → `@simplewebauthn/browser`.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

<!-- Optional: link any related issues -->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)