### PR TITLE
fix: repair main CI formatting and proxy deploy

### DIFF
--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "packageManager": "pnpm@9.10.0",
   "dependencies": {
-    "@auth/core": "latest"
+    "@auth/core": "^0.41.2"
   }
 }

--- a/packages/core/test/actions/callback.test.ts
+++ b/packages/core/test/actions/callback.test.ts
@@ -154,7 +154,11 @@ describe("assert GET callback action", () => {
 })
 
 describe("OAuth check cookies are bound to their provider", () => {
-  const cookieOptions = { secure: true, sameSite: "lax" as const, httpOnly: true }
+  const cookieOptions = {
+    secure: true,
+    sameSite: "lax" as const,
+    httpOnly: true,
+  }
   const cookies = {
     state: { name: "authjs.state", options: cookieOptions },
     nonce: { name: "authjs.nonce", options: cookieOptions },


### PR DESCRIPTION
## ☕️ Reasoning

Two unrelated breakages on `main`, fixed together:

### 1. Release workflow failing on `pnpm format`
The "Check formatting" step fails on `packages/core/test/actions/callback.test.ts` (introduced in 9f7a97fa) — one line exceeds prettier's print width. Ran prettier `--write` on the file; no behavioural change.

### 2. Proxy Vercel deploys failing on `@auth/core/providers/vipps`
`apps/proxy` declares `"@auth/core": "latest"` and is outside the pnpm workspace, so every Vercel deploy resolves `latest` fresh from npm. The `latest` dist-tag currently points to **0.34.3** — a backport patch published (2025-10-29) after 0.41.1, which moved the tag backwards. 0.34.3 predates the Vipps provider (added in 0.35.0), so the edge function build fails on `@auth/core/providers/vipps`.

This PR pins `^0.41.2` so proxy deploys no longer depend on dist-tag state.

**Note for maintainers:** the dist-tag itself should also be repaired, since anyone installing `@auth/core` today gets 0.34.3:
```
npm dist-tag add @auth/core@0.41.2 latest
```
and future backports should be published with an explicit `--tag` so they don't capture `latest`.

## 🧢 Checklist

- [x] Documentation (n/a)
- [x] Tests (formatting only; existing tests pass)
- [x] Ready to be merged