### PR TITLE
fix(docs): improve Mermaid diagram visibility in dark mode

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -56,6 +56,29 @@ html[data-theme="dark"] svg[id^="mermaid-svg"] text[id*="-attr"] {
   fill: var(--ifm-background-color) !important;
 }
 
+html[data-theme="dark"] .mermaid svg rect.actor {
+  fill: #1f2020 !important;
+  stroke: #ccc !important;
+}
+
+html[data-theme="dark"] .mermaid svg text {
+  fill: lightgrey !important;
+}
+
+html[data-theme="dark"] .mermaid svg tspan {
+  fill: lightgrey !important;
+}
+
+html[data-theme="dark"] .mermaid svg line,
+html[data-theme="dark"] .mermaid svg path {
+  stroke: lightgrey !important;
+}
+
+html[data-theme="dark"] .mermaid svg rect.note {
+  fill: #3e3f3f !important;
+  stroke: #ccc !important;
+}
+
 @import "hero.css";
 @import "admonitions.css";
 @import "buttons.css";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

The Mermaid OAuth sequence diagram on the v4 docs page was rendering with dark gray text on a dark background in dark mode,
resulting in a contrast ratio well below the WCAG AA minimum of 4.5:1.

Added CSS rules scoped to `html[data-theme="dark"]` that apply colors accordingly.

## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Fixes: https://github.com/nextauthjs/next-auth/issues/13295

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
