### PR TITLE
fix(next-auth): repair red v4 CI (lint + pre-existing test drift)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   "packageManager": "pnpm@7.13.3",
   "pnpm": {
     "overrides": {
-      "undici": "5.11.0"
+      "undici": "5.11.0",
+      "headers-polyfill": "3.0.4"
     }
   }
 }

--- a/packages/next-auth/config/jest.config.js
+++ b/packages/next-auth/config/jest.config.js
@@ -1,4 +1,9 @@
 const swcConfig = require("./swc.config")
+// The default server pages are Preact components rendered with
+// `preact-render-to-string`. Their JSX must be compiled with Preact's
+// automatic runtime; the React runtime produces React elements that
+// `preact-render-to-string` renders as an empty body.
+const swcPreactConfig = require("./swc.preact.config")
 
 /** @type {import('jest').Config} */
 module.exports = {
@@ -8,7 +13,7 @@ module.exports = {
       testMatch: ["<rootDir>/tests/**/*.test.ts"],
       rootDir: ".",
       transform: {
-        "\\.(js|jsx|ts|tsx)$": ["@swc/jest", swcConfig],
+        "\\.(js|jsx|ts|tsx)$": ["@swc/jest", swcPreactConfig],
       },
       coveragePathIgnorePatterns: ["tests"],
       testEnvironment: "@edge-runtime/jest-environment",

--- a/packages/next-auth/config/swc.preact.config.js
+++ b/packages/next-auth/config/swc.preact.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@swc/core").Config} */
+module.exports = {
+  jsc: {
+    parser: { syntax: "typescript", tsx: true },
+    transform: {
+      react: { runtime: "automatic", importSource: "preact" },
+    },
+  },
+}

--- a/packages/next-auth/tests/detect-origin.test.ts
+++ b/packages/next-auth/tests/detect-origin.test.ts
@@ -15,13 +15,13 @@ describe("detectOrigin", () => {
   beforeEach(() => {
     for (const key of ENV_KEYS) {
       saved[key] = process.env[key]
-      delete process.env[key]
+      Reflect.deleteProperty(process.env, key)
     }
   })
 
   afterEach(() => {
     for (const key of ENV_KEYS) {
-      if (saved[key] === undefined) delete process.env[key]
+      if (saved[key] === undefined) Reflect.deleteProperty(process.env, key)
       else process.env[key] = saved[key]
     }
   })

--- a/packages/next-auth/tests/email.test.ts
+++ b/packages/next-auth/tests/email.test.ts
@@ -40,13 +40,15 @@ it("Send e-mail to the only address correctly", async () => {
   )
 })
 
-it("Send e-mail to first address only", async () => {
+it("Reject an address list containing multiple `@` symbols", async () => {
   const { secret, csrf } = await createCSRF()
   const sendVerificationRequest = jest.fn()
   const signIn = jest.fn(() => true)
 
-  const firstEmail = "email@email.com"
-  const email = `${firstEmail},email@email2.com`
+  // Two real `@` symbols (one per address) must be rejected rather than
+  // silently delivering the magic link to the first address, which would let
+  // an attacker smuggle a second recipient past the single-`@` check.
+  const email = "email@email.com,email@email2.com"
   const { res } = await handler(
     {
       adapter: mockAdapter(),
@@ -64,19 +66,10 @@ it("Send e-mail to first address only", async () => {
     }
   )
 
+  expect(signIn).toBeCalledTimes(0)
+  expect(sendVerificationRequest).toBeCalledTimes(0)
   expect(res.redirect).toBe(
-    "http://localhost:3000/api/auth/verify-request?provider=email&type=email"
-  )
-
-  expect(signIn).toBeCalledTimes(1)
-  expect(signIn).toHaveBeenCalledWith(
-    expect.objectContaining({
-      user: expect.objectContaining({ email: firstEmail }),
-    })
-  )
-
-  expect(sendVerificationRequest).toHaveBeenCalledWith(
-    expect.objectContaining({ identifier: firstEmail })
+    "http://localhost:3000/api/auth/error?error=EmailSignin"
   )
 })
 

--- a/packages/next-auth/tests/getServerSession.test.ts
+++ b/packages/next-auth/tests/getServerSession.test.ts
@@ -3,6 +3,18 @@ import { MissingSecret } from "../src/core/errors"
 import { getServerSession } from "../src/next"
 import { mockLogger } from "./lib"
 
+// `AuthHandler` is compiled to a non-configurable CommonJS export, so it cannot
+// be replaced with `jest.spyOn`. Mock the module instead, defaulting to the
+// real implementation so unrelated tests in this file are unaffected.
+jest.mock("../src/core", () => {
+  const actual = jest.requireActual("../src/core")
+  return {
+    __esModule: true,
+    ...actual,
+    AuthHandler: jest.fn(actual.AuthHandler),
+  }
+})
+
 const originalWarn = console.warn
 let logger = mockLogger()
 
@@ -61,13 +73,13 @@ describe("Treat secret correctly", () => {
 
 describe("Return correct data", () => {
   afterEach(() => {
-    jest.restoreAllMocks()
+    const actual = jest.requireActual("../src/core")
+    ;(core.AuthHandler as jest.Mock).mockImplementation(actual.AuthHandler)
   })
 
   it("Should return null if there is no session", async () => {
-    const spy = jest.spyOn(core, "AuthHandler")
     // @ts-expect-error
-    spy.mockReturnValue({ body: {} })
+    ;(core.AuthHandler as jest.Mock).mockReturnValue({ body: {} })
 
     const session = await getServerSession(req, res, {
       providers: [],
@@ -91,9 +103,8 @@ describe("Return correct data", () => {
       },
     }
 
-    const spy = jest.spyOn(core, "AuthHandler")
     // @ts-expect-error
-    spy.mockReturnValue(mockedResponse)
+    ;(core.AuthHandler as jest.Mock).mockReturnValue(mockedResponse)
 
     const session = await getServerSession(req, res, {
       providers: [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 overrides:
   undici: 5.11.0
+  headers-polyfill: 3.0.4
 
 importers:
 
@@ -6576,7 +6577,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@xmldom/xmldom': 0.7.13
       debug: 4.3.7
-      headers-polyfill: 3.3.0
+      headers-polyfill: 3.0.4
       outvariant: 1.4.3
       strict-event-emitter: 0.2.8
     transitivePeerDependencies:
@@ -14471,8 +14472,8 @@ packages:
     hasBin: true
     dev: true
 
-  /headers-polyfill/3.3.0:
-    resolution: {integrity: sha512-5e57etwBpNcDc0b6KCVWEh/Ro063OxPvzVimUdM0/tsYM/T7Hfy3kknIGj78SFTOhNd8AZY41U8mOHoO4LzmIQ==}
+  /headers-polyfill/3.0.4:
+    resolution: {integrity: sha512-I1DOM1EdWYntdrnCvqQtcKwSSuiTzoqOExy4v1mdcFixFZABlWP4IPHdmoLtPda0abMHqDOY4H9svhQ10DFR4w==}
     dev: true
 
   /heap-js/2.5.0:
@@ -18406,7 +18407,7 @@ packages:
       chokidar: 3.6.0
       cookie: 0.4.2
       graphql: 16.9.0
-      headers-polyfill: 3.3.0
+      headers-polyfill: 3.0.4
       inquirer: 8.2.6
       is-node-process: 1.2.0
       js-levenshtein: 1.1.6


### PR DESCRIPTION
## Problem

The `v4` `Test` workflow was failing. Two layers of breakage:

1. **Lint** (`@typescript-eslint/no-dynamic-delete`) in `tests/detect-origin.test.ts` — this blocked the `test` turbo task (`test` `dependsOn` `lint`), so the test step never ran.
2. Once lint was unblocked, the **test** suite was red — and had been since ~Oct 2025 due to dependency drift (10 failed suites, 7 failed tests), independent of any test logic.

## Fixes

**Lint**
- Replace `delete process.env[key]` with `Reflect.deleteProperty(process.env, key)` (computed-key delete is rejected by the rule; `Reflect.deleteProperty` is the documented alternative, runtime-identical).

**Test suite (pre-existing dependency drift)**
- **headers-polyfill** → pin to `3.0.4` via pnpm override. `@mswjs/interceptors@0.16.6` does `require("headers-polyfill/lib")`, but `headers-polyfill >= 3.1.x` ships an `exports` map that blocks the deep subpath import, breaking all 7 client suites.
- **Preact JSX** → compile the core jest project with Preact's automatic runtime (`config/swc.preact.config.js`). The default pages are Preact components rendered by `preact-render-to-string`; the React runtime emitted React elements that render to an empty `<body>`, failing `assert.test.ts`.
- **AuthHandler spy** → mock `../src/core` instead of `jest.spyOn(core, "AuthHandler")` in `getServerSession.test.ts`. SWC compiles named exports to non-configurable getters, so `spyOn` threw `Cannot redefine property`.

**Test correctness**
- Update the stale `email.test.ts` "Send e-mail to first address only" case to assert that an address list containing multiple `@` symbols is now **rejected**, matching the hardened email normalizer.

## Verification

Reproduced the CI failure locally (Node 18, `pnpm test`), then confirmed green after the fixes:

```
Test Suites: 13 passed, 13 total
Tests:       67 passed, 67 total
```
Lint passes clean.

Failing run: https://github.com/nextauthjs/next-auth/actions/runs/27373924458/job/80893154065