### PR TITLE
ci: declare explicit token permissions in maintenance workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "43 17 * * 2"
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Verify

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,6 +5,10 @@ name: Label Pull Requests
 on:
   pull_request_target:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   prs:
     name: Triage

--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit permissions to `codeql-analysis.yml`
- add explicit permissions to `pr-labeler.yml`
- add explicit permissions to `sync-examples.yml`

## Permission mapping
- `codeql-analysis.yml`
  - `actions: read`
  - `contents: read`
  - `security-events: write` (for CodeQL results upload)
- `pr-labeler.yml`
  - `contents: read`
  - `pull-requests: write` (to apply labels)
- `sync-examples.yml`
  - `contents: read` (for checkout only)

## Why
These workflows previously relied on implicit default `GITHUB_TOKEN` scopes. Declaring least-privilege permissions makes required access explicit and reduces unnecessary token exposure.
