### PR TITLE
fix(core): guard against undefined provider in POST callback handler

### DIFF
--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -70,7 +70,7 @@ export async function AuthInternal(
     const { csrfTokenVerified } = options
     switch (action) {
       case "callback":
-        if (options.provider.type === "credentials")
+        if (options.provider?.type === "credentials")
           // Verified CSRF Token required for credentials providers only
           validateCSRF(action, csrfTokenVerified)
         return await actions.callback(request, options, sessionStore, cookies)


### PR DESCRIPTION
## Summary

When a POST request hits `/api/auth/callback/<invalid-provider-id>`, `options.provider` is `undefined` because no configured provider matches the ID. The code at `packages/core/src/lib/index.ts:73` accesses `options.provider.type` without a null check, causing:

```
TypeError: Cannot read properties of undefined (reading 'type')
```

The downstream `actions.callback()` already guards against this with `if (!options.provider) throw new InvalidProvider(...)`, but the crash occurs **before** that function is reached — during the CSRF check gate.

## Fix

Add optional chaining: `options.provider?.type` — consistent with how `lib/init.ts:40` already handles the same property.

When `provider` is `undefined`, the CSRF check is skipped (correctly — there's no credentials provider to protect), and execution falls through to `actions.callback()` which throws the proper `InvalidProvider` error.

## How to reproduce

Send a POST request to `/api/auth/callback/nonexistent-provider` with any body. Commonly triggered by bot/scanner traffic probing auth endpoints.