### PR TITLE
style: format callback.test.ts to satisfy prettier check

### DIFF
--- a/packages/core/test/actions/callback.test.ts
+++ b/packages/core/test/actions/callback.test.ts
@@ -154,7 +154,11 @@ describe("assert GET callback action", () => {
 })
 
 describe("OAuth check cookies are bound to their provider", () => {
-  const cookieOptions = { secure: true, sameSite: "lax" as const, httpOnly: true }
+  const cookieOptions = {
+    secure: true,
+    sameSite: "lax" as const,
+    httpOnly: true,
+  }
   const cookies = {
     state: { name: "authjs.state", options: cookieOptions },
     nonce: { name: "authjs.nonce", options: cookieOptions },


### PR DESCRIPTION
## Problem

The `Test` workflow on `main` is failing at the **Check formatting** step (`pnpm format` → `prettier --check .`).

The offending file is `packages/core/test/actions/callback.test.ts`, where a single-line `cookieOptions` object literal does not match Prettier's expected multi-line wrapping. This was introduced via the merged GHSA-x445-f3h2-j279 cookie-binding fix.

## Fix

Ran `prettier --write` on the file. Whitespace/formatting only — no logic change.

Verified locally: `prettier --check` now passes.

Failing run: https://github.com/nextauthjs/next-auth/actions/runs/27365477330/job/80863711694