### PR TITLE
fix(providers): add issuer to GitHub provider for RFC 9207 compliance

### DIFF
--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -139,6 +139,7 @@ export default function GitHub(
     id: "github",
     name: "GitHub",
     type: "oauth",
+    issuer: `${baseUrl}/login/oauth`,
     authorization: {
       url: `${baseUrl}/login/oauth/authorize`,
       params: { scope: "read:user user:email" },


### PR DESCRIPTION
## Summary

Adds RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification) compatibility to the GitHub provider by configuring the issuer value that GitHub now returns in OAuth callbacks.

## Problem

GitHub recently implemented RFC 9207 by silently returning an `iss=https://github.com/login/oauth` parameter in OAuth callback responses (April 6-10, 2026). The `openid-client` library validates this parameter unconditionally, and without an configured issuer, it throws:

```
issuer must be configured on the issuer
```

This breaks GitHub OAuth sign-in for all applications using this provider.

## Solution

Add `issuer: \` to the GitHub provider configuration. This works for both:
- **Standard GitHub:** `issuer: "https://github.com/login/oauth"`
- **GitHub Enterprise Server:** `issuer: \` (dynamically derived)

## Changes

- Added 1 line to `packages/core/src/providers/github.ts`
- No breaking changes, fully backward compatible
- Supports both GitHub and GitHub Enterprise Server

## References

- [Langfuse Issue #13091](https://github.com/langfuse/langfuse/issues/13091) - Original bug report with production evidence
- [Langfuse PR #13093](https://github.com/langfuse/langfuse/pull/13093) - Original NextAuth fix attempt (without GHES)
- [RFC 9207 Specification](https://datatracker.ietf.org/doc/html/rfc9207)
- [GitHub Community Discussion](https://github.com/orgs/community/discussions/192143)

## Test Plan

- [ ] Standard GitHub OAuth sign-in succeeds
- [ ] GitHub Enterprise Server OAuth sign-in succeeds
- [ ] Existing auth flows unaffected

Fixes: https://github.com/langfuse/langfuse/issues/13091