### PR TITLE
chore: add npm bugs metadata and fix repository field format

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,11 @@
     "webapi"
   ],
   "homepage": "https://authjs.dev",
-  "repository": "https://github.com/nextauthjs/next-auth.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextauthjs/next-auth.git",
+    "directory": "packages/core"
+  },
   "author": "Balázs Orbán <info@balazsorban.com>",
   "contributors": [
     "Balázs Orbán <info@balazsorban.com>",
@@ -110,5 +114,8 @@
     "postcss-nesting": "^12.1.5",
     "typedoc": "^0.25.12",
     "typedoc-plugin-markdown": "4.0.0-next.53"
+  },
+  "bugs": {
+    "url": "https://github.com/nextauthjs/next-auth/issues"
   }
 }

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -3,7 +3,11 @@
   "version": "5.0.0-beta.31",
   "description": "Authentication for Next.js",
   "homepage": "https://nextjs.authjs.dev",
-  "repository": "https://github.com/nextauthjs/next-auth.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextauthjs/next-auth.git",
+    "directory": "packages/next-auth"
+  },
   "author": "Balázs Orbán <info@balazsorban.com>",
   "contributors": [
     "Iain Collins <me@iaincollins.com>",
@@ -112,5 +116,8 @@
     "next": "15.5.18",
     "nodemailer": "^8.0.5",
     "react": "^18.2.0"
+  },
+  "bugs": {
+    "url": "https://github.com/nextauthjs/next-auth/issues"
   }
 }


### PR DESCRIPTION
## Problem

Both `@auth/core` and `next-auth` packages have two npm metadata issues:

1. `repository` is set to a plain URL string, which publint warns is not valid:
   ```
   pkg.repository is https://github.com/nextauthjs/next-auth.git which isn't a
   valid shorthand value supported by npm.
   ```

2. `bugs` field is missing entirely.

**Reproduction:**
```shell
npm pack @auth/core --silent && npx publint@0.3.21 run auth-core-*.tgz --level warning
npm view @auth/core bugs   # returns empty
npm view next-auth bugs    # returns empty
```

## Fix

For both packages:
- Convert `repository` from plain URL string to standard npm object with `type`, `url`, and `directory` fields
- Add `bugs.url` pointing to the GitHub issue tracker

Metadata-only change — no runtime behaviour is affected.