### PR TITLE
docs: fix incorrect SessionProvider placement in v5 migration guide

### DIFF
--- a/docs/pages/getting-started/migrating-to-v5.mdx
+++ b/docs/pages/getting-started/migrating-to-v5.mdx
@@ -129,14 +129,24 @@ Imports from `next-auth/react` are now marked with the [`"use client"`](https://
 ```ts filename="components/clientComponent.tsx"
 'use client';
 
-import { useSession, SessionProvider } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 
 const ClientComponent = () => {
   const session = useSession();
 
   return (
+    <p>Welcome {session?.user?.name}</p>
+  )
+}
+```
+
+```ts filename="app/layout.tsx"
+import { SessionProvider } from 'next-auth/react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
     <SessionProvider>
-      <p>Welcome {session?.user?.name}</p>
+      {children}
     </SessionProvider>
   )
 }


### PR DESCRIPTION
The "Client Component (App)" example in `migrating-to-v5.mdx` calls `useSession()` and then renders `<SessionProvider>` as a *child* of that same component.

`useSession()` reads context from an ancestor `SessionProvider`, so this throws `[next-auth]: useSession must be wrapped in a <SessionProvider />` at runtime. It also contradicts the explanatory text right above the snippet.

This PR splits the example into the client component (just `useSession()`) and a root layout that wraps it with `SessionProvider`, matching the correct pattern already shown in `docs/pages/getting-started/session-management/get-session.mdx`.