### PR TITLE
Feat: add mezon oauth provider and docs for NextAuth v4

### DIFF
--- a/docs/docs/providers/mezon.md
+++ b/docs/docs/providers/mezon.md
@@ -1,0 +1,34 @@
+---
+id: mezon
+title: Mezon
+---
+
+## Documentation
+
+https://mezon.ai/docs/developer/mezon-topics/oauth2
+
+## Configuration
+
+https://mezon.ai/developers/dashboard
+
+## Options
+
+The **Mezon Provider** comes with a set of default options:
+
+- [Mezon Provider options](https://github.com/nextauthjs/next-auth/blob/v4/packages/next-auth/src/providers/mezon.ts)
+
+You can override any of the options to suit your own use case.
+
+## Example
+
+```js
+import MezonProvider from "next-auth/providers/mezon"
+...
+providers: [
+  MezonProvider({
+    clientId: process.env.MEZON_CLIENT_ID,
+    clientSecret: process.env.MEZON_CLIENT_SECRET
+  })
+}
+...
+```

--- a/packages/next-auth/src/providers/mezon.ts
+++ b/packages/next-auth/src/providers/mezon.ts
@@ -1,0 +1,42 @@
+import type { OAuthConfig, OAuthUserConfig } from "."
+
+export interface MezonProfile extends Record<string, any> {
+  user_id: string;
+  email: string;
+  display_name?: string;
+  avatar?: string;
+  mezon_id: string;
+  sub: string;
+  username: string;
+}
+
+export default function Mezon<P extends MezonProfile>(
+  options: OAuthUserConfig<P>
+): OAuthConfig<P> {
+  return {
+    id: "mezon",
+    name: "Mezon",
+    type: "oauth",
+    wellKnown: "https://oauth2.mezon.ai/.well-known/openid-configuration",
+    authorization: {
+      url: "https://oauth2.mezon.ai/oauth2/auth",
+      params: {
+        scope: "offline openid",
+      },
+    },
+    token: "https://oauth2.mezon.ai/oauth2/token",
+    userinfo: "https://oauth2.mezon.ai/userinfo",
+    profile(profile) {
+      return {
+        id: profile.user_id,
+        name: profile?.display_name ?? profile?.username,
+        email: profile.email,
+        image: profile?.avatar,
+      }
+    },
+    client: {
+      token_endpoint_auth_method: "client_secret_post",
+    },
+    options
+  };
+}


### PR DESCRIPTION
## ☕️ Reasoning
- Add mezon OAuth Provider that issued by Mezon (https://mezon.ai) for NextAuth v4

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged