### PR TITLE
chore: sync package versions with npm registry

### DIFF
--- a/packages/adapter-azure-tables/package.json
+++ b/packages/adapter-azure-tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/azure-tables-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Azure Tables Storage adapter for next-auth.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-d1/package.json
+++ b/packages/adapter-d1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/d1-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "A Cloudflare D1 adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-dgraph/package.json
+++ b/packages/adapter-dgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/dgraph-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Dgraph adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/drizzle-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Drizzle adapter for Auth.js.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-dynamodb/package.json
+++ b/packages/adapter-dynamodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@auth/dynamodb-adapter",
   "repository": "https://github.com/nextauthjs/next-auth",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "AWS DynamoDB adapter for next-auth.",
   "keywords": [
     "next-auth",

--- a/packages/adapter-edgedb/package.json
+++ b/packages/adapter-edgedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/edgedb-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "EdgeDB adapter for next-auth.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-fauna/package.json
+++ b/packages/adapter-fauna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/fauna-adapter",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Fauna Adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-firebase/package.json
+++ b/packages/adapter-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/firebase-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Firebase adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-hasura/package.json
+++ b/packages/adapter-hasura/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/hasura-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Hasura adapter for Auth.js.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-kysely/package.json
+++ b/packages/adapter-kysely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/kysely-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Kysely adapter for Auth.js",
   "homepage": "https://authjs.dev/reference/adapter/kysely",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-mikro-orm/package.json
+++ b/packages/adapter-mikro-orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/mikro-orm-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "MikroORM adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/mongodb-adapter",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "MongoDB adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-neo4j/package.json
+++ b/packages/adapter-neo4j/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/neo4j-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "neo4j adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-neon/package.json
+++ b/packages/adapter-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/neon-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Neon Postgres adapter for next-auth.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/pg-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Postgres adapter for next-auth.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-pouchdb/package.json
+++ b/packages/adapter-pouchdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/pouchdb-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "PouchDB adapter for next-auth.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/prisma-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Prisma adapter for Auth.js",
   "homepage": "https://authjs.dev/reference/adapter/prisma",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-sequelize/package.json
+++ b/packages/adapter-sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/sequelize-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Sequelize adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-supabase/package.json
+++ b/packages/adapter-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/supabase-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Supabase adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-surrealdb/package.json
+++ b/packages/adapter-surrealdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/surrealdb-adapter",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "SurrealDB adapter for next-auth.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-typeorm/package.json
+++ b/packages/adapter-typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/typeorm-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "TypeORM adapter for Auth.js.",
   "homepage": "https://authjs.dev/reference/adapter/typeorm",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-unstorage/package.json
+++ b/packages/adapter-unstorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/unstorage-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Unstorage adapter for Auth.js.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-upstash-redis/package.json
+++ b/packages/adapter-upstash-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/upstash-redis-adapter",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Upstash adapter for Auth.js.",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/adapter-xata/package.json
+++ b/packages/adapter-xata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/xata-adapter",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Xata adapter for Auth.js",
   "homepage": "https://authjs.dev",
   "repository": "https://github.com/nextauthjs/next-auth",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/core",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Authentication for the Web.",
   "keywords": [
     "authentication",

--- a/packages/frameworks-express/package.json
+++ b/packages/frameworks-express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@auth/express",
   "description": "Authentication for Express.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "files": [
     "*.js",

--- a/packages/frameworks-qwik/package.json
+++ b/packages/frameworks-qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/qwik",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Authentication for Qwik.",
   "license": "ISC",
   "author": "gioboa <giorgiob.boa@gmail.com>",

--- a/packages/frameworks-solid-start/package.json
+++ b/packages/frameworks-solid-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/solid-start",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Authentication for SolidStart.",
   "license": "ISC",
   "author": "OrJDev <orjdeveloper@gmail.com>",

--- a/packages/frameworks-sveltekit/package.json
+++ b/packages/frameworks-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth/sveltekit",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Authentication for SvelteKit.",
   "keywords": [
     "authentication",


### PR DESCRIPTION
## ☕️ Reasoning

A @auth/* release cut on 2025-10-26 (orphan commit 089f0e37) published *.11.1 and @auth/core@0.41.1 to npm, but the version bump never reached main. The working tree is at *.11.0 while the registry holds *.11.1.

Running the release tool from this state tries to republish *.11.1 and fails with npm 403. This PR aligns the package.json versions with the registry so the next release cuts *.11.2 on top.

`pnpm peek` with this change plans:

```
@auth/core: 0.41.1 -> 0.41.2
@auth/*-adapter: *.11.1 -> *.11.2
@auth/surrealdb-adapter: 2.2.1 -> 2.2.2
@auth/express: 0.12.1 -> 0.12.2
@auth/qwik: 0.9.1 -> 0.9.2
@auth/solid-start: 0.19.1 -> 0.19.2
@auth/sveltekit: 1.11.1 -> 1.11.2
```

@auth/core tracks the 0.41.x line here; 0.34.3 is the LTS line on `v0.34.3`.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Prerequisite for the next automated @auth/* release; unblocks PR #13410 (RFC 9207 GitHub issuer fix) reaching users.

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)