### PR TITLE
fix(core): document that getToken returns null for malformed authorization headers

### DIFF
--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -137,6 +137,9 @@ export interface GetTokenParams<R extends boolean = false>
 /**
  * Takes an Auth.js request (`req`) and returns either the Auth.js issued JWT's payload,
  * or the raw JWT string. We look for the JWT in the either the cookies, or the `Authorization` header.
+ *
+ * Returns `null` if no JWT is found in the cookies or `Authorization` header, and also when
+ * the `Authorization` header's Bearer value contains malformed percent-encoding.
  */
 export async function getToken<R extends boolean = false>(
   params: GetTokenParams<R>


### PR DESCRIPTION
`getToken()` returns `null` when the token is missing or unusable, including when the `Authorization` header's Bearer value contains malformed percent-encoding, but the JSDoc did not state the null contract. Callers checking the return value have no documented guarantee to rely on. This documents it.
