### PR TITLE
fix(core): resolve signin URL correctly on error page

### DIFF
--- a/packages/core/src/lib/pages/error.tsx
+++ b/packages/core/src/lib/pages/error.tsx
@@ -22,7 +22,7 @@ interface ErrorView {
 /** Renders an error page. */
 export default function ErrorPage(props: ErrorProps) {
   const { url, error = "default", theme } = props
-  const signinPageUrl = `${url}/signin`
+  const signinPageUrl = url ? new URL("signin", url).href : "/signin"
 
   const errors: Record<ErrorPageParam | "default", ErrorView> = {
     default: {

--- a/packages/core/test/pages.test.ts
+++ b/packages/core/test/pages.test.ts
@@ -4,6 +4,33 @@ import { authOptions } from "./fixtures/pages"
 import { init } from "../src/lib/init"
 
 describe("pages", () => {
+  describe("error", () => {
+    beforeEach(() => {
+      vi.resetAllMocks()
+    })
+
+    it("should generate correct signin URL on error page", async () => {
+      // Generated when visiting `/auth/error?error=AccessDenied`
+      const { options } = await init({
+        authOptions,
+        action: "error",
+        providerId: "github",
+        url: new URL("http://localhost:3000/auth/error?error=AccessDenied"),
+        cookies: {},
+        isPost: false,
+        csrfDisabled: true,
+      })
+
+      const render = renderPage({ ...options, query: {}, cookies: [] })
+      const errorPage = render.error("AccessDenied")
+
+      // The signin link should point to /auth/signin, not /auth/error?error=AccessDenied/signin
+      expect(errorPage.body).toContain(
+        `href="http://localhost:3000/auth/signin"`
+      )
+      expect(errorPage.body).not.toContain(`error=AccessDenied/signin`)
+    })
+  })
   describe("sign-out", () => {
     beforeEach(() => {
       vi.resetAllMocks()


### PR DESCRIPTION
## Summary

Fixes #13204

The signin link on the error page was incorrectly constructed using string concatenation:
```typescript
const signinPageUrl = `${url}/signin`
```

When the URL is `/auth/error?error=AccessDenied`, this results in the malformed URL:
`/auth/error?error=AccessDenied/signin`

## Changes

Changed to use the `URL` constructor to properly resolve the signin path:
```typescript
const signinPageUrl = url ? new URL("signin", url).href : "/signin"
```

This correctly produces `/auth/signin` regardless of query parameters in the current URL.

## Testing

Added test case in `pages.test.ts` to verify the signin link is generated correctly on the error page.