### PR TITLE
chore(ci): pin surrealdb test server to the v2 image for the 1.3 client

### DIFF
--- a/packages/adapter-surrealdb/test/test.sh
+++ b/packages/adapter-surrealdb/test/test.sh
@@ -1,26 +1,23 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 CONTAINER_NAME=authjs-surrealdb-test
 
-# Get the latest 2.x container since 3.x-alpha is not yet fully supported by js library
-TAG=$(curl -s "https://registry.hub.docker.com/v2/repositories/surrealdb/surrealdb/tags?page_size=100" \
-| jq -r '.results[].name' \
-| grep -E '^v2\.[0-9]+(\.[0-9]+)?$' \
-| sort -V \
-| tail -n1)
-
-# Start db
+# The surrealdb JS client 1.3.x pairs with a v2.x server; the v2 tag tracks the latest v2 release.
 docker run -d --rm \
   -p 8000:8000 \
   --name ${CONTAINER_NAME} \
-  surrealdb/surrealdb:${TAG} start --log debug --user test --pass test memory
+  surrealdb/surrealdb:v2 start --log debug --user test --pass test memory
 
-echo "Waiting 5s for db to start..."
-sleep 5
+trap 'docker stop ${CONTAINER_NAME} >/dev/null 2>&1 || true' EXIT
 
-# Always stop container, but exit with 1 when tests are failing
-if vitest run -c ../utils/vitest.config.ts; then
-  docker stop ${CONTAINER_NAME}
-else
-  docker stop ${CONTAINER_NAME} && exit 1
-fi
+echo "Waiting for SurrealDB to become ready..."
+for _ in $(seq 1 30); do
+  if curl -sf http://127.0.0.1:8000/health >/dev/null; then
+    echo "SurrealDB is ready."
+    break
+  fi
+  sleep 1
+done
+
+vitest run -c ../utils/vitest.config.ts


### PR DESCRIPTION
The SurrealDB adapter's test bootstrap picked its Docker image tag by scraping the first page of Docker Hub's tag list for the newest `v2.x` release. That list has since filled up with `rolling-*`, `nightly`, and `v3.x` tags, so every `v2.x` tag has aged off page one and the scrape now returns nothing. With an empty tag, the script runs `docker run surrealdb/surrealdb: start ...`, which Docker rejects with `invalid reference format`. No server ever starts, so the test's `db.connect("ws://0.0.0.0:8000")` fails with `ECONNREFUSED`, and the client's version probe against the unreachable host produces a misleading "Unexpected token '<'" log that just reflects the missing server, not a separate bug.

This replaces the registry scrape with the floating `surrealdb/surrealdb:v2` tag, which resolves to a current v2 release compatible with the pinned 1.3.x JS client. It also swaps the blind 5-second sleep for a poll against the server's `/health` endpoint and uses a `trap ... EXIT` to guarantee the container stops while preserving the test suite's exit code under `set -euo pipefail`. No runtime source, dependency, or published package changes; this only fixes the test bootstrap script.
