### PR TITLE
fix(apple): guard against unexpected user shape in profile callback

### DIFF
--- a/packages/core/src/providers/apple.ts
+++ b/packages/core/src/providers/apple.ts
@@ -175,9 +175,10 @@ export default function Apple(
     // It adds the `name` object to the `profile`, with `firstName` and `lastName` fields.
     [conformInternal]: true,
     profile(profile) {
-      const name = profile.user
-        ? `${profile.user.name.firstName} ${profile.user.name.lastName}`
-        : profile.email
+      const name =
+        profile.user?.name?.firstName && profile.user?.name?.lastName
+          ? `${profile.user.name.firstName} ${profile.user.name.lastName}`
+          : profile.email
       return {
         id: profile.sub,
         name: name,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The Apple provider's `profile` callback in `packages/core/src/providers/apple.ts` assumes that whenever `profile.user` is truthy, it has the shape `{ name: { firstName, lastName } }`.

That object comes from `JSON.parse(params.user)` in `packages/core/src/lib/actions/callback/oauth/callback.ts`, which performs no shape validation. Any JSON-valid value (a string, a number, `null`, or a partial object) ends up assigned to `profile.user`. When it is truthy but not the expected shape, `profile.user.name.firstName` throws a `TypeError`.

The error is swallowed upstream in `getUserAndAccount`'s catch block, so the user just sees a silent sign-in failure with no useful diagnostic.

This change adds defensive optional chaining so the callback falls back to `profile.email` instead of throwing when the `user` payload is malformed or partial. No behavior change for the happy path.

## 🧢 Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

None.
<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
