### PR TITLE
Migrations fail silently on Cloudflare Workers

### DIFF
--- a/packages/adapter-d1/src/migrations.ts
+++ b/packages/adapter-d1/src/migrations.ts
@@ -49,13 +49,7 @@ export const down = [
 ]
 
 async function up(db: D1Database) {
-  upSQLStatements.forEach(async (sql) => {
-    try {
-      await db.prepare(sql).run()
-    } catch (e: any) {
-      console.error(e.cause?.message, e.message)
-    }
-  })
+  await Promise.all(upSQLStatements.map(async (sql) => db.prepare(sql).run()))
 }
 
 export { up }


### PR DESCRIPTION
## ☕️ Reasoning

Each migration statement is not being properly awaited, so awaiting the up() method does nothing.

Not sure how exactly it's desired to handle errors.. but the existing does not work and fails silently, leaving users to either manually migrate or do as I have done. 


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged


