### PR TITLE
docs: fix TypeScript type mismatch in refresh token rotation example

### DIFF
--- a/docs/pages/guides/refresh-token-rotation.mdx
+++ b/docs/pages/guides/refresh-token-rotation.mdx
@@ -51,7 +51,7 @@ Below is a sample implementation of refreshing the `access_token` with Google. P
   <Code.Next>
 
 ```ts filename="./auth.ts"
-import NextAuth, { type User } from "next-auth"
+import NextAuth from "next-auth"
 import Google from "next-auth/providers/google"
 
 export const { handlers, auth } = NextAuth({
@@ -65,6 +65,9 @@ export const { handlers, auth } = NextAuth({
     async jwt({ token, account }) {
       if (account) {
         // First-time login, save the `access_token`, its expiry and the `refresh_token`
+        if (!account.access_token || !account.expires_at) {
+          throw new TypeError("Missing access_token or expires_at")
+        }
         return {
           ...token,
           access_token: account.access_token,


### PR DESCRIPTION
Closes #13281

## Problem

The issue reporter suggested changing `account.access_token` to `user.access_token`, but that's a misdiagnosis.

The real problem is a **TypeScript type mismatch**:

- `Account` extends `Partial<TokenEndpointResponse>`, so `access_token` is `string | undefined`
- `Account.expires_at` is declared as `expires_at?: number`, also optional
- But the augmented `JWT` interface declares `access_token: string` and `expires_at: number` as **required**

This causes a TypeScript compile error when following the documentation as written.

## Fix

Added a type guard before assigning `account.access_token` and `account.expires_at` to the token, consistent with the existing `if (!token.refresh_token) throw new TypeError(...)` pattern already used later in the same callback.

Also removed the unused `type User` import.

## Changes

- Remove unused `type User` import
- Add `if (!account.access_token || !account.expires_at)` type guard with `TypeError`