### PR TITLE
chore: fix repository shorthand and add bugs metadata

### DIFF
--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -3,7 +3,13 @@
   "version": "5.0.0-beta.31",
   "description": "Authentication for Next.js",
   "homepage": "https://nextjs.authjs.dev",
-  "repository": "https://github.com/nextauthjs/next-auth.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextauthjs/next-auth.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nextauthjs/next-auth/issues"
+  },
   "author": "Balázs Orbán <info@balazsorban.com>",
   "contributors": [
     "Iain Collins <me@iaincollins.com>",


### PR DESCRIPTION
This PR fixes the invalid repository shorthand and adds missing bugs metadata to the package.json of next-auth.

Fixes:
- Updated  from a string to a proper object.
- Added  field.

Wallet (TON): UQAVD5f6XBxXDlK4SDbvRpq_btbnmniWroIXv55bvgFnceaz