### PR TITLE
fix(providers): normalize email in WebAuthn getUserInfo

### DIFF
--- a/packages/core/src/providers/webauthn.ts
+++ b/packages/core/src/providers/webauthn.ts
@@ -251,13 +251,15 @@ const getUserInfo: GetUserInfo = async (options, request) => {
   // If email is not provided, return null
   if (!email || typeof email !== "string") return null
 
-  const existingUser = await adapter.getUserByEmail(email)
+  const normalizedEmail = email.toLowerCase().trim()
+
+  const existingUser = await adapter.getUserByEmail(normalizedEmail)
   if (existingUser) {
     return { user: existingUser, exists: true }
   }
 
   // If the user does not exist, return a new user info.
-  return { user: { email }, exists: false }
+  return { user: { email: normalizedEmail }, exists: false }
 }
 
 /**


### PR DESCRIPTION
The WebAuthn provider's `getUserInfo` passes the raw email straight to `adapter.getUserByEmail`, while the email and OAuth providers both normalize it first (lowercase + trim in `send-token.ts`, `.toLowerCase()` in the OAuth callback).

On adapters where `getUserByEmail` is case-sensitive, a user who registers a passkey with `User@example.com` won't match when they later sign in with `user@example.com`, and can end up with a duplicate account.

Just aligning WebAuthn with how the other providers already handle email input.