### PR TITLE
fix(proxy): override Vercel build command so it doesn't run turbo

### DIFF
--- a/apps/proxy/vercel.json
+++ b/apps/proxy/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "echo 'No build step required: the proxy is deployed as Vercel Functions from api/'"
+}


### PR DESCRIPTION
## ☕️ Reasoning

The `proxy` Vercel deployment on `main` fails during build:

```
> Detected Turbo. Adjusting default settings...
x Missing tasks in project
->   x Could not find task `build` in project
Error: Command "turbo run build" exited with 1
```
(from `npx vercel inspect dpl_R6Qy53byKXgidYV2zVKzg2KJ7QGL --logs`)

**Root cause:** `apps/proxy` is intentionally *outside* the pnpm workspace (`pnpm-workspace.yaml` covers `packages/*`, `apps/dev/*`, `docs` only) and is installed with `pnpm install --ignore-workspace`. It has no build step — it ships as Vercel Functions compiled from `api/` (`api/[auth].ts`, `api/callback/[auth].ts`). Vercel auto-detects Turbo and sets the default build command to `turbo run build`, but the isolated proxy package has no `turbo.json` and no `build` task, so the command errors before the functions are ever built.

**Fix:** add `apps/proxy/vercel.json` with an explicit no-op `buildCommand`, so Vercel skips the turbo default. The `api/` functions are still detected and deployed as before.

## 🧢 Checklist

- [x] Documentation (n/a)
- [x] Tests (n/a — deploy config)
- [ ] Ready to be merged — needs a proxy redeploy to confirm green

> Note: this is the same proxy project that #13444 fixed for the `@auth/core` version resolution; this is a separate, build-command failure surfaced after that.