### PR TITLE
fix(next-auth): Handle /api/auth/_log as recognized action

### DIFF
--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -4,6 +4,7 @@ import { init } from "./init.js"
 import renderPage from "./pages/index.js"
 import * as actions from "./actions/index.js"
 import { validateCSRF } from "./actions/callback/oauth/csrf-token.js"
+import { setLogger } from "./utils/logger.js"
 
 import type { RequestInternal, ResponseInternal } from "../types.js"
 import type { AuthConfig } from "../index.js"
@@ -17,6 +18,23 @@ export async function AuthInternal(
   authOptions: AuthConfig
 ): Promise<ResponseInternal> {
   const { action, providerId, error, method } = request
+
+  // Handle _log action: accept client-side debug log messages.
+  // When debug is enabled, log the message server-side; always return 200.
+  if (action === "_log") {
+    const logger = setLogger(authOptions)
+    if (request.body) {
+      const { level, code, message: msg } = request.body
+      if (level === "error") {
+        logger.debug("client_error", { code, message: msg, ...request.body })
+      } else if (level === "warn") {
+        logger.debug("client_warn", { code, message: msg, ...request.body })
+      } else {
+        logger.debug("client_log", { message: msg, ...request.body })
+      }
+    }
+    return { status: 200, body: "" }
+  }
 
   const csrfDisabled = authOptions.skipCSRFCheck === skipCSRFCheck
 

--- a/packages/core/src/lib/utils/actions.ts
+++ b/packages/core/src/lib/utils/actions.ts
@@ -1,6 +1,7 @@
 import type { AuthAction } from "../../types.js"
 
 const actions: AuthAction[] = [
+  "_log",
   "providers",
   "session",
   "csrf",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -320,6 +320,7 @@ export interface PublicProvider {
  *   - **`GET`**: Returns the options for the WebAuthn authentication and registration flows.
  */
 export type AuthAction =
+  | "_log"
   | "callback"
   | "csrf"
   | "error"

--- a/packages/core/test/url-parsing.test.ts
+++ b/packages/core/test/url-parsing.test.ts
@@ -76,6 +76,18 @@ describe("parse the action and provider id", () => {
       providerId: undefined,
       basePath: "/auth",
     },
+    {
+      path: "/api/auth/_log",
+      action: "_log",
+      providerId: undefined,
+      basePath: "/api/auth",
+    },
+    {
+      path: "/auth/_log",
+      action: "_log",
+      providerId: undefined,
+      basePath: "/auth",
+    },
   ])("$path", ({ path, error, basePath, action, providerId }) => {
     if (action || providerId) {
       const parsed = parseActionAndProviderId(path, basePath)


### PR DESCRIPTION
## ☕️ Reasoning

Add `/api/auth/_log`, so the `[...nextauth]` catch-all route handler does not throw an `UnknownAction` error.

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Fixes https://github.com/nextauthjs/next-auth/issues/13426.
