### PR TITLE
docs(pg): clarify account uniqueness for account lookup

### DIFF
--- a/docs/pages/getting-started/adapters/pg.mdx
+++ b/docs/pages/getting-started/adapters/pg.mdx
@@ -226,7 +226,8 @@ CREATE TABLE accounts
   session_state TEXT,
   token_type TEXT,
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  CONSTRAINT accounts_provider_providerAccountId_unique UNIQUE (provider, "providerAccountId")
 );
 
 CREATE TABLE sessions


### PR DESCRIPTION
## ☕️ Reasoning

The PostgreSQL adapter resolves linked accounts by querying the `accounts` table using `provider` and `providerAccountId` in `getUserByAccount`.

However, the schema example does not enforce or document a uniqueness constraint on this pair. This allows duplicate rows for the same account, which does not match the adapter’s lookup behavior and can lead to ambiguous results.

This change clarifies that a unique constraint on `(provider, "providerAccountId")` is expected for correct adapter behavior.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

N/A